### PR TITLE
Instruct to deploy kube-state-metrics manually

### DIFF
--- a/_source/logzio_collections/_metrics-sources/kubernetes.md
+++ b/_source/logzio_collections/_metrics-sources/kubernetes.md
@@ -10,6 +10,10 @@ shipping-tags:
   - container
 ---
 
+### Prerequisites
+* [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) installed
+* Allow outgoing traffic to destination port 5015
+
 <!-- tabContainer:start -->
 <div class="branching-container">
 
@@ -67,12 +71,8 @@ If you see a response,
 that means kube-state-metrics is installed,
 and you can move on to step 2.
 
-Otherwise, deploy kube-state-metrics to your cluster.
-
-```shell
-git clone https://github.com/kubernetes/kube-state-metrics.git \
-  && kubectl --namespace=kube-system apply -f kube-state-metrics/examples/standard
-```
+Otherwise, deploy [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)
+with a [compatible version](https://github.com/kubernetes/kube-state-metrics#compatibility-matrix) to your cluster.
 
 ##### Store your Logz.io credentials
 

--- a/_source/logzio_collections/_metrics-sources/kubernetes.md
+++ b/_source/logzio_collections/_metrics-sources/kubernetes.md
@@ -10,10 +10,6 @@ shipping-tags:
   - container
 ---
 
-### Prerequisites
-* [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) installed
-* Allow outgoing traffic to destination port 5015
-
 <!-- tabContainer:start -->
 <div class="branching-container">
 
@@ -25,6 +21,10 @@ shipping-tags:
 <div id="automated-config">
 
 #### Automated deployment
+
+**Before you begin, you'll need**:
+[kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) installed,
+destination port 5015 is open on your firewall for outgoing traffic
 
 <div class="tasklist">
 
@@ -58,6 +58,10 @@ and then open [Logz.io](https://app.logz.io/).
 <div id="manual-config">
 
 #### Manual deployment
+
+**Before you begin, you'll need**:
+[kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) installed,
+destination port 5015 is open on your firewall for outgoing traffic
 
 <div class="tasklist">
 

--- a/shipping-config-samples/quickstart.sh
+++ b/shipping-config-samples/quickstart.sh
@@ -20,7 +20,7 @@ fi
 
 has_kube_stat_metrics=$(kubectl get deployments --all-namespaces | grep kube-state-metrics)
 if [[ -z $has_kube_stat_metrics ]]; then
-  echo "ERROR: kube-state-metrics is not deployed in your cluster, please deploy it from https://github.com/kubernetes/kube-state-metrics and run this script again"
+  echo "ERROR: kube-state-metrics is not deployed in your cluster. Please deploy it from https://github.com/kubernetes/kube-state-metrics and run this script again"
   exit 1
 fi
 

--- a/shipping-config-samples/quickstart.sh
+++ b/shipping-config-samples/quickstart.sh
@@ -20,9 +20,8 @@ fi
 
 has_kube_stat_metrics=$(kubectl get deployments --all-namespaces | grep kube-state-metrics)
 if [[ -z $has_kube_stat_metrics ]]; then
-  git clone https://github.com/kubernetes/kube-state-metrics.git
-  kubectl --namespace=kube-system apply -f kube-state-metrics/examples/standard
-  rm  -rf kube-state-metrics
+  echo "ERROR: kube-state-metrics is not deployed in your cluster, please deploy it from https://github.com/kubernetes/kube-state-metrics and run this script again"
+  exit 1
 fi
 
 kube_stat_ns=$(kubectl get deployments --all-namespaces -o json | jq '.items[] | select(.metadata.name == "kube-state-metrics")' | jq -r '.metadata.namespace')


### PR DESCRIPTION
Signed-off-by: yyyogev <yogev.metzuyanim@logz.io>

# What changed

Instruct to deploy kube-state-metrics manually both in  the script and the manual instructions

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
