### PR TITLE
Doc for testing IAM user perms for S3

### DIFF
--- a/_source/_data/toc.yml
+++ b/_source/_data/toc.yml
@@ -129,14 +129,16 @@ firstLevel:
       url: /user-guide/tokens/shared-tokens.html
     - title: Manage API tokens
       url: /user-guide/tokens/api-tokens.html
+
   - title: Archive & restore
     url: /user-guide/archive-and-restore/
-
     thirdLevel:
       - title: Configure archiving
         url: /user-guide/archive-and-restore/configure-archiving.html
       - title: Restore archived logs
         url: /user-guide/archive-and-restore/restore-archived-logs.html
+      - title: Set S3 permissions
+        url: /user-guide/archive-and-restore/set-s3-permissions.html
 
   # ===== SHIPPING AND PARSING =====
 - title: Shipping & parsing

--- a/_source/user-guide/archive-and-restore/set-s3-permissions.md
+++ b/_source/user-guide/archive-and-restore/set-s3-permissions.md
@@ -1,0 +1,92 @@
+---
+layout: article
+title: Set S3 permissions
+permalink: /user-guide/archive-and-restore/set-s3-permissions.html
+tags:
+  - s3
+  - archive-and-restore
+contributors:
+  - imnotashrimp
+  - schwin007
+---
+
+To archive and restore your logs to a S3 bucket,
+Logz.io needs these permissions:
+
+* To **archive** to a bucket, we need `s3:PutObject` permissions
+* To **restore** archives, we need `s3:ListBucket` and `s3:GetObject` permissions
+
+You'll set these permissions for an AWS IAM user.
+
+<div class="info-box tip">
+  We recommend allowing all three permissions so you won't run into any issues when you want to restore.
+</div>
+
+Sample policy
+{: .inline-header }
+
+This code block shows a policy for an IAM user with all three permissions enabled:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:PutObject",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<BUCKET-NAME>",
+        "arn:aws:s3:::<BUCKET-NAME>/*"
+      ]
+    }
+  ]
+}
+```
+
+## Testing Your Configuration
+
+To confirm your IAM user has `PutObject` permissions,
+you can fill in your credentials on the [Archive & restore](https://app.logz.io/#/dashboard/tools/archive-and-restore) page,
+and then click **Test connection**.
+
+To test for `ListBucket` and `GetObject` permissions, you can use [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
+
+###### To test your IAM user permissions
+
+**You'll need**:
+[AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) configured with the IAM user credentials you're testing
+
+{: .tasklist .firstline-headline }
+1. Create a test file
+
+    Make a new dummy file for testing purposes.
+
+    ```shell
+    touch DELETE-logzio-test.txt
+    ```
+
+2. Run the tests
+
+    Test `PutObject` permissions by moving your dummy file to the bucket:
+
+    ```shell
+    aws s3 mv DELETE-logzio-test.txt s3://<BUCKET-NAME>/
+    ```
+
+    Test `ListBucket` permissions by listing the bucket contents:
+
+    ```shell
+    aws s3 ls s3://<BUCKET-NAME>/
+    ```
+
+    Test `GetObject` permissions by copying your dummy file to the bucket:
+
+    ```shell
+    aws s3 cp s3://<BUCKET-NAME>/DELETE-logzio-test.txt SUCCESSFUL-GetObject-perms.txt
+    ```
+
+    If all the commands are successful, we can archive and restore your logs with these IAM user credentials.


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### What changed

New doc for testing S3 permissions, to be linked to from the app and help users better figure out what permissions they're handing over to us.

@logzio/validation-engineers I had trouble setting up the permissions on my own S3, so someone actually running through the steps on a properly-configured bucket is super important here.

Pages to review:
- https://deploy-preview-214--logz-docs.netlify.com/user-guide/archive-and-restore/set-s3-permissions.html

## Remaining work
- [x] Technical review
- [x] Copy Review
- [x] Give URL to dev team

## Post launch
**Do not remove** - To be completed by the docs team upon merge:
- [x] Let dev know that this doc is live and ready to be linked to
- [x] Replace https://support.logz.io/hc/en-us/articles/209486489-What-permissions-must-I-have-to-archive-logs-to-a-S3-bucket- with "This page has been moved to..."

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->