### PR TITLE
log-shipping/remove-macos-apache

### DIFF
--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -23,7 +23,7 @@ Configuration tl;dr
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
-| Default log locations | Ubuntu, Debian: `/var/log/apache2/access.log` <br> macOS, RHEL, CentOS, Fedora: `/var/log/httpd/access_log` |
+| Default log locations | Ubuntu, Debian: `/var/log/apache2/access.log` <br> RHEL, CentOS, Fedora: `/var/log/httpd/access_log` |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
 {:.paramlist}
 
@@ -59,7 +59,7 @@ filebeat.inputs:
 
   paths:
   # Ubuntu, Debian: `/var/log/apache2/access.log`
-  #  macOS, RHEL, CentOS, Fedora: `/var/log/httpd/access_log`
+  #  RHEL, CentOS, Fedora: `/var/log/httpd/access_log`
   - /var/log/apache2/access.log
 
   fields:
@@ -77,7 +77,7 @@ filebeat.inputs:
 
   paths:
   # Ubuntu, Debian: `/var/log/apache2/error.log`
-  #  macOS, RHEL, CentOS, Fedora: `/var/log/httpd/error_log`
+  #  RHEL, CentOS, Fedora: `/var/log/httpd/error_log`
   - /var/log/apache2/error.log
 
   fields:


### PR DESCRIPTION
# What changed

removed macos from the Apache log locations.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-411--logz-docs.netlify.com/shipping/log-sources/apache.html

## Remaining work

no remaining work or post launch tasks

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
