### PR TITLE
Endpoint URL ports

### DIFF
--- a/_source/user-guide/integrations/endpoints.md
+++ b/_source/user-guide/integrations/endpoints.md
@@ -16,6 +16,9 @@ or when Logz.io finds new insights in your logs.
 Logz.io supports sending notifications to
 BigPanda, Datadog, PagerDuty, Slack, VictorOps, or your own custom endpoint.
 
+Alerts are sent on ports 80 and 443 only; setting a custom port as part of endpoint URL will result in alerts not being sent to said endpoint.
+{:.info-box.important}
+
 ![Notification endpoints]({{site.baseurl}}/images/alerts/alerts--alert-endpoints.png)
 
 You can manage your endpoints

--- a/_source/user-guide/integrations/endpoints.md
+++ b/_source/user-guide/integrations/endpoints.md
@@ -16,9 +16,6 @@ or when Logz.io finds new insights in your logs.
 Logz.io supports sending notifications to
 BigPanda, Datadog, PagerDuty, Slack, VictorOps, or your own custom endpoint.
 
-Alerts are sent on ports 80 and 443 only; setting a custom port as part of endpoint URL will result in alerts not being sent to said endpoint.
-{:.info-box.important}
-
 ![Notification endpoints]({{site.baseurl}}/images/alerts/alerts--alert-endpoints.png)
 
 You can manage your endpoints
@@ -37,3 +34,8 @@ You can also add new endpoints when you're configuring a new notification.
   hover over the endpoint,
   and click <i class="li li-pencil"></i> (edit)
   or <i class="li li-trash"></i> (delete).
+
+Alerts are sent on ports 80 and 443 only.
+Setting a custom port as part of an endpoint URL
+will result in alerts not being sent to said endpoint.
+{:.info-box.important}


### PR DESCRIPTION
# What changed

Added a note about the alerts supporting ports 80 and 443 only.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-361--logz-docs.netlify.com/user-guide/integrations/endpoints.html

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review
- [x] Copy Review

## Post launch

none
