### PR TITLE
Conditionalize robots.txt

### DIFF
--- a/_source/logzio_collections/_docs-admin/index.md
+++ b/_source/logzio_collections/_docs-admin/index.md
@@ -8,6 +8,8 @@ permalink: /docs-admin/
   | where: "label", page.collection
   | first -%}
 
+This build's environment: {{jekyll.environment}}
+
 ##### Admin TOC
 
 {% for doc in thisCollection.docs %}

--- a/_source/robots.txt
+++ b/_source/robots.txt
@@ -1,2 +1,14 @@
+---
+---
 User-agent: *
+
+{%- if jekyll.environment == "production" %}
 Allow: /
+Disallow: /docs-admin/
+Disallow: /technical-notes/
+Sitemap: {{ site.url | append: site.baseurl}}/sitemap.xml
+
+{%- else %}
+Disallow: /
+
+{%- endif -%}

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 $PWD/scripts/_build-process.sh
-JEKYLL_ENV=production jekyll build
+jekyll build

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,35 @@
+# Settings in the [build] context are global and are applied to all contexts
+# unless otherwise overridden by more specific contexts.
+[build]
+  # Directory to change to before starting a build.
+  # This is where we will look for package.json/.nvmrc/etc.
+  publish = "_site/"
+  command = "./build.sh"
+
+# Production context: all deploys from the Production branch set in your site's 
+# deploy contexts will inherit these settings.
+[context.production]
+  publish = "_site/"
+  command = "./build.sh"
+
+[context.production.environment]
+  JEKYLL_ENV = "production"
+
+
+# Deploy Preview context: all deploys resulting from a pull/merge request will 
+# inherit these settings.
+[context.deploy-preview]
+  publish = "_site/"
+  command = "./build.sh"
+
+[context.deploy-preview.environment]
+  JEKYLL_ENV = "develop"
+
+# Branch Deploy context: all deploys that are not from a pull/merge request or 
+# from the Production branch will inherit these settings.
+[context.branch-deploy]
+  publish = "_site/"
+  command = "./build.sh"
+
+[context.branch-deploy.environment]
+  JEKYLL_ENV = "develop"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,26 +10,17 @@
 # deploy contexts will inherit these settings.
 [context.production]
   publish = "_site/"
-  command = "./build.sh"
-
-[context.production.environment]
-  JEKYLL_ENV = "production"
+  command = "JEKYLL_ENV=production ./build.sh"
 
 
 # Deploy Preview context: all deploys resulting from a pull/merge request will 
 # inherit these settings.
 [context.deploy-preview]
   publish = "_site/"
-  command = "./build.sh"
-
-[context.deploy-preview.environment]
-  JEKYLL_ENV = "develop"
+  command = "JEKYLL_ENV=develop ./build.sh"
 
 # Branch Deploy context: all deploys that are not from a pull/merge request or 
 # from the Production branch will inherit these settings.
 [context.branch-deploy]
   publish = "_site/"
-  command = "./build.sh"
-
-[context.branch-deploy.environment]
-  JEKYLL_ENV = "develop"
+  command = "JEKYLL_ENV=develop ./build.sh"


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### New pull request

Added Netlify toml and added conditions to robots.txt so that:
- deploys from master branch are given "production" environment and robots.txt allows crawling
- deploy previews from other branches or PRs are given "develop" environment and all crawling is disallowed.

#### To test
Navigate to /robots.txt. If you see `Disallow: /`, environment is develop.

#### After deploying
Navigate to docs.logz.io/robots.txt. If you see `Disallow: /`, then something went wrong and you should roll back the deploy.