### PR TITLE
add logic to get page updated date from stale-list if not in frontmatter

### DIFF
--- a/_source/_includes/page-date.html
+++ b/_source/_includes/page-date.html
@@ -1,0 +1,12 @@
+{%- assign thisPath = page.path -%}
+{%- unless page.collection == nil -%}
+  {%- assign thisPath = thisPath | prepend: "logzio_collections/" -%}
+{%- endunless -%}
+{%- assign thisPath = thisPath | prepend: "_source/" -%}
+
+{%- assign thisRecord = site.data.stale-list.contents | where: "filepath", thisPath | first %}
+{%- assign pageDate = page.updated | default: thisRecord.committed -%}
+
+{%- if pageDate %}
+  <div class="updated">Updated {{pageDate | date: "%b %e, %Y" }}</div>
+{%- endif -%}

--- a/_source/_layouts/default.html
+++ b/_source/_layouts/default.html
@@ -17,7 +17,7 @@
         {{- page.title | escape -}}
       </h1>
 
-      {%- if page.updated %} <div class="updated">Updated {{page.updated | date: "%b %e, %Y" }}</div> {%- endif -%}
+      {% include page-date.html %}
       {% include community.html %}
       {% include page-flags.html %}
 


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### New pull request

By default, page updated date is shown only if `updated:` field is set in frontmatter.
This PR adds logic to pull the date from the stale-list yaml (that's generated at build time) if `updated` is missing from frontmatter.