### PR TITLE
Rename regions

### DIFF
--- a/_source/_data/logzio-regions.yml
+++ b/_source/_data/logzio-regions.yml
@@ -1,5 +1,9 @@
+# When naming the region, take from AWS and Azure docs
+# AWS: https://aws.amazon.com/about-aws/global-infrastructure/regions_az/?p=ngi&loc=2
+# Azure: https://azure.microsoft.com/en-us/global-infrastructure/locations/
+
 us:
-  title: N. Virginia region
+  title: US East (Northern Virginia)
   suffix: false
   cloud: AWS
   listener-ips:
@@ -20,7 +24,7 @@ us:
     - 52.87.4.83
     - 54.210.40.1
 au:
-  title: Australia region
+  title: Asia Pacific (Sydney)
   cloud: AWS
   listener-ips:
     - 3.105.145.247
@@ -32,7 +36,7 @@ au:
     - 3.104.255.132
     - 54.206.91.46
 ca:
-  title: Canada region
+  title: Canada (Central)
   cloud: AWS
   listener-ips:
     - 99.79.1.61
@@ -44,7 +48,7 @@ ca:
     - 99.79.113.22
     - 52.60.89.173
 eu:
-  title: Frankfurt region
+  title: Europe (Frankfurt)
   cloud: AWS
   listener-ips:
     - 35.157.100.82
@@ -58,7 +62,7 @@ eu:
     - 52.57.23.254
     - 52.57.24.166
 nl:
-  title: West Europe region
+  title: West Europe (Netherlands)
   cloud: Azure
   listener-ips:
     - 104.40.177.72
@@ -70,7 +74,7 @@ nl:
     - 52.166.13.236
     - 52.174.154.12
 wa:
-  title: West US 2 region
+  title: West US 2 (Washington)
   cloud: Azure
   listener-ips:
     - 52.247.202.222

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3,15 +3,15 @@ schemes: [ https ]
 host: api.logz.io
 x-servers:
   - url: https://api.logz.io/v1
-    description: N. Virginia region
+    description: US East (Northern Virginia)
   - url: https://api-au.logz.io/v1
-    description: Australia region
+    description: Asia Pacific (Sydney)
   - url: https://api-ca.logz.io/v1
-    description: Canada region
+    description: Canada (Central)
   - url: https://api-eu.logz.io/v1
-    description: Frankfurt region
+    description: Europe (Frankfurt)
   - url: https://api-nl.logz.io/v1
-    description: West Europe region
+    description: West Europe (Netherlands)
 basePath: /v1
 produces: [ application/json ]
 consumes: [ application/json ]

--- a/_source/user-guide/accounts/account-region.md
+++ b/_source/user-guide/accounts/account-region.md
@@ -34,17 +34,15 @@ Read on for a list of region codes and URLs.
 
 ## Regions and URLs
 
-| Region | App host | Listener host | API host |
+| Region | Cloud | App host | Listener host | API host |
 |---|---|---|
 {% for r in regions -%}
 {%- assign attribs = r[1] -%}
 {%- case attribs.suffix -%}
   {%- when false -%}
     {%- assign suffix = "" -%}
-    {%- assign regionCode = "" -%}
   {%- else -%}
     {%- assign suffix = r[0] | prepend: "-" -%}
-    {%- assign regionCode = r[0] | prepend: " (" | append: ")" -%}
 {%- endcase -%}
-| {{attribs.title}}{{regionCode}} | app{{suffix}}.logz.io | listener{{suffix}}.logz.io | api{{suffix}}.logz.io |
+| {{attribs.title}} | {{attribs.cloud}} | app{{suffix}}.logz.io | listener{{suffix}}.logz.io | api{{suffix}}.logz.io |
 {% endfor -%}


### PR DESCRIPTION
# What changed

- Renamed regions to align with AWS & Azure naming.
- API doc updated to align with renamed regions
- Added cloud to account region page


----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- [x] https://deploy-preview-300--logz-docs.netlify.com/user-guide/accounts/account-region.html
- [x] https://deploy-preview-300--logz-docs.netlify.com/user-guide/log-shipping/listener-ip-addresses.html
- [x] https://deploy-preview-300--logz-docs.netlify.com/api/
- [x] Look at the **Files changed** tab - logzio-regions.yml

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review
- [x] Copy Review

## Post launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Teams to update with the new information: everyone?

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
