### PR TITLE
Listener ip feed

### DIFF
--- a/_source/no-search/listener-ip-addresses.xml
+++ b/_source/no-search/listener-ip-addresses.xml
@@ -1,0 +1,33 @@
+---
+layout: none
+permalink: /listener-ip-addresses.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Logz.io listener IP addresses</title>
+    <description>If you're having trouble shipping your logs to Logz.io, you may need to open your firewall to Logz.io listener servers. This page contains the Logz.io listener IP addresses so you can do just that.</description>
+    <link>{{ site.url }}{{ site.baseurl }}/user-guide/log-shipping/listener-ip-addresses.html</link>
+    <atom:link href="{{site.url}}{{site.baseurl}}{{page.permalink}}" rel="self" type="application/rss+xml" />
+
+    {% for r in site.data.logzio-regions -%}
+      {%- assign attribs = r[1] -%}
+      {%- case attribs.suffix -%}
+        {%- when false -%}
+          {%- assign suffix = "" -%}
+        {%- else -%}
+          {%- assign suffix = r[0] | prepend: "-" -%}
+      {%- endcase %}
+
+      <item>
+        <title>listener{{suffix}}.logz.io — {{attribs.title}}, {{attribs.cloud}}</title>
+        <description>
+          If you're shipping logs to listener{{suffix}}.logz.io, open your firewall to these {{attribs.cloud}} IP addresses:
+
+          {% assign sortedIPs = attribs.listener-ips | sort | join: ", " -%}
+          {{sortedIPs}}
+        </description>
+      </item>
+    {%- endfor %}
+  </channel>
+</rss>

--- a/_source/user-guide/log-shipping/listener-ip-addresses.md
+++ b/_source/user-guide/log-shipping/listener-ip-addresses.md
@@ -26,9 +26,9 @@ If you're having trouble shipping your logs to Logz.io, you may need to open you
       {%- assign suffix = r[0] | prepend: "-" -%}
   {%- endcase %}
 
-#### app{{suffix}}.logz.io — _{{attribs.title}}, {{attribs.cloud}}_
+#### listener{{suffix}}.logz.io — _{{attribs.title}}, {{attribs.cloud}}_
 
-If you're shipping logs to app{{suffix}}.logz.io, open your firewall to these {{attribs.cloud}} IP addresses:
+If you're shipping logs to listener{{suffix}}.logz.io, open your firewall to these {{attribs.cloud}} IP addresses:
 
 {% assign sortedIPs = attribs.listener-ips | sort -%}
 {%- for ip in sortedIPs %}


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### What changed

Support requested a feed for listener IP addresses. Customers should be able to subscribe to this list now.

- The feed: https://deploy-preview-207--logz-docs.netlify.com/listener-ip-addresses.xml
- Fixed a typo: https://deploy-preview-207--logz-docs.netlify.com/user-guide/log-shipping/listener-ip-addresses.html

Feed is valid per W3C spec: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fdeploy-preview-207--logz-docs.netlify.com%2Flistener-ip-addresses.xml

## Remaining work
- [x] Technical review
- [x] Copy Review

## Post launch

no tasks needed

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->