### PR TITLE
prioritize local metricbeat for the system module

### DIFF
--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -20,17 +20,19 @@ shipping-tags:
 * [Using Docker](#docker-config)
 {:.branching-tabs}
 
-
 <!-- tab:start -->
 <div id="docker-config">
 
 ## Docker setup
-**Use this only to monitor linux systems. If you wish to monitor other types of system, Use [Meticbeat locally](#metricbeat-config)**
 
 To simplify shipping metrics from one or many sources,
 we created Docker Metrics Collector.
 Docker Metrics Collector is a container
 that runs Metricbeat with the modules you enable at runtime.
+
+This Docker container monitors Linux system metrics only.
+For other OSes, we recommend running Metricbeat locally on the system itself.
+{:.info-box.note}
 
 #### Configuration
 

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -25,7 +25,7 @@ shipping-tags:
 <div id="docker-config">
 
 ## Docker setup
-#### Use this only to monitor linux systems. If you wish to monitor other types of system, Use [Meticbeat locally](#metricbeat-config)
+**Use this only to monitor linux systems. If you wish to monitor other types of system, Use [Meticbeat locally](#metricbeat-config)**
 
 To simplify shipping metrics from one or many sources,
 we created Docker Metrics Collector.

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -21,6 +21,77 @@ shipping-tags:
 {:.branching-tabs}
 
 <!-- tab:start -->
+<div id="metricbeat-config">
+
+#### Metricbeat setup
+
+**Before you begin, you'll need**:
+[Metricbeat 7.1](https://www.elastic.co/guide/en/beats/metricbeat/7.1/metricbeat-installation.html) or higher
+
+<div class="tasklist">
+
+##### Download the Logz.io certificate
+
+Download the Logz.io public certificate to your certificate authority folder.
+
+```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+```
+
+##### Add Logz.io configuration
+
+Replace the General configuration with Logz.io settings.
+
+{% include log-shipping/replace-vars.html token=true %}
+
+```yaml
+# ===== General =====
+fields:
+  logzio_codec: json
+  token: <<SHIPPING-TOKEN>>
+fields_under_root: true
+```
+
+##### Set Logz.io as the output
+
+If Logz.io is not an output, add it now.
+Remove all other outputs.
+
+{% include log-shipping/replace-vars.html listener=true %}
+
+```yaml
+# ===== Outputs =====
+output.logstash:
+  hosts: ["<<LISTENER-HOST>>:5015"]
+  ssl.certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+```
+
+##### _(If needed)_ Enable the system module
+
+The system module is enabled by default.
+If you've disabled it for any reason, re-enable it now.
+
+```shell
+sudo metricbeat modules enable system
+```
+
+You can change the metrics collected by Metricbeat by modifying `modules.d/system.yml`.
+If you installed Metricbeat from a package manager, this directory is under `/etc/metricbeat`.
+
+##### Start Metricbeat
+
+Start or restart Metricbeat for the changes to take effect.
+
+##### Check Logz.io for your metrics
+
+Give your metrics some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/#/dashboard/kibana).
+
+</div>
+
+</div>
+<!-- tab:end -->
+
+<!-- tab:start -->
 <div id="docker-config">
 
 ## Docker setup
@@ -105,79 +176,6 @@ then click
 
 </div>
 <!-- tab:end -->
-
-
-<!-- tab:start -->
-<div id="metricbeat-config">
-
-#### Metricbeat setup
-
-**Before you begin, you'll need**:
-[Metricbeat 7.1](https://www.elastic.co/guide/en/beats/metricbeat/7.1/metricbeat-installation.html) or higher
-
-<div class="tasklist">
-
-##### Download the Logz.io certificate
-
-Download the Logz.io public certificate to your certificate authority folder.
-
-```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-```
-
-##### Add Logz.io configuration
-
-Replace the General configuration with Logz.io settings.
-
-{% include log-shipping/replace-vars.html token=true %}
-
-```yaml
-# ===== General =====
-fields:
-  logzio_codec: json
-  token: <<SHIPPING-TOKEN>>
-fields_under_root: true
-```
-
-##### Set Logz.io as the output
-
-If Logz.io is not an output, add it now.
-Remove all other outputs.
-
-{% include log-shipping/replace-vars.html listener=true %}
-
-```yaml
-# ===== Outputs =====
-output.logstash:
-  hosts: ["<<LISTENER-HOST>>:5015"]
-  ssl.certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
-```
-
-##### _(If needed)_ Enable the system module
-
-The system module is enabled by default.
-If you've disabled it for any reason, re-enable it now.
-
-```shell
-sudo metricbeat modules enable system
-```
-
-You can change the metrics collected by Metricbeat by modifying `modules.d/system.yml`.
-If you installed Metricbeat from a package manager, this directory is under `/etc/metricbeat`.
-
-##### Start Metricbeat
-
-Start or restart Metricbeat for the changes to take effect.
-
-##### Check Logz.io for your metrics
-
-Give your metrics some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/#/dashboard/kibana).
-
-</div>
-
-</div>
-<!-- tab:end -->
-
 
 </div>
 <!-- tabContainer:end -->

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -16,9 +16,8 @@ shipping-tags:
 
 <!-- tabContainer:start -->
 <div class="branching-container">
-
-* [Using Docker <span class="sm ital">(recommended)</span>](#docker-config)
-* [Using Metricbeat](#metricbeat-config)
+* [Using Metricbeat <span class="sm ital">(recommended)</span>](#metricbeat-config)
+* [Using Docker](#docker-config)
 {:.branching-tabs}
 
 
@@ -26,6 +25,7 @@ shipping-tags:
 <div id="docker-config">
 
 ## Docker setup
+#### Use this only to monitor linux systems. If you wish to monitor other types of system, Use [Meticbeat locally](#metricbeat-config)
 
 To simplify shipping metrics from one or many sources,
 we created Docker Metrics Collector.
@@ -66,6 +66,11 @@ For a complete list of options, see the parameters below the code block.👇
 docker run --name docker-collector-metrics \
 --env LOGZIO_TOKEN="<<SHIPPING-TOKEN>>" \
 --env LOGZIO_MODULES="system" \
+--volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
+--volume="/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro" \
+--volume="/proc:/hostfs/proc:ro" \
+--volume="/:/hostfs:ro" \
+--net=host \
 logzio/docker-collector-metrics
 ```
 

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -16,6 +16,7 @@ shipping-tags:
 
 <!-- tabContainer:start -->
 <div class="branching-container">
+
 * [Using Metricbeat <span class="sm ital">(recommended)</span>](#metricbeat-config)
 * [Using Docker](#docker-config)
 {:.branching-tabs}


### PR DESCRIPTION
Signed-off-by: yyyogev <yogev.metzuyanim@logz.io>

# What changed

Our preferred way of system monitoring is not local metricbeat


## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-459--logz-docs.netlify.app/shipping/metrics-sources/system.html

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review
- [x] Copy Review

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information: metrics-support channel
- [ ] Update these log shipping pages in the app: - system

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
