### PR TITLE
AD on-prem shipping

### DIFF
--- a/_source/logzio_collections/_log-sources/active-directory-winserver.md
+++ b/_source/logzio_collections/_log-sources/active-directory-winserver.md
@@ -90,7 +90,7 @@ shipping-tags:
     fields:
       logzio_codec: json
       token: <<SHIPPING-TOKEN>>
-      type: wineventlog6
+      type: wineventlog
     fields_under_root: true
     ```
 

--- a/_source/logzio_collections/_log-sources/active-directory-winserver.md
+++ b/_source/logzio_collections/_log-sources/active-directory-winserver.md
@@ -1,5 +1,4 @@
 ---
-published: false
 title: Ship Active Directory logs from Windows Server
 logo:
   logofile: windows.svg
@@ -18,7 +17,8 @@ shipping-tags:
 ###### Configuration
 
 **You'll need**:
-[Winlogbeat](https://www.elastic.co/downloads/beats/winlogbeat)
+[Winlogbeat 7](https://www.elastic.co/downloads/beats/winlogbeat) or
+[Winlogbeat 6](https://www.elastic.co/guide/en/beats/winlogbeat/6.8/winlogbeat-installation.html)
 
 1.  Download the Logz.io certificate
 
@@ -31,7 +31,17 @@ shipping-tags:
 
     {% include log-shipping/replace-vars.html token=true %}
 
+    <div class="branching-container">
+
+    * [Winlogbeat 7](#winlogbeat-7-code)
+    * [Winlogbeat 6](#winlogbeat-6-code)
+    {: .branching-tabs }
+
+    <div id="winlogbeat-7-code">
+
     ```yaml
+    # Winlogbeat 7 configuration
+
     winlogbeat.event_logs:
       - name: Application
         ignore_older: 72h
@@ -43,7 +53,50 @@ shipping-tags:
       token: <<SHIPPING-TOKEN>>
       type: wineventlog
     fields_under_root: true
+
+    processors:
+      - add_host_metadata: ~
+      - add_cloud_metadata: ~
+      - rename:
+          fields:
+          - from: "agent"
+            to: "beat_agent"
+          ignore_missing: true
+      - rename:
+          fields:
+          - from: "log.file.path"
+            to: "source"
+          ignore_missing: true
+      - rename:
+          fields:
+          - from: "log"
+            to: "log_information"
+          ignore_missing: true
     ```
+
+    </div>
+
+    <div id="winlogbeat-6-code">
+
+    ```yaml
+    # Winlogbeat 6 configuration
+
+    winlogbeat.event_logs:
+      - name: Application
+        ignore_older: 72h
+      - name: Security
+      - name: System
+
+    fields:
+      logzio_codec: json
+      token: <<SHIPPING-TOKEN>>
+      type: wineventlog6
+    fields_under_root: true
+    ```
+
+    </div>
+
+    </div>
 
 3.  Add Logz.io as an output
 


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### What changed

Added a page for shipping logs from AD on-prem. AD Azure to follow in a future PR.

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- [x] Click the **Security** filter to see AD. https://deploy-preview-234--logz-docs.netlify.com/shipping/
- [x] https://deploy-preview-234--logz-docs.netlify.com/shipping/log-sources/active-directory-winserver.html

**Notes for reviewers**:

Please confirm both of these configurations work.
- [x] Winlogbeat 7 config works
- [x] Winlogbeat 6 config works


## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review
- [x] Copy Review

## Post launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Teams to update with the new information: Support

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
