### PR TITLE
streamline the page-date include

### DIFF
--- a/_source/_includes/page-date.html
+++ b/_source/_includes/page-date.html
@@ -1,17 +1,52 @@
+{%- comment -%}
+*   Drop this file in your _includes/ folder and add
+*   {% include page-date.html %} in `default` layout template.
+*
+*   - To hide, set `show-date: false` in frontmatter.
+*   - To override, set `updated: yyyy-mm-dd` in frontmatter.
+*         {%- endcomment -%}
+
+{%- comment -%}
+*   If `show-date` is false, don't bother with this include.
+*         {%- endcomment -%}
+{%- unless page.show-date == false -%}
+
+
+{%- comment -%}
+*   Folder paths for your source files and Jekyll collections. Find these in
+*   _config.yml. End these values with a trailing slash.
+*
+*   Paths should match the format in stale-list.yml. In other words, match the
+*   filesystem, not Jekyll's _config.yml.
+*         {%- endcomment -%}
+{%- assign sourceFolder = "_source/" -%}
+{%- assign collectionsFolder = "logzio_collections/" -%}
+
 {%- assign thisPath = page.path -%}
+
+{%- comment -%}
+*   If this page is part of a collection, prepend with `collectionsFolder`.
+*         {%- endcomment -%}
 {%- unless page.collection == nil -%}
-  {%- assign thisPath = thisPath | prepend: "logzio_collections/" -%}
+  {%- assign thisPath = thisPath | prepend: collectionsFolder -%}
 {%- endunless -%}
-{%- assign thisPath = thisPath | prepend: "_source/" -%}
 
+{%- comment -%}
+*   Prepend all pages with `sourceFolder`. At this point, thisPath *should*
+*   match a record in stale-list.yml.
+*         {%- endcomment -%}
+{%- assign thisPath = thisPath | prepend: sourceFolder -%}
+
+{%- comment -%}
+*   Find the file in stale-list.yml whose filepath matches `thisPath`.
+*         {%- endcomment -%}
 {%- assign thisRecord = site.data.stale-list.contents | where: "filepath", thisPath | first %}
-{%- case page.show-date -%}
-  {%- when false -%}
-    {%- assign pageDate = nil -%}
-  {%- else -%}
-    {%- assign pageDate = page.updated | default: thisRecord.committed -%}
-{%- endcase -%}
 
-{%- if pageDate %}
-  <div class="updated">Updated {{pageDate | date: "%b %e, %Y" }}</div>
-{%- endif -%}
+{%- comment -%}
+*   If frontmatter contains `updated`, use that. Otherwise, use the commit
+*   date from stale-list.yml.
+*         {%- endcomment -%}
+{%- assign pageDate = page.updated | default: thisRecord.committed -%}
+
+<div class="updated">Updated {{ pageDate | date: "%b %e, %Y" }}</div>
+{%- endunless -%}


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### New pull request

Rework the page-date include so that it won't run if show-date is false in a page's frontmatter
