### PR TITLE
Updated logzio-dir-path

### DIFF
--- a/_source/logzio_collections/_log-sources/docker.md
+++ b/_source/logzio_collections/_log-sources/docker.md
@@ -167,7 +167,7 @@ Docker Community Edition (Docker CE) 18.03 or later
       {% include log-shipping/replace-vars.html listener=true %}
 
     logzio-dir-path	<span class="required-param"></span>
-    : Logs disk path. All the unsent logs are saved to the disk in this location.	
+    : Unsent logs are saved to this location on the disk.	
 
     logzio-source
     : Event source.

--- a/_source/logzio_collections/_log-sources/docker.md
+++ b/_source/logzio_collections/_log-sources/docker.md
@@ -167,7 +167,7 @@ Docker Community Edition (Docker CE) 18.03 or later
       {% include log-shipping/replace-vars.html listener=true %}
 
     logzio-dir-path	<span class="required-param"></span>
-    : Path of the logs to be sent to Logz.io.
+    : Logs disk path. All the unsent logs are saved to the disk in this location.	
 
     logzio-source
     : Event source.


### PR DESCRIPTION

# What changed

Wording was unclear: "Path of the logs to be sent to Logz.io".
According to the github, it's "Logs disk path. All the unsent logs are saved to the disk in this location."

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- [ ] Page1
- [ ] Page2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
