### PR TITLE
add doctype to api page

### DIFF
--- a/_source/_layouts/api-ref.html
+++ b/_source/_layouts/api-ref.html
@@ -1,6 +1,7 @@
 ---
 layout: none
 ---
+<!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: 'en' }}">
 
   {% include head.html %}


### PR DESCRIPTION
<!-- Please note: We can't accept pull requests for changes to our OpenAPI file. If you want to suggest an edit to our API doc, please open an issue at https://github.com/logzio/logz-docs/issues/. -->

### What changed

Added `<!DOCTYPE html>` declaration to API page.

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- [x] https://deploy-preview-289--logz-docs.netlify.com/api/

**Notes for reviewers**: just check page in code view, make sure doctype is there

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review

## Post launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Teams to update with the new information: levi

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
