### PR TITLE
add env variable for shipping zipkin spans

### DIFF
--- a/_source/logzio_collections/_log-sources/jaeger.md
+++ b/_source/logzio_collections/_log-sources/jaeger.md
@@ -3,7 +3,7 @@ title: Ship traces with Jaeger
 logo:
   logofile: jaeger.svg
   orientation: vertical
-data-source: Jaeger 
+data-source: Jaeger
 description: Here's how you can use Logz.io as data storage for Jaeger traces.
 open-source:
   - title: Jaeger-Logz.io Trace Storage
@@ -84,14 +84,16 @@ logzio/jaeger-logzio:latest
 | Parameter | Description |
 |---|---|
 | ACCOUNT_TOKEN <span class="required-param"></span> | Required when using as a collector to ship traces to Logz.io. <br> {% include log-shipping/replace-vars.html token=true %} |
-| API_TOKEN	<span class="required-param"></span> | Required to read back traces from Logz.io. <br> Replace `<<API-TOKEN>>` with an [API token](https://app.logz.io/#/dashboard/settings/api-tokens) from the account you want to use. |
+| API_TOKEN <span class="required-param"></span> | Required to read back traces from Logz.io. <br> Replace `<<API-TOKEN>>` with an [API token](https://app.logz.io/#/dashboard/settings/api-tokens) from the account you want to use. |
 | REGION <span class="default-param">_Blank (US East)_</span> | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL. <br> You can find your region code in the [Regions and URLs](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. |
-| GRPC_STORAGE_PLUGIN_LOG_LEVEL	<span class="default-param">`warn`</span> | The lowest log level to send. From lowest to highest, log levels are `trace`, `debug`, `info`, `warn`, `error`. <br> Controls logging for Jaeger Logz.io Collector only (not Jaeger components). |
+| GRPC_STORAGE_PLUGIN_LOG_LEVEL <span class="default-param">`warn`</span> | The lowest log level to send. From lowest to highest, log levels are `trace`, `debug`, `info`, `warn`, `error`. <br> Controls logging for Jaeger Logz.io Collector only (not Jaeger components). |
+| COLLECTOR_ZIPKIN_HTTP_PORT | If you're using a Zipkin implementation to create traces, et this environment variable to `9411`. This tells Jaeger that it's accepting Zipkin spans so it can transform them to Jaeger-formatted spans. |
 {:.paramlist}
 
 ##### Check Jaeger for your traces
 
-Give your traces some time to get from your system to ours, and then open your Jaeger UI.
+Give your traces some time to get from your system to ours,
+and then open your Jaeger UI.
 
 </div>
 
@@ -141,6 +143,7 @@ logzio/jaeger-logzio-collector:latest
 | ACCOUNT_TOKEN <span class="required-param"></span> | Required when using as a collector to ship traces to Logz.io. <br> {% include log-shipping/replace-vars.html token=true %} |
 | REGION <span class="default-param">_Blank (US East)_</span> | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to). <br> You can find your region code in the [Regions and URLs](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. |
 | GRPC_STORAGE_PLUGIN_LOG_LEVEL	<span class="default-param">`warn`</span> | The lowest log level to send. From lowest to highest, log levels are `trace`, `debug`, `info`, `warn`, `error`. <br> Controls logging for Jaeger Logz.io Collector only (not Jaeger components). |
+| COLLECTOR_ZIPKIN_HTTP_PORT | If you're using a Zipkin implementation to create traces, et this environment variable to `9411`. This tells Jaeger that it's accepting Zipkin spans so it can transform them to Jaeger-formatted spans. |
 {:.paramlist}
 
 ##### Run Jaeger query
@@ -160,7 +163,7 @@ logzio/jaeger-logzio-query:latest
 |---|---|
 | API_TOKEN	<span class="required-param"></span> | Required to read back traces from Logz.io. <br> Replace `<<API-TOKEN>>` with an [API token](https://app.logz.io/#/dashboard/settings/api-tokens) from the account you want to use. |
 | REGION <span class="default-param">_Blank (US East)_</span> | Two-letter region code, or blank for US East (Northern Virginia). This determines your API URL. <br> You can find your region code in the [Regions and URLs](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. |
-| GRPC_STORAGE_PLUGIN_LOG_LEVEL	<span class="default-param">`warn`</span> | The lowest log level to send. From lowest to highest, log levels are `trace`, `debug`, `info`, `warn`, `error`. <br> Controls logging for Jaeger Logz.io Collector only (not Jaeger components). |
+| GRPC_STORAGE_PLUGIN_LOG_LEVEL <span class="default-param">`warn`</span> | The lowest log level to send. From lowest to highest, log levels are `trace`, `debug`, `info`, `warn`, `error`. <br> Controls logging for Jaeger Logz.io Collector only (not Jaeger components). |
 {:.paramlist}
 
 ##### _(If needed)_ Run Jaeger agent
@@ -181,7 +184,8 @@ docker run --rm --name=jaeger-agent --network=net-logzio \
 
 ##### Check Jaeger for your traces
 
-Give your traces some time to get from your system to ours, and then open your Jaeger UI.
+Give your traces some time to get from your system to ours,
+and then open your Jaeger UI.
 
 </div>
 


### PR DESCRIPTION
# What changed

Added environment variable to ship zipkin spans with jaeger. Definitely needs a pair of eyes on it to make sure it's correct.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
