### PR TITLE
add kafka to preconfigured log types

### DIFF
--- a/_source/user-guide/log-shipping/built-in-log-types.md
+++ b/_source/user-guide/log-shipping/built-in-log-types.md
@@ -27,6 +27,7 @@ This table shows the built-in log types that Logz.io supports. If you don't see 
 | GPFS                  | `gpfs`                                     |
 | HAProxy               | `haproxy`                                  |
 | Jenkins               | `jenkins`                                  |
+| Kafka                 | `kafka_server`                             |
 | Microsoft IIS         | `iis`                                      |
 | MongoDB               | `mongodb`                                  |
 | Monit                 | `monit`                                    |

--- a/_source/user-guide/log-shipping/built-in-log-types.md
+++ b/_source/user-guide/log-shipping/built-in-log-types.md
@@ -31,11 +31,11 @@ This table shows the built-in log types that Logz.io supports. If you don't see 
 | Microsoft IIS         | `iis`                                      |
 | MongoDB               | `mongodb`                                  |
 | Monit                 | `monit`                                    |
-| Mysql                 | `mysql`                                    |
-| Mysql error           | `mysql_error`                              |
-| Mysql slow query      | `mysql_slow_query`                         |
-| Mysql monitor         | `mysql_monitor`                            |
+| MySQL                 | `mysql`                                    |
+| MySQL error           | `mysql_error`                              |
+| MySQL slow query      | `mysql_slow_query`                         |
+| MySQL monitor         | `mysql_monitor`                            |
 | Nagios                | `nagios`                                   |
-| Nginx access          | `nginx`, `nginx_access`, `nginx-access`    |
-| Nginx error           | `nginx-error`                              |
+| nginx access          | `nginx`, `nginx_access`, `nginx-access`    |
+| nginx error           | `nginx-error`                              |
 | OSSEC                 | `ossec`                                    |


### PR DESCRIPTION

<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### New pull request

<!-- A clear, concise description of the change and why you made it. Include URLs of changed pages, if you can. -->

from Support:
> We added a bas parsing for kafka logs under the type “kafka_server”

This PR adds that log type to the built-in log types page