### PR TITLE
fix response codes for /user-management

### DIFF
--- a/_source/api-src/logzio-public-api.yml
+++ b/_source/api-src/logzio-public-api.yml
@@ -1778,7 +1778,7 @@ paths:
         - lang: cURL
           source: 'curl -X DELETE "https://api.logz.io/v1/user-management/11300" -H "accept: application/json" -H "X-API-TOKEN: <token>"'
       responses:
-        204:
+        200:
           description: successful operation
   /user-management/suspend/{id}:
     post:
@@ -1799,7 +1799,7 @@ paths:
         - lang: cURL
           source: 'curl -X POST "https://api.logz.io/v1/user-management/suspend/11300" -H "accept: application/json" -H "X-API-TOKEN: <token>"'
       responses:
-        204:
+        200:
           description: successful operation
   /user-management/unsuspend/{id}:
     post:
@@ -1820,7 +1820,7 @@ paths:
         - lang: cURL
           source: 'curl -X POST "https://api.logz.io/v1/user-management/unsuspend/11300" -H "accept: application/json" -H "X-API-TOKEN: <token>"'
       responses:
-        204:
+        200:
           description: successful operation
 
 


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### New pull request

Fixed response codes for these endpoints:

* DELETE /user-management/{id}
* POST /user-management/suspend/{id}
* POST /user-management/unsuspend/{id}

Was incorrectly shown as 204, but should be 200.