### PR TITLE
fix certificate typo in azure sso page

### DIFF
--- a/_source/user-guide/users/single-sign-on/azure-sso.md
+++ b/_source/user-guide/users/single-sign-on/azure-sso.md
@@ -46,7 +46,7 @@ To discuss switching to an Enterprise plan, please contact your account manager.
 
 4. Zip the SAML certificate
 
-    In the SAML Signing Certificate section of the page, click the **Certificate (Raw)** download link (next to the certificate).
+    In the SAML Signing Certificate section of the page, click the **Certificate (Base64)** download link (next to the certificate).
 
     Download the certificate file and zip it.
     You'll attach this zip file to your next email to the Support team.


### PR DESCRIPTION
from Support: "The certificate shouldn’t be the Raw format, it should be the Base64 instead. Verified it with Josh and indeed the Raw didn’t work but the Base64 did."

<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### New pull request

<!-- A clear, concise description of the change and why you made it. Include URLs of changed pages, if you can. -->

Fixed typo