### PR TITLE
remove problematic redirects rule

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -38,9 +38,3 @@
   to = "/user-guide/tokens/:splat"
   status = 301
   force = true
-
-[[redirects]]
-  from = "/shipping/log-sources/*/:slug"
-  to= "/shipping/log-sources/:slug"
-  status = 301
-  force = true


### PR DESCRIPTION
# What changed

There was a problematic redirect in the netlify config toml. This should fix the issue.

To test, go to the shipping page and click on a log source, a metrics source, and a shipper.

https://deploy-preview-426--logz-docs.netlify.com/shipping/