### PR TITLE
clarify that at least one recipient is needed for snapshots

### DIFF
--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -2864,19 +2864,28 @@ definitions:
         type: array
         items:
           type: string
-        description: URLs of Slack webhooks that you want to send this snapshot to
+        description: >-
+          URLs of Slack webhooks that you want to send this snapshot to.
+          <br> At least one of `emails`, `slackWebhookUrls`, and `endpoints` is required with each request.
+          If all three are missing, the request will fail.
         example: ["https://hooks.slack.com/services/CC29C43F8/7E6E833FB/Ebe297580E7FaC354F9D4d7"]
       endpoints:
         type: array
         items:
           type: integer
           format: int32
-        description: IDs of notification endpoints that you want to send this snapshot to
+        description: >-
+          IDs of notification endpoints that you want to send this snapshot to
+          <br> At least one of `emails`, `slackWebhookUrls`, and `endpoints` is required with each request.
+          If all three are missing, the request will fail.
       emails:
         type: array
         items:
           type: string
-        description: Email addresses that you want to send this snapshot to
+        description: >-
+          Email addresses that you want to send this snapshot to
+          <br> At least one of `emails`, `slackWebhookUrls`, and `endpoints` is required with each request.
+          If all three are missing, the request will fail.
       message:
         type: string
         description: Message to send to the shared object recipients


### PR DESCRIPTION
# What changed

Fixes a clarity issue that snapshot requests need to supply at least one recipient.

Addresses #257 

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-399--logz-docs.netlify.com/api/#operation/createSnapshot

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review
- [x] Copy Review

## Post launch

To be completed by the docs team upon merge:

no post-launch tasks

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
