### PR TITLE
Change the references within the metrics source pages to point to the…

### DIFF
--- a/_source/_includes/metric-shipping/replace-vars.html
+++ b/_source/_includes/metric-shipping/replace-vars.html
@@ -1,0 +1,30 @@
+{{ include.prepend }}
+
+{%- if include.token -%}
+  {%- case include.token -%}
+    {%- when 'noReplace' -%}
+    The [token](https://app.logz.io/#/dashboard/settings/manage-accounts) of the account you want to ship to.
+    {%- else -%}
+    Replace `<<SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-accounts) of the account you want to ship to.
+  {%- endcase -%}
+{%- endif -%}
+
+{%- if include.token and include.listener -%}
+    <br /> <br />
+{%- endif -%}
+
+{%- if include.listener -%}
+  {%- case include.listener -%}
+    {%- when 'noReplace' -%}
+    {%- if include.isMidSentence == true -%}
+      your&nbsp;
+    {%- else -%}
+      Your&nbsp;
+    {%- endif -%}
+    region's listener host. For more information on finding your account's region, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html).
+    {%- else -%}
+    Replace `<<LISTENER-HOST>>` with your region's listener host (for example, `listener.logz.io`). For more information on finding your account's region, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html).
+  {%- endcase -%}
+{%- endif -%}
+
+{{ include.append }}

--- a/_source/logzio_collections/_metrics-sources/azure-diagnostic-metrics.md
+++ b/_source/logzio_collections/_metrics-sources/azure-diagnostic-metrics.md
@@ -97,7 +97,7 @@ Make sure to use the settings shown below.
 | Parameter | Description |
 |---|---|
 | Metrics listener host | Use the listener URL for your metrics account region. For more information on finding your account's region, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
-| Metrics account token | Use the [token](https://app.logz.io/#/dashboard/settings/general) of the metrics account you want to ship to. |
+| Metrics account token | Use the [token](https://app.logz.io/#/dashboard/settings/manage-accounts) of the metrics account you want to ship to. |
 {:.paramlist}
 
 At the bottom of the page, select **I agree to the terms and conditions stated above**, and then click **Purchase** to deploy.

--- a/_source/logzio_collections/_metrics-sources/docker.md
+++ b/_source/logzio_collections/_metrics-sources/docker.md
@@ -72,7 +72,7 @@ logzio/docker-collector-metrics
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
+| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include metric-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
 | LOGZIO_MODULES <span class="required-param"></span> | Comma-separated list of Metricbeat modules to be enabled on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/logzio_modules`. |
 | LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL. <br> You can find your region code in the [Regions and URLs]({{site.baseurl}}/user-guide/accounts/account-region.html#regions-and-urls) table. |
 | LOGZIO_TYPE <span class="default-param">`docker-collector-metrics`</span> | This field is needed only if you're shipping metrics to Kibana and you want to override the default value. <br> In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. |

--- a/_source/logzio_collections/_metrics-sources/ec2-auto-scaling.md
+++ b/_source/logzio_collections/_metrics-sources/ec2-auto-scaling.md
@@ -107,7 +107,7 @@ logzio/docker-collector-metrics
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
+| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include metric-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
 | LOGZIO_MODULES <span class="required-param"></span> | Comma-separated list of Metricbeat modules to enable on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/logzio_modules`. |
 | LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL. <br> You can find your region code in the [Regions and URLs]({{site.baseurl}}/user-guide/accounts/account-region.html#regions-and-urls) table. |
 | LOGZIO_TYPE <span class="default-param">`docker-collector-metrics`</span> | This field is needed only if you're shipping metrics to Kibana and you want to override the default value. <br> In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. |

--- a/_source/logzio_collections/_metrics-sources/ec2.md
+++ b/_source/logzio_collections/_metrics-sources/ec2.md
@@ -98,7 +98,7 @@ logzio/docker-collector-metrics
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
+| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include metric-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
 | LOGZIO_MODULES <span class="required-param"></span> | Comma-separated list of Metricbeat modules to enable on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/logzio_modules`. |
 | LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL. <br> You can find your region code in the [Regions and URLs]({{site.baseurl}}/user-guide/accounts/account-region.html#regions-and-urls) table. |
 | LOGZIO_TYPE <span class="default-param">`docker-collector-metrics`</span> | This field is needed only if you're shipping metrics to Kibana and you want to override the default value. <br> In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. |

--- a/_source/logzio_collections/_metrics-sources/jmx.md
+++ b/_source/logzio_collections/_metrics-sources/jmx.md
@@ -79,7 +79,7 @@ java -javaagent:./jmx2logzio-javaagent.jar=LOGZIO_TOKEN=<<SHIPPING-TOKEN>>,SERVI
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io [account token](https://app.logz.io/#/dashboard/settings/manage-accounts) <br> {% include log-shipping/replace-vars.html token=true %} |
+| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io [account token](https://app.logz.io/#/dashboard/settings/manage-accounts) <br> {% include metric-shipping/replace-vars.html token=true %} |
 | SERVICE_NAME <span class="required-param"></span> | A name you define for the service. This is included in the reported metrics. |
 | LISTENER_URL <span class="default-param">`https://listener.logz.io:8071`</span> | Listener URL and port. {% include log-shipping/replace-vars.html listener=true %} |
 | SERVICE_HOST <span class="default-param">Host machine name</span> | Hostname to be included in the reported metrics. |

--- a/_source/logzio_collections/_metrics-sources/kubernetes.md
+++ b/_source/logzio_collections/_metrics-sources/kubernetes.md
@@ -34,7 +34,7 @@ bash <(curl -s https://raw.githubusercontent.com/logzio/logz-docs/master/shippin
 
 | Prompt | Description |
 |---|---|
-| Logz.io metrics shipping token <span class="required-param"></span> | {% include log-shipping/replace-vars.html token='noReplace' %} |
+| Logz.io metrics shipping token <span class="required-param"></span> | {% include metric-shipping/replace-vars.html token='noReplace' %} |
 | Logz.io region | Two-letter region code, or blank for US East (Northern Virginia). This determnies your listener URL (where you're shipping the logs to) and API URL. <br> You can find your region code in the [Regions and URLs](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. |
 | Kubelet shipping protocol <span class="default-param">`http`</span> | `http` or `https`. If your Kubernetes setup is EKS, you'll need to use `https`. |
 | Cluster name <span class="default-param">Detected by the script</span> | The name of the Kubernetes cluster you're deploying in. |
@@ -78,7 +78,7 @@ git clone https://github.com/kubernetes/kube-state-metrics.git \
 
 Save your Logz.io shipping credentials as a Kubernetes secret.
 
-{% include log-shipping/replace-vars.html token=true listener=true %}
+{% include metric-shipping/replace-vars.html token=true listener=true %}
 
 ```shell
 kubectl --namespace=kube-system create secret generic logzio-metrics-secret \

--- a/_source/logzio_collections/_metrics-sources/lambda.md
+++ b/_source/logzio_collections/_metrics-sources/lambda.md
@@ -99,7 +99,7 @@ logzio/docker-collector-metrics
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
+| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include metric-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
 | LOGZIO_MODULES <span class="required-param"></span> | Comma-separated list of Metricbeat modules to enable on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/logzio_modules`. |
 | LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL. <br> You can find your region code in the [Regions and URLs]({{site.baseurl}}/user-guide/accounts/account-region.html#regions-and-urls) table. |
 | LOGZIO_TYPE <span class="default-param">`docker-collector-metrics`</span> | This field is needed only if you're shipping metrics to Kibana and you want to override the default value. <br> In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. |

--- a/_source/logzio_collections/_metrics-sources/rds.md
+++ b/_source/logzio_collections/_metrics-sources/rds.md
@@ -97,7 +97,7 @@ logzio/docker-collector-metrics
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
+| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include metric-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
 | LOGZIO_MODULES <span class="required-param"></span> | Comma-separated list of Metricbeat modules to enable on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/logzio_modules`. |
 | LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL. <br> You can find your region code in the [Regions and URLs]({{site.baseurl}}/user-guide/accounts/account-region.html#regions-and-urls) table. |
 | LOGZIO_TYPE <span class="default-param">`docker-collector-metrics`</span> | This field is needed only if you're shipping metrics to Kibana and you want to override the default value. <br> In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. |

--- a/_source/logzio_collections/_metrics-sources/s3.md
+++ b/_source/logzio_collections/_metrics-sources/s3.md
@@ -109,7 +109,7 @@ logzio/docker-collector-metrics
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
+| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include metric-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
 | LOGZIO_MODULES <span class="required-param"></span> | Comma-separated list of Metricbeat modules to enable on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/logzio_modules`. |
 | LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL. <br> You can find your region code in the [Regions and URLs]({{site.baseurl}}/user-guide/accounts/account-region.html#regions-and-urls) table. |
 | LOGZIO_TYPE <span class="default-param">`docker-collector-metrics`</span> | This field is needed only if you're shipping metrics to Kibana and you want to override the default value. <br> In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. |

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -73,7 +73,7 @@ logzio/docker-collector-metrics
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
+| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include metric-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
 | LOGZIO_MODULES <span class="required-param"></span> | Comma-separated list of Metricbeat modules to be enabled on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/logzio_modules`. |
 | LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL. <br> You can find your region code in the [Regions and URLs]({{site.baseurl}}/user-guide/accounts/account-region.html#regions-and-urls) table. |
 | LOGZIO_TYPE <span class="default-param">`docker-collector-metrics`</span> | This field is needed only if you're shipping metrics to Kibana and you want to override the default value. <br> In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. |
@@ -122,7 +122,7 @@ sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/CO
 
 Replace the General configuration with Logz.io settings.
 
-{% include log-shipping/replace-vars.html token=true %}
+{% include metric-shipping/replace-vars.html token=true %}
 
 ```yaml
 # ===== General =====
@@ -137,7 +137,7 @@ fields_under_root: true
 If Logz.io is not an output, add it now.
 Remove all other outputs.
 
-{% include log-shipping/replace-vars.html listener=true %}
+{% include metric-shipping/replace-vars.html listener=true %}
 
 ```yaml
 # ===== Outputs =====


### PR DESCRIPTION
… metrics tokens instead of the shipping tokens

Changed any direct references from shipping token to the manage accounts page (current home of the metrics token) as well as introducing the `metric-shipping/replace-vars` for the indirect references.

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
