### PR TITLE
set jquery accordion to expanded by default

### DIFF
--- a/_source/js/logz-docs.js
+++ b/_source/js/logz-docs.js
@@ -24,8 +24,8 @@ $('table').tablesorter({ sortList: [[0,0]] });
 
 // accordion
 $( '.accordion' ).accordion({
-  active: false,
-  collapsible: true,
+  active: 0,
+  collapsible: false,
   heightStyle: 'content',
   icons: false
 });


### PR DESCRIPTION
As it turns out, one of our product managers didn't know you could expand the accordion on the log shipping troubleshooting page.

So that's a design flaw on my part 🥇 

This update fixes that:
1. First panel is expanded by default
2. Now you can’t collapse the accordion (one panel will ALWAYS be open)

This should make the accordions easier to understand when you first get to the page