### PR TITLE
Clickable card

### DIFF
--- a/_source/_layouts/docs-home.html
+++ b/_source/_layouts/docs-home.html
@@ -32,13 +32,13 @@
 
 
     <div class="cards half-cards">
-      {% for card in page.half-cards %}
-      <a href="{{ card.url }}">
-        <div class="card half-card">
+      {% for card in page.half-cards -%}
+      <div class="card half-card">
+        <a href="{{ card.url }}">
           <span class="card-title">{{ card.title }}</span>
-        </div>
-      </a>
-      {% endfor %}
+        </a>
+      </div>
+      {%- endfor %}
     </div>
 
   </div>

--- a/_source/css/logz-docs.css
+++ b/_source/css/logz-docs.css
@@ -245,15 +245,26 @@ div.card {
   margin: 12px;
   width: 250px;
   text-align: center;
-
+  display: flex;
   box-shadow: none;
   transition: box-shadow 200ms;
 }
 
 .card > a {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
+  width: 100%;
+  justify-self: stretch;
+  align-self: stretch;
+  justify-content: space-around;
+}
+
+.full-card > a {
   padding: 14px;
+}
+
+.mini-card > a {
+  padding: 0;
 }
 
 div.card:hover {
@@ -272,12 +283,6 @@ div.mini-card {
   width: 150px;
   height: 160px;
   display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-}
-
-.mini-card > a {
-  padding: 0 5px;
 }
 
 div.mini-card.community-project-card {
@@ -359,12 +364,9 @@ div.card-icon i::before {
   justify-content: flex-start;
 }
 
-.mini-card.community-project-card a {
-  margin-top: auto;
-  margin-bottom: auto;
-}
+.mini-card.community-project-card a {justify-content: flex-start;}
 
-.mini-card.community-project-card::before {
+.mini-card.community-project-card > a::before {
   content: "Community project";
 
   background-color: rgb(var(--app-gray-primary));


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### New pull request

My last PRs introduced layout issues for the docs-home template. This fixes it so that docs-home, the log shipping page, and the community shippers page all contain cards that are clickable.

Will do some more refinement in a later PR.