### PR TITLE
Docs admin pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,6 +66,9 @@ collections:
   contributors:
     output: true
     permalink: /contributors/:name
+  docs-admin:
+    output: true
+    permalink: /docs-admin/:path
 
 defaults:
   - scope:
@@ -73,6 +76,13 @@ defaults:
     values:
       search: false
       tags: false
+  - scope:
+      path: ''
+      type: docs-admin
+    values:
+      search: false
+      tags: false
+      community-info: false
   - scope:
       path: ''
       type: contributors

--- a/_source/_includes/tags/capture-site-pages.html
+++ b/_source/_includes/tags/capture-site-pages.html
@@ -1,0 +1,17 @@
+{%- comment -%}
+* Initialize empty arrays
+*         {%- endcomment -%}
+{%- assign shippingDataSources = "" | split: "" -%}
+
+{%- comment -%}
+*   shippingDataSources is a placeholder for the data-sources collection.
+*   If Jekyll can't find data-sources, it defaults to an empty array
+*   (initialized above) so it doesn't break the remaining code.
+*
+*   shippingDataSources is used for the rest of this doc, so if you add
+*   more data sources in the future, add them to shippingDataSources with
+*   `concat: <COLLECTION-NAME>`. Leave the default last.
+*         {%- endcomment -%}
+{%- assign shippingDataSources = site.data-sources
+  | default: shippingDataSources -%}
+{%- assign htmlPages = site.html_pages -%}

--- a/_source/_includes/tags/capture-site-pages.html
+++ b/_source/_includes/tags/capture-site-pages.html
@@ -15,3 +15,5 @@
 {%- assign shippingDataSources = site.data-sources
   | default: shippingDataSources -%}
 {%- assign htmlPages = site.html_pages -%}
+
+{%- assign allPages = htmlPages | concat: shippingDataSources | sort: "title" -%}

--- a/_source/logzio_collections/_docs-admin/docs-report.md
+++ b/_source/logzio_collections/_docs-admin/docs-report.md
@@ -1,0 +1,15 @@
+---
+layout: article
+title: Docs report
+---
+{%- include tags/capture-site-pages.html -%}
+
+**Site build time:** {{site.time}}
+
+### Page flags
+
+| Page | Admin | Beta | Logz.io plan |
+|---|---|---|---|
+{%- for p in allPages %}
+| [{{p.title | default: p.url | split: "/" | last }}]({{p.url}}) | {{p.flags.admin}} | {{p.flags.beta}} | {{p.flags.logzio-plan}} |
+{%- endfor -%}

--- a/_source/logzio_collections/_docs-admin/index.md
+++ b/_source/logzio_collections/_docs-admin/index.md
@@ -1,0 +1,20 @@
+---
+layout: article
+title: Docs admin
+permalink: /docs-admin/
+---
+
+{%- assign thisCollection = site.collections
+  | where: "label", page.collection
+  | first -%}
+
+##### Admin TOC
+
+{% for doc in thisCollection.docs %}
+  {%- assign filename = doc.path | split: "/" | last | split: "." | first -%}
+  {%- unless filename == "index" -%}
+  * [{{doc.title}}]({{doc.url}})
+  {%- endunless -%}
+{%- endfor %}
+
+<!-- TODO: After merging log shipping, move tags page to /docs-admin -->


### PR DESCRIPTION
Created a new collection, `docs-admin`. This collection will house pages that help with docs administration.

First two pages are:

- Index page with a TOC for the rest of the pages

- A page that shows a table of the flags set on each doc. Gives an at-a-glance view into which flags are set on each doc.