### PR TITLE
disable k8s custom config

### DIFF
--- a/_source/logzio_collections/_log-sources/elastic-kubernetes-service.md
+++ b/_source/logzio_collections/_log-sources/elastic-kubernetes-service.md
@@ -17,24 +17,24 @@ shipping-tags:
 ---
 
 For Kubernetes, a DaemonSet ensures that some or all nodes run a copy of a pod.
-This implementation is uses a Fluentd DaemonSet to collect Kubernetes logs.
+This implementation uses a Fluentd DaemonSet to collect Kubernetes logs.
 Fluentd is flexible enough and has the proper plugins to distribute logs to different third parties such as Logz.io.
 
 The logzio-k8s image comes pre-configured for Fluentd to gather all logs from the Kubernetes node environment and append the proper metadata to the logs.
 
-<div class="branching-container">
+{%- comment -%} <div class="branching-container">
 
 * [Default configuration <span class="sm ital">(recommended)</span>](#default-config)
 * [Custom configuration](#custom-config)
-{:.branching-tabs}
+{:.branching-tabs} {%- endcomment -%}
 
 <!-- tab:start -->
 <div id="default-config">
 
-## Deploy logzio-k8s with default configuration
+{%- comment -%} ## Deploy logzio-k8s with default configuration
 
 For most environments, we recommend using the default configuration.
-However, you can deploy a custom configuration if your environment needs it.
+However, you can deploy a custom configuration if your environment needs it. {%- endcomment -%}
 
 #### To deploy logzio-k8s
 
@@ -72,7 +72,7 @@ see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-
 </div>
 <!-- tab:end -->
 
-<!-- tab:start -->
+{%- comment -%} <!-- tab:start -->
 <div id="custom-config">
 
 ## Deploy logzio-k8s with custom configuration
@@ -154,4 +154,4 @@ see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-
 
 ## Disabling systemd input
 
-To suppress Fluentd system messages, set the `FLUENTD_SYSTEMD_CONF` environment variable to `disable` in your Kubernetes environment.
+To suppress Fluentd system messages, set the `FLUENTD_SYSTEMD_CONF` environment variable to `disable` in your Kubernetes environment. {%- endcomment -%}

--- a/_source/logzio_collections/_log-sources/kubernetes.md
+++ b/_source/logzio_collections/_log-sources/kubernetes.md
@@ -16,24 +16,24 @@ shipping-tags:
 ---
 
 For Kubernetes, a DaemonSet ensures that some or all nodes run a copy of a pod.
-This implementation is uses a Fluentd DaemonSet to collect Kubernetes logs.
+This implementation uses a Fluentd DaemonSet to collect Kubernetes logs.
 Fluentd is flexible enough and has the proper plugins to distribute logs to different third parties such as Logz.io.
 
 The logzio-k8s image comes pre-configured for Fluentd to gather all logs from the Kubernetes node environment and append the proper metadata to the logs.
 
-<div class="branching-container">
+{%- comment -%} <div class="branching-container">
 
 * [Default configuration <span class="sm ital">(recommended)</span>](#default-config)
 * [Custom configuration](#custom-config)
-{:.branching-tabs}
+{:.branching-tabs} {%- endcomment -%}
 
 <!-- tab:start -->
 <div id="default-config">
 
-#### Deploy logzio-k8s with default configuration
+{%- comment -%} ## Deploy logzio-k8s with default configuration
 
 For most environments, we recommend using the default configuration.
-However, you can deploy a custom configuration if your environment needs it.
+However, you can deploy a custom configuration if your environment needs it. {%- endcomment -%}
 
 <div class="tasklist">
 
@@ -78,7 +78,7 @@ see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-
 <!-- tab:end -->
 
 
-<!-- tab:start -->
+{%- comment -%} <!-- tab:start -->
 <div id="custom-config">
 
 ## Deploy logzio-k8s with custom configuration
@@ -154,8 +154,8 @@ see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-
 <!-- tab:end -->
 
 </div>
-<!-- tabContainer:end -->
+<!-- tabContainer:end --> {%- endcomment -%}
 
-### Disabling systemd input
+<h3>Disabling systemd input</h3>
 
 To suppress Fluentd system messages, set the `FLUENTD_SYSTEMD_CONF` environment variable to `disable` in your Kubernetes environment.


### PR DESCRIPTION
# What changed

Removed custom config on k8s and eks log shipping, as it's now out of date and tripping up users. Will add once we can research and better document the process.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- [x] https://deploy-preview-320--logz-docs.netlify.com/shipping/log-sources/kubernetes.html
- [x] https://deploy-preview-320--logz-docs.netlify.com/shipping/log-sources/elastic-kubernetes-service.html

## Remaining work

<!-- List any outstanding work here -->
- [x] Copy Review

## Post launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Teams to update with the new information: Support
- [ ] Update these log shipping pages in the app:
  - [ ] EKS
  - [ ] Kubernetes

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
