### PR TITLE
Fix shipping sorting

### DIFF
--- a/_source/_includes/log-shipping/in-app-configuration.html
+++ b/_source/_includes/log-shipping/in-app-configuration.html
@@ -14,5 +14,5 @@
     {%- assign action = "fill out the S3 bucket information" -%}
 {%- endcase -%}
 
-To use the {{tool}}, {{action}} on the [{{page.shipping-summary.data-source}} log shipping]({{page.logzio-app-url}}) page.
+To use the {{tool}}, {{action}} on the [{{page.data-source}} log shipping]({{page.logzio-app-url}}) page.
 You must be logged in to Logz.io.

--- a/_source/_layouts/default.html
+++ b/_source/_layouts/default.html
@@ -13,10 +13,10 @@
     {% include left-toc.html %}
 
     <div class="body-container">
-    {%- if page.shipping-summary -%}
+    {%- if page.data-source -%}
     <div class="breadcrumbs">
       <span><a href="{{site.baseurl}}/shipping/">Ship your data</a></span>
-      <span>{{ page.shipping-summary.data-source }}</span>
+      <span>{{ page.data-source }}</span>
     </div>
     {%- endif -%}
     <div class="title-container">

--- a/_source/data/shipping-manifest.json
+++ b/_source/data/shipping-manifest.json
@@ -24,7 +24,7 @@ permalink: /data/shipping-manifest.json
           {%- for d in thisCollection.docs %}
             {
               "title": "{{d.title}}",
-              "dataSource": "{{d.shipping-summary.data-source}}",
+              "dataSource": "{{d.data-source}}",
               {%- if d.open-source -%}
                 {%- capture openSourceString -%}
                   [

--- a/_source/logzio_collections/_community-shippers/angular--angular1-logzio-logging.md
+++ b/_source/logzio_collections/_community-shippers/angular--angular1-logzio-logging.md
@@ -4,8 +4,7 @@ project-url: https://github.com/drmikecrowe/angular1-logzio-logging
 logo:
   logofile: angular.svg
   orientation: vertical
-shipping-summary:
-  data-source: Angular code
+data-source: Angular code
 shipping-tags:
   - from-your-code
 ---

--- a/_source/logzio_collections/_community-shippers/ansible--jmcvetta-logzio.md
+++ b/_source/logzio_collections/_community-shippers/ansible--jmcvetta-logzio.md
@@ -4,8 +4,7 @@ project-url: https://github.com/jmcvetta/ansible-logzio
 logo:
   logofile: ansible.svg
   orientation: vertical
-shipping-summary:
-  data-source: Ansible
+data-source: Ansible
 shipping-tags:
   - platform-service
 ---

--- a/_source/logzio_collections/_community-shippers/dotnet--logzio-nlog.md
+++ b/_source/logzio_collections/_community-shippers/dotnet--logzio-nlog.md
@@ -4,8 +4,7 @@ project-url: https://github.com/kylewest/logzio-nlog
 logo:
   logofile: dotnet.svg
   orientation: vertical
-shipping-summary:
-  data-source: .NET code
+data-source: .NET code
 shipping-tags:
   - from-your-code
 ---

--- a/_source/logzio_collections/_community-shippers/dotnet--serilog-sinks-logzio.md
+++ b/_source/logzio_collections/_community-shippers/dotnet--serilog-sinks-logzio.md
@@ -4,8 +4,7 @@ project-url: https://github.com/asperheim/serilog-sinks-logzio
 logo:
   logofile: dotnet.svg
   orientation: vertical
-shipping-summary:
-  data-source: .NET code
+data-source: .NET code
 shipping-tags:
   - from-your-code
 ---

--- a/_source/logzio_collections/_community-shippers/fluentd--fluentd-logzio.md
+++ b/_source/logzio_collections/_community-shippers/fluentd--fluentd-logzio.md
@@ -4,8 +4,7 @@ project-url: https://github.com/jdrago999/fluentd-logzio
 logo:
   logofile: fluentd.svg
   orientation: vertical
-shipping-summary:
-  data-source: Fluentd
+data-source: Fluentd
 shipping-tags:
   - log-shipper
 ---

--- a/_source/logzio_collections/_community-shippers/go--logruzio.md
+++ b/_source/logzio_collections/_community-shippers/go--logruzio.md
@@ -4,8 +4,7 @@ project-url: https://github.com/bshuster-repo/logruzio
 logo:
   logofile: go.svg
   orientation: horizontal
-shipping-summary:
-  data-source: Go code
+data-source: Go code
 shipping-tags:
   - from-your-code
 ---

--- a/_source/logzio_collections/_community-shippers/ios--justlog.md
+++ b/_source/logzio_collections/_community-shippers/ios--justlog.md
@@ -4,8 +4,7 @@ project-url: https://github.com/justeat/JustLog
 logo:
   logofile: ios.svg
   orientation: vertical
-shipping-summary:
-  data-source: iOS
+data-source: iOS
 shipping-tags:
   - from-your-code
 ---

--- a/_source/logzio_collections/_community-shippers/kubernetes--fluentd-logzio-kubernetes.md
+++ b/_source/logzio_collections/_community-shippers/kubernetes--fluentd-logzio-kubernetes.md
@@ -4,8 +4,7 @@ project-url: https://github.com/snyk/fluentd-logzio-kubernetes
 logo:
   logofile: kubernetes.svg
   orientation: vertical
-shipping-summary:
-  data-source: Kubernetes
+data-source: Kubernetes
 shipping-tags:
   - container
 ---

--- a/_source/logzio_collections/_community-shippers/node--logzio-node-debug.md
+++ b/_source/logzio_collections/_community-shippers/node--logzio-node-debug.md
@@ -4,8 +4,7 @@ project-url: https://github.com/amio-io/logzio-node-debug
 logo:
   logofile: nodejs.svg
   orientation: vertical
-shipping-summary:
-  data-source: Node code
+data-source: Node code
 shipping-tags:
   - from-your-code
 ---

--- a/_source/logzio_collections/_community-shippers/php--elastica-logzio.md
+++ b/_source/logzio_collections/_community-shippers/php--elastica-logzio.md
@@ -4,8 +4,7 @@ project-url: https://github.com/lordoffreaks/elastica-logzio
 logo:
   logofile: php.svg
   orientation: vertical
-shipping-summary:
-  data-source: PHP code
+data-source: PHP code
 shipping-tags:
   - from-your-code
 ---

--- a/_source/logzio_collections/_community-shippers/php--php-logger.md
+++ b/_source/logzio_collections/_community-shippers/php--php-logger.md
@@ -4,8 +4,7 @@ project-url: https://github.com/vagnercsouza/logger
 logo:
   logofile: php.svg
   orientation: vertical
-shipping-summary:
-  data-source: PHP code
+data-source: PHP code
 shipping-tags:
   - from-your-code
 ---

--- a/_source/logzio_collections/_community-shippers/puppet--puppet-logzio_shipper.md
+++ b/_source/logzio_collections/_community-shippers/puppet--puppet-logzio_shipper.md
@@ -4,8 +4,7 @@ project-url: https://github.com/iwalz/puppet-logzio_shipper
 logo:
   logofile: puppet.png
   orientation: vertical
-shipping-summary:
-  data-source: Puppet
+data-source: Puppet
 shipping-tags:
   - ci-cd
 ---

--- a/_source/logzio_collections/_community-shippers/ruby--logstashlogger.md
+++ b/_source/logzio_collections/_community-shippers/ruby--logstashlogger.md
@@ -4,8 +4,7 @@ project-url: https://github.com/dwbutler/logstash-logger
 logo:
   logofile: ruby.svg
   orientation: vertical
-shipping-summary:
-  data-source: Ruby code
+data-source: Ruby code
 shipping-tags:
   - from-your-code
 ---

--- a/_source/logzio_collections/_community-shippers/tyk--tyk-pump.md
+++ b/_source/logzio_collections/_community-shippers/tyk--tyk-pump.md
@@ -4,8 +4,7 @@ project-url: https://github.com/TykTechnologies/tyk-pump
 logo:
   logofile: tyk.svg
   orientation: vertical
-shipping-summary:
-  data-source: Tyk
+data-source: Tyk
 shipping-tags:
   - platform-service
 ---

--- a/_source/logzio_collections/_log-sources/active-directory-winserver.md
+++ b/_source/logzio_collections/_log-sources/active-directory-winserver.md
@@ -4,8 +4,7 @@ title: Ship Active Directory logs from Windows Server
 logo:
   logofile: windows.svg
   orientation: vertical
-shipping-summary:
-  data-source: Active Directory (Windows Server)
+data-source: Active Directory (Windows Server)
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -3,8 +3,7 @@ title: Ship Apache logs
 logo:
   logofile: apache.svg
   orientation: vertical
-shipping-summary:
-  data-source: Apache HTTPS Server 2
+data-source: Apache HTTPS Server 2
 contributors:
   - amosd92
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -3,8 +3,7 @@ title: AWS cost and usage report
 logo:
   logofile: aws.svg
   orientation: vertical
-shipping-summary:
-  data-source: AWS cost and usage report
+data-source: AWS cost and usage report
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/AWS-costandusagereport
 open-source:
   - title: AWS Cost and Usage Lambda

--- a/_source/logzio_collections/_log-sources/azure-activity-logs.md
+++ b/_source/logzio_collections/_log-sources/azure-activity-logs.md
@@ -6,8 +6,7 @@ open-source:
 logo:
   logofile: azure-monitor.svg
   orientation: vertical
-shipping-summary:
-  data-source: Azure activity logs
+data-source: Azure activity logs
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Activity-log
 tags:
   - azure

--- a/_source/logzio_collections/_log-sources/azure-diagnostic-logs.md
+++ b/_source/logzio_collections/_log-sources/azure-diagnostic-logs.md
@@ -6,8 +6,7 @@ open-source:
 logo:
   logofile: azure-monitor.svg
   orientation: vertical
-shipping-summary:
-  data-source: Azure diagnostic logs
+data-source: Azure diagnostic logs
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Diagnostics-settings
 tags:
   - azure

--- a/_source/logzio_collections/_log-sources/cloudfront.md
+++ b/_source/logzio_collections/_log-sources/cloudfront.md
@@ -3,8 +3,7 @@ title: Ship CloudFront logs
 logo:
   logofile: aws-cloudfront.svg
   orientation: vertical
-shipping-summary:
-  data-source: Amazon CloudFront
+data-source: CloudFront
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/CloudFront
 contributors:
   - idohalevi

--- a/_source/logzio_collections/_log-sources/cloudtrail.md
+++ b/_source/logzio_collections/_log-sources/cloudtrail.md
@@ -3,8 +3,7 @@ title: Ship CloudTrail logs
 logo:
   logofile: aws-cloudtrail.svg
   orientation: vertical
-shipping-summary:
-  data-source: Amazon CloudTrail
+data-source: CloudTrail
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/CloudTrail
 contributors:
   - idohalevi

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -3,8 +3,7 @@ title: Ship CloudWatch logs
 logo:
   logofile: aws-cloudwatch.svg
   orientation: vertical
-shipping-summary:
-  data-source: Amazon CloudWatch
+data-source: CloudWatch
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/CloudWatch
 open-source:
   - title: CloudWatch Lambda Log Shipper

--- a/_source/logzio_collections/_log-sources/docker-performance.md
+++ b/_source/logzio_collections/_log-sources/docker-performance.md
@@ -3,8 +3,7 @@ title: Ship Docker performance logs
 logo:
   logofile: docker.svg
   orientation: horizontal
-shipping-summary:
-  data-source: Docker performance logs
+data-source: Docker performance logs
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Perfagent
 contributors:
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/docker.md
+++ b/_source/logzio_collections/_log-sources/docker.md
@@ -3,8 +3,7 @@ title: Ship Docker logs
 logo:
   logofile: docker.svg
   orientation: horizontal
-shipping-summary:
-  data-source: Docker container
+data-source: Docker container
 open-source:
   - title: docker-collector-logs
     github-repo: docker-collector-logs

--- a/_source/logzio_collections/_log-sources/dotnet.md
+++ b/_source/logzio_collections/_log-sources/dotnet.md
@@ -3,8 +3,7 @@ title: Ship .NET logs
 logo:
   logofile: dotnet.svg
   orientation: vertical
-shipping-summary:
-  data-source: .NET code
+data-source: .NET code
 open-source:
   - title: logzio-dotnet
     github-repo: logzio-dotnet

--- a/_source/logzio_collections/_log-sources/elastic-container-service.md
+++ b/_source/logzio_collections/_log-sources/elastic-container-service.md
@@ -6,8 +6,7 @@ logo:
 open-source:
   - title: Logz.io AWS ECS Collector
     github-repo: logzio-aws-ecs
-shipping-summary:
-  data-source: Amazon Elastic Container Service
+data-source: Elastic Container Service
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/ECS
 contributors:
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/elastic-load-balancing.md
+++ b/_source/logzio_collections/_log-sources/elastic-load-balancing.md
@@ -3,8 +3,7 @@ title: Ship Elastic Load Balancing logs
 logo:
   logofile: aws-elb.svg
   orientation: vertical
-shipping-summary:
-  data-source: Amazon Elastic Load Balancing
+data-source: Elastic Load Balancing
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/ELB
 contributors:
   - idohalevi

--- a/_source/logzio_collections/_log-sources/fortigate.md
+++ b/_source/logzio_collections/_log-sources/fortigate.md
@@ -3,8 +3,7 @@ title: Ship FortiGate logs
 logo:
   logofile: fortinet.svg
   orientation: vertical
-shipping-summary:
-  data-source: FortiGate
+data-source: FortiGate
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -3,8 +3,7 @@ title: Ship GitLab logs
 logo:
   logofile: gitlab.svg
   orientation: vertical
-shipping-summary:
-  data-source: GitLab
+data-source: GitLab
 contributors:
   - amosd92
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/go.md
+++ b/_source/logzio_collections/_log-sources/go.md
@@ -6,8 +6,7 @@ logo:
 open-source:
   - title: Logzio Golang API client
     github-repo: logzio-go
-shipping-summary:
-  data-source: Go code
+data-source: Go code
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/guardduty.md
+++ b/_source/logzio_collections/_log-sources/guardduty.md
@@ -6,8 +6,7 @@ logo:
 open-source:
   - title: Kinesis Stream Shipper - Lambda
     github-repo: logzio_aws_serverless/tree/master/kinesis
-shipping-summary:
-  data-source: Amazon GuardDuty
+data-source: GuardDuty
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/GuardDuty
 contributors:
   - idohalevi

--- a/_source/logzio_collections/_log-sources/haproxy.md
+++ b/_source/logzio_collections/_log-sources/haproxy.md
@@ -3,8 +3,7 @@ title: Ship HAProxy logs
 logo:
   logofile: haproxy.png
   orientation: horizontal
-shipping-summary:
-  data-source: HAProxy
+data-source: HAProxy
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/heroku.md
+++ b/_source/logzio_collections/_log-sources/heroku.md
@@ -3,8 +3,7 @@ title: Ship Heroku logs
 logo:
   logofile: heroku.svg
   orientation: vertical
-shipping-summary:
-  data-source: Heroku
+data-source: Heroku
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/iis.md
+++ b/_source/logzio_collections/_log-sources/iis.md
@@ -3,8 +3,7 @@ title: Ship IIS logs
 logo:
   logofile: iis.png
   orientation: horizontal
-shipping-summary:
-  data-source: Microsoft IIS
+data-source: Microsoft IIS
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/java.md
+++ b/_source/logzio_collections/_log-sources/java.md
@@ -4,8 +4,7 @@ logo:
   logofile: java.svg
   orientation: vertical
 vertical-logo: true
-shipping-summary:
-  data-source: Java code
+data-source: Java code
 open-source:
   - title: Logzio Log4j 2 Appender
     github-repo: logzio-log4j2-appender

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -3,8 +3,7 @@ title: Ship Jenkins logs
 logo:
   logofile: jenkins.png
   orientation: vertical
-shipping-summary:
-  data-source: Jenkins
+data-source: Jenkins
 open-source:
   - title: Jenkins Logstash Plugin
     github-repo: logstash-plugin

--- a/_source/logzio_collections/_log-sources/json-uploads.md
+++ b/_source/logzio_collections/_log-sources/json-uploads.md
@@ -3,8 +3,7 @@ title: Upload JSON logs
 logo:
   logofile: json.svg
   orientation: vertical
-shipping-summary:
-  data-source: JSON uploads
+data-source: JSON uploads
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -6,8 +6,7 @@ logo:
 open-source:
   - title: Kinesis Stream Shipper - Lambda
     github-repo: logzio_aws_serverless/tree/master/kinesis
-shipping-summary:
-  data-source: Amazon Kinesis
+data-source: Kinesis
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Kinesis
 contributors:
   - idohalevi

--- a/_source/logzio_collections/_log-sources/kubernetes.md
+++ b/_source/logzio_collections/_log-sources/kubernetes.md
@@ -3,8 +3,7 @@ title: Ship Kubernetes logs
 logo:
   logofile: kubernetes.svg
   orientation: vertical
-shipping-summary:
-  data-source: Kubernetes
+data-source: Kubernetes
 open-source:
   - title: logzio-k8s
     github-repo: logzio-k8s

--- a/_source/logzio_collections/_log-sources/linux.md
+++ b/_source/logzio_collections/_log-sources/linux.md
@@ -3,8 +3,7 @@ title: Ship Linux logs
 logo:
   logofile: linux.svg
   orientation: vertical
-shipping-summary:
-  data-source: Linux
+data-source: Linux
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -3,8 +3,7 @@ title: Ship MySQL logs
 logo:
   logofile: mysql.svg
   orientation: horizontal
-shipping-summary:
-  data-source: MySQL
+data-source: MySQL
 open-source:
   - title: mysql-logs
     github-repo: mysql-logs

--- a/_source/logzio_collections/_log-sources/network-device.md
+++ b/_source/logzio_collections/_log-sources/network-device.md
@@ -3,8 +3,7 @@ title: Ship logs from network devices
 logo:
   logofile: network-device.svg
   orientation: horizontal
-shipping-summary:
-  data-source: Network device
+data-source: Network device
 contributors:
   - imnotashrimp
   - schwin007

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -3,8 +3,7 @@ title: Ship nginx logs
 logo:
   logofile: nginx.svg
   orientation: horizontal
-shipping-summary:
-  data-source: nginx
+data-source: nginx
 contributors:
   - amosd92
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/nodejs.md
+++ b/_source/logzio_collections/_log-sources/nodejs.md
@@ -3,8 +3,7 @@ title: Ship Node.js logs
 logo:
   logofile: nodejs.svg
   orientation: vertical
-shipping-summary:
-  data-source: Node.js code
+data-source: Node.js code
 open-source:
   - title: logzio-nodejs
     github-repo: logzio-nodejs

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -3,8 +3,7 @@ title: Ship logs from OSSEC
 logo:
   logofile: ossec.png
   orientation: vertical
-shipping-summary:
-  data-source: OSSEC
+data-source: OSSEC
 contributors:
   - imnotashrimp
   - schwin007

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -3,8 +3,7 @@ title: Ship Puppet logs
 logo:
   logofile: puppet.png
   orientation: vertical
-shipping-summary:
-  data-source: Puppet
+data-source: Puppet
 contributors:
   - amosd92
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/python.md
+++ b/_source/logzio_collections/_log-sources/python.md
@@ -3,8 +3,7 @@ title: Ship Python logs
 logo:
   logofile: python.svg
   orientation: vertical
-shipping-summary:
-  data-source: Python code
+data-source: Python code
 open-source:
   - title: Logz.io Python Handler
     github-repo: logzio-python-handler

--- a/_source/logzio_collections/_log-sources/s3.md
+++ b/_source/logzio_collections/_log-sources/s3.md
@@ -3,10 +3,7 @@ title: Ship S3 access logs
 logo:
   logofile: aws-s3.svg
   orientation: vertical
-shipping-summary:
-  data-source: Amazon S3 access logs
-  log-shippers:
-    - S3 fetcher
+data-source: S3 access logs
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/S3Access
 contributors:
   - idohalevi

--- a/_source/logzio_collections/_log-sources/vpc.md
+++ b/_source/logzio_collections/_log-sources/vpc.md
@@ -3,8 +3,7 @@ title: Ship VPC flow logs
 logo:
   logofile: aws-vpc.svg
   orientation: vertical
-shipping-summary:
-  data-source: Amazon VPC
+data-source: VPC
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/VPC
 contributors:
   - idohalevi

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -3,8 +3,7 @@ title: Ship logs from Wazuh
 logo:
   logofile: wazuh.svg
   orientation: vertical
-shipping-summary:
-  data-source: Wazuh
+data-source: Wazuh
 contributors:
   - imnotashrimp
   - schwin007

--- a/_source/logzio_collections/_log-sources/windows.md
+++ b/_source/logzio_collections/_log-sources/windows.md
@@ -3,8 +3,7 @@ title: Ship Windows logs
 logo:
   logofile: windows.svg
   orientation: vertical
-shipping-summary:
-  data-source: Windows
+data-source: Windows
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/zipkin.md
+++ b/_source/logzio_collections/_log-sources/zipkin.md
@@ -6,8 +6,7 @@ logo:
 open-source:
   - title: Zipkin-Logz.io Trace Storage
     github-repo: zipkin-logzio
-shipping-summary:
-  data-source: Zipkin traces
+data-source: Zipkin traces
 contributors:
   - yyyogev
   - imnotashrimp

--- a/_source/logzio_collections/_metrics-sources/azure-diagnostic-metrics.md
+++ b/_source/logzio_collections/_metrics-sources/azure-diagnostic-metrics.md
@@ -6,8 +6,7 @@ open-source:
 logo:
   logofile: azure-monitor.svg
   orientation: vertical
-shipping-summary:
-  data-source: Azure diagnostic metrics
+data-source: Azure diagnostic metrics
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Diagnostics-settings
 tags:
   - azure

--- a/_source/logzio_collections/_shippers/curl.md
+++ b/_source/logzio_collections/_shippers/curl.md
@@ -3,8 +3,7 @@ title: cURL log file upload
 logo:
   logofile: curl.svg
   orientation: vertical
-shipping-summary:
-  data-source: cURL file upload
+data-source: cURL file upload
 shipping-tags:
   - log-shipper
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/File-UploadcURL

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -3,8 +3,7 @@ title: Shipping with Filebeat
 logo:
   logofile: beats.svg
   orientation: vertical
-shipping-summary:
-  data-source: Filebeat
+data-source: Filebeat
 shipping-tags:
   - log-shipper
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Filebeat

--- a/_source/logzio_collections/_shippers/fluentd.md
+++ b/_source/logzio_collections/_shippers/fluentd.md
@@ -3,8 +3,7 @@ title: Fluentd
 logo:
   logofile: fluentd.svg
   orientation: vertical
-shipping-summary:
-  data-source: Fluentd
+data-source: Fluentd
 shipper-tags:
   - log-shipper
 contributors:

--- a/_source/logzio_collections/_shippers/logstash.md
+++ b/_source/logzio_collections/_shippers/logstash.md
@@ -3,8 +3,7 @@ title: Shipping with Logstash
 logo:
   logofile: logstash.svg
   orientation: vertical
-shipping-summary:
-  data-source: Logstash
+data-source: Logstash
 shipping-tags:
   - log-shipper
 contributors:

--- a/_source/logzio_collections/_shippers/s3-bucket.md
+++ b/_source/logzio_collections/_shippers/s3-bucket.md
@@ -3,8 +3,7 @@ title: Configure the Amazon S3 fetcher
 logo:
   logofile: aws-s3.svg
   orientation: vertical
-shipping-summary:
-  data-source: S3 fetcher
+data-source: S3 fetcher
 shipping-tags:
   - log-shipper
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/S3-Bucket

--- a/_source/shipping/index.html
+++ b/_source/shipping/index.html
@@ -25,7 +25,7 @@ community-info: false
 *   Get all the tags in this tab
 *         {%- endcomment -%}
 {%- assign thisCollection = site.collections | where: "label", tab.collection | first -%}
-{%- assign docs = thisCollection.docs | sort: "shipping-summary.data-source" -%}
+{%- assign docs = thisCollection.docs | sort: "data-source" -%}
 {%- assign tagsInThisTab = "" | split: "" -%}
 {%- comment -%} Get the tags in this collection {%- endcomment -%}
 {%- for doc in docs -%}
@@ -73,12 +73,12 @@ community-info: false
     {%- assign docTags = doc.shipping-tags | join: " " -%}
     <div class="card mini-card filter {{docTags}}
       {%- if doc.community-project == true %} community-project-card{%- endif -%}"
-      data-source="{{doc.shipping-summary.data-source | slugify}}">
+      data-source="{{doc.data-source | slugify}}">
       <a href="{{shipperUrl}}">
-      <div class="card-icon {{doc.logo.orientation}}" style="background-image: url('{{site.baseurl}}/images/shipper-logos/{{doc.logo.logofile}}');" alt="{{doc.shipping-summary.data-source}} logo">
+      <div class="card-icon {{doc.logo.orientation}}" style="background-image: url('{{site.baseurl}}/images/shipper-logos/{{doc.logo.logofile}}');" alt="{{doc.data-source}} logo">
       </div>
       <div class="card-text">
-        <span class="card-title">{{ doc.shipping-summary.data-source }}</span>
+        <span class="card-title">{{ doc.data-source }}</span>
         {%- if doc.community-project == true %}
         <p>{{doc.title}}</p>
         {%- endif %}

--- a/_source/shipping/index.html
+++ b/_source/shipping/index.html
@@ -25,7 +25,7 @@ community-info: false
 *   Get all the tags in this tab
 *         {%- endcomment -%}
 {%- assign thisCollection = site.collections | where: "label", tab.collection | first -%}
-{%- assign docs = thisCollection.docs | sort: "data-source" -%}
+{%- assign docs = thisCollection.docs | sort_natural: "data-source" -%}
 {%- assign tagsInThisTab = "" | split: "" -%}
 {%- comment -%} Get the tags in this collection {%- endcomment -%}
 {%- for doc in docs -%}


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### What changed

Restructured shipping page frontmatter to remove `shipping-summary` root element. This moved `data-source` from nested to root, and allowed for use of the `sort_natural` filter.

Previously, sorting didn't respect lowercase letters and instead moved nginx to the end of the page. Sorting also didn't know what to do with .NET.

End result for the user: The shipping page is now sorted alphabetically. nginx appears where it should alphabetically, and .NET is now at the beginning because of the `.`

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- [x] https://deploy-preview-235--logz-docs.netlify.com/shipping/

**Notes for reviewers**:

## Remaining work

<!-- List any outstanding work here -->
- [x] Compare with shipping manifest in `develop` and make sure there's no structural change
  - Notes: Compared the two, and it's good. No changes needed to the app.

## Post launch

nothing to do post launch

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
