### PR TITLE
fix the aws serverless docs glitch

### DIFF
--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -75,7 +75,7 @@ In the _Environment variables_ section, set your Logz.io account token, URL, and
 |---|---|
 | TOKEN <span class="required-param"></span> | {% include log-shipping/replace-vars.html token='noReplace' %} <!-- logzio-inject:account-token --> |
 | URL <span class="required-param"></span> | Protocol, listener host, and port (for example, `https://<<LISTENER-HOST>>:8071`). <br > {% include log-shipping/replace-vars.html listener=true %} <!-- logzio-inject:listener-url --> |
-| TYPE <span class="required-param"></span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
+| TYPE <span class="default-param">`logzio_cloudwatch_lambda`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
 | FORMAT <span class="default-param">`text`</span> | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. |
 | COMPRESS <span class="default-param">`false`</span> | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. |
 {:.paramlist}
@@ -170,13 +170,10 @@ aws cloudformation deploy
 | Parameter | Description |
 |---|---|
 | LogzioTOKEN <span class="required-param"></span> | {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
-| KinesisStream <span class="required-param"></span> | The name of the Kinesis stream where this function will listen for updates. |
-| LogzioURL <span class="default-param">`https://listener.logz.io:8071`</span> | {% include log-shipping/replace-vars.html listener='noReplace' %} <!-- logzio-inject:listener-url --> |
-| LogzioTYPE <span class="default-param">`logzio_kinesis_stream`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
+| LogzioURL <span class="default-param">`https://listener.logz.io:8071`</span> | Protocol, listener host, and port (for example, `https://<<LISTENER-HOST>>:8071`). <br > {% include log-shipping/replace-vars.html listener='noReplace' %} <!-- logzio-inject:listener-url --> |
+| LogzioTYPE <span class="default-param">`logzio_cloudwatch_logs`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
 | LogzioFORMAT <span class="default-param">`text`</span> | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. |
 | LogzioCOMPRESS <span class="default-param">`false`</span> | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. |
-| KinesisStreamBatchSize <span class="default-param">`100`</span> | The largest number of records to read from your stream at one time. |
-| KinesisStreamStartingPosition <span class="default-param">`LATEST`</span> | The position in the stream to start reading from. For more information, see [ShardIteratorType](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html) in the Amazon Kinesis API Reference. |
 {:.paramlist}
 
 ##### Check Logz.io for your logs

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -78,6 +78,7 @@ In the _Environment variables_ section, set your Logz.io account token, URL, and
 | TYPE <span class="default-param">`logzio_cloudwatch_lambda`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
 | FORMAT <span class="default-param">`text`</span> | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. |
 | COMPRESS <span class="default-param">`false`</span> | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. |
+| ENRICH | Enrich CloudWatch events with custom properties, formatted as `key1=value1;key2=value2`. |
 {:.paramlist}
 
 ##### Configure the function's basic settings
@@ -174,6 +175,7 @@ aws cloudformation deploy
 | LogzioTYPE <span class="default-param">`logzio_cloudwatch_logs`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
 | LogzioFORMAT <span class="default-param">`text`</span> | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. |
 | LogzioCOMPRESS <span class="default-param">`false`</span> | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. |
+| LogzioENRICH | Enrich CloudWatch events with custom properties, formatted as `key1=value1;key2=value2`. |
 {:.paramlist}
 
 ##### Check Logz.io for your logs

--- a/_source/logzio_collections/_log-sources/guardduty.md
+++ b/_source/logzio_collections/_log-sources/guardduty.md
@@ -4,8 +4,8 @@ logo:
   logofile: aws-guardduty.png
   orientation: vertical
 open-source:
-  - title: Kinesis Stream Shipper - Lambda
-    github-repo: logzio_aws_serverless/tree/master/python3/kinesis
+  - title: CloudWatch Lambda Log Shipper
+    github-repo: logzio_aws_serverless/tree/master/python3/cloudwatch
 data-source: GuardDuty
 logzio-app-url: https://app.logz.io/#/dashboard/data-sources/GuardDuty
 contributors:
@@ -106,6 +106,7 @@ In the _Environment variables_ section, set your Logz.io account token, URL, and
 | TYPE <span class="default-param">`"guardduty"`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
 | FORMAT <span class="default-param">`"text"`</span> | `"json"` or `"text"`. If `"json"`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. |
 | COMPRESS <span class="default-param">`false`</span> | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. |
+| ENRICH | Enrich CloudWatch events with custom properties, formatted as `key1=value1;key2=value2`. |
 {:.paramlist}
 
 ##### Configure the function's basic settings
@@ -224,6 +225,7 @@ aws cloudformation deploy
 | LogzioTYPE <span class="default-param">`logzio_cloudwatch_logs`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
 | LogzioFORMAT <span class="default-param">`"text"`</span> | `"json"` or `"text"`. If `"json"`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. |
 | LogzioCOMPRESS <span class="default-param">`false`</span> | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. |
+| LogzioENRICH | Enrich CloudWatch events with custom properties, formatted as `key1=value1;key2=value2`. |
 {:.paramlist}
 
 ##### Check Logz.io for your logs

--- a/_source/logzio_collections/_log-sources/guardduty.md
+++ b/_source/logzio_collections/_log-sources/guardduty.md
@@ -220,13 +220,10 @@ aws cloudformation deploy
 | Parameter | Description |
 |---|---|
 | LogzioTOKEN <span class="required-param"></span> | {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
-| KinesisStream <span class="required-param"></span> | The name of the Kinesis stream where this function will listen for updates. |
-| LogzioURL <span class="default-param">`https://listener.logz.io:8071`</span> | {% include log-shipping/replace-vars.html listener='noReplace' %} <!-- logzio-inject:listener-url --> |
-| LogzioTYPE <span class="default-param">`logzio_kinesis_stream`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
+| LogzioURL <span class="default-param">`https://listener.logz.io:8071`</span> | Protocol, listener host, and port (for example, `https://<<LISTENER-HOST>>:8071`). <br > {% include log-shipping/replace-vars.html listener='noReplace' %} <!-- logzio-inject:listener-url --> |
+| LogzioTYPE <span class="default-param">`logzio_cloudwatch_logs`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
 | LogzioFORMAT <span class="default-param">`"text"`</span> | `"json"` or `"text"`. If `"json"`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. |
 | LogzioCOMPRESS <span class="default-param">`false`</span> | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. |
-| KinesisStreamBatchSize <span class="default-param">`100`</span> | The largest number of records to read from your stream at one time. |
-| KinesisStreamStartingPosition <span class="default-param">`"LATEST"`</span> | The position in the stream to start reading from. For more information, see [ShardIteratorType](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html) in the Amazon Kinesis API Reference. |
 {:.paramlist}
 
 ##### Check Logz.io for your logs

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -76,7 +76,7 @@ In the _Environment variables_ section, set your Logz.io account token, URL, and
 |---|---|
 | TOKEN <span class="required-param"></span> | {% include log-shipping/replace-vars.html token='noReplace' %} <!-- logzio-inject:account-token --> |
 | URL <span class="required-param"></span> | Protocol, listener host, and port (for example, `https://<<LISTENER-HOST>>:8071`). <br > {% include log-shipping/replace-vars.html listener=true %} <!-- logzio-inject:listener-url --> |
-| TYPE <span class="required-param"></span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
+| TYPE <span class="default-param">`logzio_kinesis_stream`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
 | FORMAT <span class="default-param">`text`</span> | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. |
 | COMPRESS <span class="default-param">`false`</span> | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. |
 {:.paramlist}
@@ -171,7 +171,7 @@ aws cloudformation deploy
 |---|---|
 | LogzioTOKEN <span class="required-param"></span> | {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
 | KinesisStream <span class="required-param"></span> | The name of the Kinesis stream where this function will listen for updates. |
-| LogzioURL <span class="default-param">`https://listener.logz.io:8071`</span> | {% include log-shipping/replace-vars.html listener='noReplace' %} <!-- logzio-inject:listener-url --> |
+| LogzioURL <span class="default-param">`https://listener.logz.io:8071`</span> | Protocol, listener host, and port (for example, `https://<<LISTENER-HOST>>:8071`). <br > {% include log-shipping/replace-vars.html listener='noReplace' %} <!-- logzio-inject:listener-url --> |
 | LogzioTYPE <span class="default-param">`logzio_kinesis_stream`</span> | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type. <br> You should create a new Lambda for each log type you use. |
 | LogzioFORMAT <span class="default-param">`text`</span> | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. |
 | LogzioCOMPRESS <span class="default-param">`false`</span> | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. |


### PR DESCRIPTION
# What changed

Cleaning up issues with the AWS serverless docs (cloudwatch, kinesis, guardduty)

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- [CloudWatch](https://deploy-preview-350--logz-docs.netlify.com/shipping/log-sources/cloudwatch.html)
- [GuardDuty](https://deploy-preview-350--logz-docs.netlify.com/shipping/log-sources/guardduty.html)
- [Kinesis](https://deploy-preview-350--logz-docs.netlify.com/shipping/log-sources/kinesis.html)

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review
- [x] Copy Review

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- Update these log shipping pages in the app:
  - [ ] guardduty
  - [ ] cloudwatch
  - [ ] kinesis
- Update these readmes:
  - [ ] [CloudWatch readme](https://github.com/logzio/logzio_aws_serverless/blob/master/python3/cloudwatch/README.md)
  - [ ] [Kinesis readme](https://github.com/logzio/logzio_aws_serverless/blob/master/python3/kinesis/README.md)


<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
