### PR TITLE
Add the tag:GetResources permission as used within the collector

### DIFF
--- a/_source/logzio_collections/_metrics-sources/lambda.md
+++ b/_source/logzio_collections/_metrics-sources/lambda.md
@@ -40,7 +40,8 @@ with these permissions:
 `ec2:DescribeInstances`,
 `ec2:DescribeRegions`,
 `iam:ListAccountAliases`,
-`sts:GetCallerIdentity`
+`sts:GetCallerIdentity`,
+`tag:GetResources`
 
 If you don't have one, set that up now.
 


### PR DESCRIPTION
# What changed

Adding the missing `tag:GetResources` as a call was made within the docker metrics collector, reference:

```
2020-03-27T16:17:41.800Z	INFO	cfgfile/reload.go:226	Loading of config files completed.
2020-03-27T16:17:51.211Z	INFO	[aws.cloudwatch]	cloudwatch/cloudwatch.go:450	getResourcesTags failed, skipping region eu-west-2: error GetResources: AccessDeniedException: User: arn:aws:iam::011173820421:user/docker-metrics-collector is not authorized to perform: tag:GetResources
	status code: 400, request id: 6aa7fbff-0eb8-456c-bf2e-5eae01b7a7a1
2020-03-27T16:17:52.214Z	INFO	pipeline/output.go:95	Connecting to backoff(async(tcp://listener.logz.io:5015))
```

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-438--logz-docs.netlify.com/shipping/metrics-sources/lambda.html

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review
- [x] Copy Review

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information: Metrics content
- [ ] Update these log shipping pages in the app: - lambda metrics

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
