### PR TITLE
add alice admin notes

### DIFF
--- a/_source/user-guide/integrations/alice-slack-chatbot.md
+++ b/_source/user-guide/integrations/alice-slack-chatbot.md
@@ -13,11 +13,11 @@ Alice is a chatbot who lives in your Slack workspace. You can ask Alice to perfo
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/dNPhfyjaBTw" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
-##### Assign Alice an API token
+##### Assign an API token
 
-If you're an Enterprise user, you can create an API token from [**<i class="li li-gear"></i> > Tools > API tokens**](https://app.logz.io/#/dashboard/settings/api-tokens). We recommend creating a token for use only with Alice.
+If you're an Enterprise account admin, you can create an API token from [**<i class="li li-gear"></i> > Tools > API tokens**](https://app.logz.io/#/dashboard/settings/api-tokens). We recommend creating a token for use only with Alice.
 
-If you're a Pro user, email [help@logz.io](mailto:help@logz.io) to request an API token for Alice.
+If you're a Pro account admin, email [help@logz.io](mailto:help@logz.io) to request an API token for Alice. Plase note we can honor a request only from an account admin.
 
 <div class="info-box important">
   Users with access to your Slack workspace will be able to ask Alice to report information on your account, even if they don't have access to Logz.io.
@@ -39,9 +39,9 @@ If you're a Pro user, email [help@logz.io](mailto:help@logz.io) to request an AP
 
     If you’re not sure about your account region, check the URL you use to sign in Logz.io. If you sign in to `app.logz.io`, choose **US**. If you sign in to `app-eu.logz.io`, choose **EU**.
 
-You can now ask Alice to help you with your Logz.io account. You can add Alice to a specific channel (just tag `@Alice`) or issue commands from the app itself in Slack.
+You can now ask Alice to help you with your Logz.io account. You can invite Alice to a specific channel (just tag `@Alice`) or issue commands from the app itself in Slack.
 
 ###### To change Alice's name
 
-If you ever need to change the name of the bot in your Slack workspace—for example, if you have a coworker named Alice—just go to the app's management page and click the edit pencil in the **Bot User** section.
+If you ever need to change Alice's name in your Slack workspace—for example, if you have a coworker named Alice—just go to the app's [management page](https://slack.com/apps/A9VPCDA9X-alice?next_id=0) and click the edit pencil in the **Bot User** section.
 


### PR DESCRIPTION
Added language to clarify that only account admins can create or request an API token

https://docs.logz.io/user-guide/integrations/alice-slack-chatbot.html