### PR TITLE
upcase h5 and h6

### DIFF
--- a/_source/css/logz-docs.css
+++ b/_source/css/logz-docs.css
@@ -430,9 +430,10 @@ h4 {
 }
 
 h5, h6 {
-  font-size: 1.15rem;
+  font-size: 1.1rem;
   font-weight: 700;
-  margin-bottom: .25rem;
+  text-transform: uppercase;
+  margin-bottom: 0;
 }
 
 /* Use h6 to introduce procedures. If you need a regular heading, use h5 */


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### New pull request

Small tweak to CSS so that h5 and h6 are now uppercase