### PR TITLE
change edit branch to master

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ show_atom_feed: false
 github:
   org_url:  https://github.com/logzio # only edit username - leave base URL
   repo_name: /logz-docs
-  edit_branch: /develop # which branch do you want users to edit?
+  edit_branch: /master # which branch do you want users to edit?
   issue_template: docs-issue # GitHub template for new issues, without the .md extension. Leave blank if no template.
 
 # if you use google analytics or tag manager, add your tracking id here. To disable, remove or comment out the line


### PR DESCRIPTION
# What changed

Changed the edit branch to master - develop is no longer the default branch on the logz-docs repo.

----

To test, go to any page, and click the 'edit' button at the bottom. If you don't get a 404, everything's good :)