### PR TITLE
add permissions note to shared tokens tag

### DIFF
--- a/_source/api-src/logzio-public-api.yml
+++ b/_source/api-src/logzio-public-api.yml
@@ -79,14 +79,16 @@ tags:
   - name: Search logs
     description: >-
       Use the Elasticsearch Search API DSL query language to search your Logz.io data.
-      
-      
+
+
       To ensure system performance and data availability, we've introduced some limitations to the original Elasticsearch specification. These limitations are detailed in the applicable API calls below.
   - name: Retrieve audit trail
   - name: Manage CloudTrail links
   - name: Manage notification endpoints
   - name: Import or export Kibana objects
   - name: Manage shared tokens
+    description: >-
+      **Note:** Shared token endpoints require permissions that must be set by our Support team. Please email help@logz.io for assistance.
   - name: Logz.io snapshots
   - name: Manage users
 


### PR DESCRIPTION
added a note to the shared tokens tag in the API spec, to clear up confusions with the permissions