### PR TITLE
Shipper tag filtering from URL

### DIFF
--- a/_source/js/logz-docs.js
+++ b/_source/js/logz-docs.js
@@ -102,7 +102,7 @@ function pageFilter(filter) {
     $('.filter').filter('.'+value).show();
   }
   // add `active` class to clicked button, remove from other buttons
-  $(value).addClass('filter-active').siblings().removeClass('filter-active');
+  $('.filter-btn[data-filter="'+value+'"]').addClass('filter-active').siblings().removeClass('filter-active');
   return;
 }
 

--- a/_source/js/logz-docs.js
+++ b/_source/js/logz-docs.js
@@ -56,32 +56,38 @@ $(function() {
   });
 });
 
-// filter categories on a shipping page
+// filter page on click
 $(function() {
   $('.filter-btn').click(function() {
-    var value = $(this).data('filter');
-    if (value == 'all') {
-      $('.filter').show();
-    } else {
-      $('.filter').hide();
-      $('.filter').filter('.'+value).show();
-    }
-    // add `active` class to clicked button, remove from other buttons
-    $(this).addClass('filter-active').siblings().removeClass('filter-active');
+    pageFilter(this);
   });
 
-// reset on tab click
-$('.branching-tabs > li > a').click(function() {
-  $('.branching-tabs li  a').removeClass('visit');
-  $(this).addClass('visit');
+  // reset on tab click
+  $('.branching-tabs > li > a').click(function() {
+    $('.branching-tabs li  a').removeClass('visit');
+    $(this).addClass('visit');
 
-  if($(this).hasClass('visit')){
+    if($(this).hasClass('visit')){
+      $('.filter').show();
+      $('.filter-btn[data-filter="all"').addClass('filter-active').siblings().removeClass('filter-active');
+    }
+  });
+
+});
+
+// page filtering behavior
+function pageFilter(filter) {
+  var value = $(filter).data('filter');
+  if (value == 'all') {
     $('.filter').show();
-    $('.filter-btn[data-filter="all"').addClass('filter-active').siblings().removeClass('filter-active');
+  } else {
+    $('.filter').hide();
+    $('.filter').filter('.'+value).show();
   }
-});
-
-});
+  // add `active` class to clicked button, remove from other buttons
+  $(filter).addClass('filter-active').siblings().removeClass('filter-active');
+  return;
+}
 
 // scroll to <summary> when clicked
 $(function() {

--- a/_source/js/logz-docs.js
+++ b/_source/js/logz-docs.js
@@ -56,10 +56,26 @@ $(function() {
   });
 });
 
+// filter page based on url param
+$(function() {
+  $.urlParam = function(name){
+    var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
+    if (results==null) {
+       return 'all';
+    }
+    return decodeURI(results[1]) || 0;
+  }
+
+  if ($.urlParam('filter')) {
+    var thisFilter = $.urlParam('filter');
+    pageFilter(thisFilter);
+  }
+})
+
 // filter page on click
 $(function() {
   $('.filter-btn').click(function() {
-    pageFilter(this);
+    pageFilter($(this).data('filter'));
   });
 
   // reset on tab click
@@ -69,7 +85,7 @@ $(function() {
 
     if($(this).hasClass('visit')){
       $('.filter').show();
-      $('.filter-btn[data-filter="all"').addClass('filter-active').siblings().removeClass('filter-active');
+      $('.filter-btn[data-filter="all"]').addClass('filter-active').siblings().removeClass('filter-active');
     }
   });
 
@@ -77,7 +93,8 @@ $(function() {
 
 // page filtering behavior
 function pageFilter(filter) {
-  var value = $(filter).data('filter');
+  var value = filter;
+  console.log(value);
   if (value == 'all') {
     $('.filter').show();
   } else {
@@ -85,7 +102,7 @@ function pageFilter(filter) {
     $('.filter').filter('.'+value).show();
   }
   // add `active` class to clicked button, remove from other buttons
-  $(filter).addClass('filter-active').siblings().removeClass('filter-active');
+  $(value).addClass('filter-active').siblings().removeClass('filter-active');
   return;
 }
 

--- a/_source/shipping/index.html
+++ b/_source/shipping/index.html
@@ -51,7 +51,7 @@ community-info: false
 <nav id="card-filters">
   <div class="filters-inline-header">Filters:</div>
   <div class="filter-items">
-      <a class="filter-btn filter-active fancy-link" data-filter="all">All</a>
+      <a class="filter-btn fancy-link" data-filter="all">All</a>
     {%- for tag in tagsInThisTab %}
       <a class="filter-btn fancy-link" data-filter="{{tag[0].slug}}">{{tag[0].name}}</a>
     {% endfor -%}


### PR DESCRIPTION
# What changed

Added filtering for the shipping page, based on a URL param. So now ending the URL with `?filter=azure` will show only azure log sources

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- [ ] https://deploy-preview-295--logz-docs.netlify.com/shipping/?filter=azure

## Remaining work

none

## Post launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Teams to update with the new information: Partners

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
