### PR TITLE
rework rss file so each IP is its own item

### DIFF
--- a/_source/_includes/page-info/community.html
+++ b/_source/_includes/page-info/community.html
@@ -5,6 +5,7 @@
     {% include page-info/contributor-list.html %}
   </div>
   {%- endunless -%}
+  {% include page-info/rss-subscribe.html %}
   {% include page-info/logzio-plan.html %}
 </div>
 

--- a/_source/_includes/page-info/rss-subscribe.html
+++ b/_source/_includes/page-info/rss-subscribe.html
@@ -1,0 +1,5 @@
+{%- if page.flags.rss-subscribe -%}
+<div class="rss-button">
+  <a href="{{page.flags.rss-subscribe | prepend: site.baseurl}}"><i class="fas fa-rss"></i> Subscribe for updates</a>
+</div>
+{%- endif -%}

--- a/_source/css/logz-docs.css
+++ b/_source/css/logz-docs.css
@@ -985,6 +985,16 @@ h1 .avatar.avatar-small {
   background: linear-gradient(to bottom, var(--background-very-light), silver);
 }
 
+.rss-button a {
+  color: white;
+  background-color: orange;
+  font-weight: 700;
+  width: fit-content;
+  padding: 5px 15px;
+  border-radius: 6px;
+  margin: 0;
+}
+
 /* ===== FPO - IMAGE PLACEHOLDERS ===== */
 .fpo {
   display: flex;

--- a/_source/css/logz-docs.css
+++ b/_source/css/logz-docs.css
@@ -986,14 +986,21 @@ h1 .avatar.avatar-small {
 }
 
 .rss-button a {
-  color: white;
-  background-color: orange;
+  color: orange;
+  border: 1px solid currentColor;
   font-weight: 700;
   width: fit-content;
-  padding: 5px 15px;
+  padding: 0 5px;
   border-radius: 6px;
   margin: 0;
 }
+
+.rss-button a:hover {
+  color: white;
+  background-color: orange;
+  border: 1px solid currentColor;
+}
+
 
 /* ===== FPO - IMAGE PLACEHOLDERS ===== */
 .fpo {
@@ -1014,6 +1021,7 @@ h1 .avatar.avatar-small {
   text-align: center;
   color: var(--text-code);
   font-weight: 700;
+  font-size: .9rem;
 }
 
 .fpo.fpo-1::after {

--- a/_source/no-search/listener-ip-addresses.xml
+++ b/_source/no-search/listener-ip-addresses.xml
@@ -10,24 +10,12 @@ permalink: /listener-ip-addresses.xml
     <link>{{ site.url }}{{ site.baseurl }}/user-guide/log-shipping/listener-ip-addresses.html</link>
     <atom:link href="{{site.url}}{{site.baseurl}}{{page.permalink}}" rel="self" type="application/rss+xml" />
 
-    {% for r in site.data.logzio-regions -%}
-      {%- assign attribs = r[1] -%}
-      {%- case attribs.suffix -%}
-        {%- when false -%}
-          {%- assign suffix = "" -%}
-        {%- else -%}
-          {%- assign suffix = r[0] | prepend: "-" -%}
-      {%- endcase %}
-
-      <item>
-        <title>listener{{suffix}}.logz.io — {{attribs.title}}, {{attribs.cloud}}</title>
-        <description>
-          If you're shipping logs to listener{{suffix}}.logz.io, open your firewall to these {{attribs.cloud}} IP addresses:
-
-          {% assign sortedIPs = attribs.listener-ips | sort | join: ", " -%}
-          {{sortedIPs}}
-        </description>
-      </item>
+    {% for region in site.data.logzio-regions -%}
+      {%- for ip in region[1].listener-ips -%}
+    <item>
+        <title>{{ip}} - {{region[1].cloud}} - {{region[1].title}}</title>
+    </item>
+      {%- endfor -%}
     {%- endfor %}
   </channel>
 </rss>

--- a/_source/user-guide/log-shipping/listener-ip-addresses.md
+++ b/_source/user-guide/log-shipping/listener-ip-addresses.md
@@ -11,10 +11,16 @@ contributors:
   - schwin007
 ---
 
+<div class="rss-button">
+  [<i class="fas fa-rss"></i> Subscribe for updates]({{site.baseurl}}/listener-ip-addresses.xml)
+</div>
+
 If you're having trouble shipping your logs to Logz.io, you may need to open your firewall to Logz.io listener servers. To see if you need to change your firewall configuration, see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
 
 <div class="info-box note">
-  Ship logs to the listener URL, not to individual IP addresses. This ensures that logs are properly balanced on our listener servers, and that your logs will be available to you as quickly as possible.
+  Ship logs to the listener URL, not to individual IP addresses.
+  This ensures that logs are properly balanced on our listener servers,
+  and that your logs will be available to you as quickly as possible.
 </div>
 
 {% for r in site.data.logzio-regions -%}

--- a/_source/user-guide/log-shipping/listener-ip-addresses.md
+++ b/_source/user-guide/log-shipping/listener-ip-addresses.md
@@ -4,16 +4,14 @@ title: Listener IP addresses
 description: If you're having trouble shipping your logs to Logz.io, you may need to open your firewall to Logz.io listener servers. This page contains the Logz.io listener IP addresses so you can do just that.
 permalink: /user-guide/log-shipping/listener-ip-addresses.html
 show-date: false
+flags:
+  rss-subscribe: /listener-ip-addresses.xml
 tags:
   - log-shipping
 contributors:
   - imnotashrimp
   - schwin007
 ---
-
-<div class="rss-button">
-  [<i class="fas fa-rss"></i> Subscribe for updates]({{site.baseurl}}/listener-ip-addresses.xml)
-</div>
 
 If you're having trouble shipping your logs to Logz.io, you may need to open your firewall to Logz.io listener servers. To see if you need to change your firewall configuration, see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
 


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### What changed

Changed the RSS file so that each `<item>` is an IP address. This way, subscribed users should be able to see when IP addresses are added.

Added subscribe button to the IP addresses page https://deploy-preview-212--logz-docs.netlify.com/user-guide/log-shipping/listener-ip-addresses.html

## Remaining work
- [x] Technical review

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->