### PR TITLE
Fix layout none

### DIFF
--- a/_source/_layouts/api-ref.html
+++ b/_source/_layouts/api-ref.html
@@ -1,4 +1,5 @@
 ---
+layout: none
 ---
 <html lang="{{ page.lang | default: site.lang | default: 'en' }}">
 

--- a/_source/logzio_collections/_docs-admin/index.md
+++ b/_source/logzio_collections/_docs-admin/index.md
@@ -2,6 +2,11 @@
 layout: article
 title: Docs admin
 permalink: /docs-admin/
+additional-docs:
+  - name: Shipping manifest (for this deploy only)
+    permalink: /data/shipping-manifest.json
+  - name: robots.txt
+    permalink: /robots.txt
 ---
 
 {%- assign thisCollection = site.collections
@@ -17,5 +22,7 @@ This build's environment: {{jekyll.environment}}
   {%- unless filename == "index" %}
   * [{{doc.title}}]({{doc.url}})
   {%- endunless -%}
+{%- endfor -%}
+{%- for doc in page.additional-docs %}
+  * [{{ doc.name }}]({{ site.baseurl | append: doc.permalink }})
 {%- endfor %}
-  * [Shipping manifest]({{site.baseurl}}/data/shipping-manifest.json) (for this deploy only)

--- a/_source/robots.txt
+++ b/_source/robots.txt
@@ -1,4 +1,6 @@
 ---
+layout: none
+permalink: /robots.txt
 ---
 User-agent: *
 


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### What changed

Some pages contained no frontmatter, causing them to be rendered with the default layout.
This PR adds `layout: none` to those pages so that extra templating doesn't get applied.

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- [x] https://deploy-preview-244--logz-docs.netlify.com/robots.txt

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review

## Post launch

**Do not remove** - To be completed by the docs team upon merge:
- [x] Teams to update with the new information: Levi

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
