### PR TITLE
log-shipping/event-trigger-cloudwatch

### DIFF
--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -178,6 +178,16 @@ aws cloudformation deploy
 | LogzioENRICH | Enrich CloudWatch events with custom properties, formatted as `key1=value1;key2=value2`. |
 {:.paramlist}
 
+##### Set the CloudWatch Logs event trigger
+
+Find the **Add triggers** list (left side of the Designer panel). Choose **CloudWatch Logs** from this list.
+
+Below the Designer, you'll see the Configure triggers panel. Choose the **Log group** that the Lambda function will watch.
+
+Type a **Filter name** (required) and **Filter pattern** (optional).
+
+Click **Add**, and then click **Save** at the top of the page.
+
 ##### Check Logz.io for your logs
 
 Give your logs some time to get from your system to ours, and then open [Kibana](https://app.logz.io/#/dashboard/kibana).

--- a/_source/user-guide/mapping-and-parsing/data-parsing-wizard.md
+++ b/_source/user-guide/mapping-and-parsing/data-parsing-wizard.md
@@ -109,5 +109,3 @@ to troubleshoot any problems with your grok pattern.
 If everything looks good,
 click **Apply** to parse future logs using these settings.
 Otherwise, click **Back** to make changes to your settings.
-
-</div>


### PR DESCRIPTION
# What changed

Added a missing step to cloudwatch shipper - setting the cloudwatch logs event trigger
----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-416--logz-docs.netlify.com/shipping/log-sources/cloudwatch.html

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information: josh, ido
- [ ] Update these log shipping pages in the app: cloudwatch
- [ ] Sync with readme at logzio_aws_serverless/tree/master/python3/cloudwatch

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
