### PR TITLE
Log shipping/public cert update - FILEBEAT

### DIFF
--- a/_source/logzio_collections/_docs-admin/in-app-docs.md
+++ b/_source/logzio_collections/_docs-admin/in-app-docs.md
@@ -296,7 +296,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
 {:.paramlist}
 
@@ -327,7 +327,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
 {:.paramlist}
 

--- a/_source/logzio_collections/_docs-admin/in-app-docs.md
+++ b/_source/logzio_collections/_docs-admin/in-app-docs.md
@@ -282,7 +282,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
 {:.paramlist}
 
@@ -299,7 +299,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
 {:.paramlist}
 

--- a/_source/logzio_collections/_docs-admin/in-app-docs.md
+++ b/_source/logzio_collections/_docs-admin/in-app-docs.md
@@ -283,7 +283,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -314,7 +314,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_docs-admin/in-app-docs.md
+++ b/_source/logzio_collections/_docs-admin/in-app-docs.md
@@ -280,6 +280,20 @@ Accordions use the native `details` and `summary` tags.
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
@@ -296,6 +310,20 @@ Configuration tl;dr
 <summary>
 Configuration tl;dr
 </summary>
+
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 | Item | Description |
 |---|---|

--- a/_source/logzio_collections/_docs-admin/in-app-docs.md
+++ b/_source/logzio_collections/_docs-admin/in-app-docs.md
@@ -296,7 +296,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
 {:.paramlist}
 
@@ -327,7 +327,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
 {:.paramlist}
 

--- a/_source/logzio_collections/_log-sources/active-directory-winserver.md
+++ b/_source/logzio_collections/_log-sources/active-directory-winserver.md
@@ -24,7 +24,7 @@ shipping-tags:
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/active-directory-winserver.md
+++ b/_source/logzio_collections/_log-sources/active-directory-winserver.md
@@ -19,11 +19,24 @@ shipping-tags:
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
 
-Download the [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) to your machine.
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
-We'll place the certificate in `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt` for this example.
+Download the
+[new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)
+to `C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt`
+and the
+[old Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt)
+to `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt`
+on your machine.
 
 ##### Configure Windows applications as an input
 
@@ -89,7 +102,9 @@ Winlogbeat can have one output only, so remove any other `output` entries.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - 'C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt'
+      - 'C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Restart Winlogbeat

--- a/_source/logzio_collections/_log-sources/active-directory-winserver.md
+++ b/_source/logzio_collections/_log-sources/active-directory-winserver.md
@@ -21,14 +21,19 @@ shipping-tags:
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 Download the
 [new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -21,7 +21,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | Ubuntu, Debian: `/var/log/apache2/access.log` <br> RHEL, CentOS, Fedora: `/var/log/httpd/access_log` |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -40,14 +40,19 @@ root access
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | Ubuntu, Debian: `/var/log/apache2/access.log` <br> RHEL, CentOS, Fedora: `/var/log/httpd/access_log` |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -38,11 +38,21 @@ root access
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -130,7 +140,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -19,6 +19,20 @@ shipping-tags:
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -22,7 +22,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -57,7 +57,7 @@ root access
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | Ubuntu, Debian: `/var/log/apache2/access.log` <br> RHEL, CentOS, Fedora: `/var/log/httpd/access_log` |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|

--- a/_source/logzio_collections/_log-sources/auditd.md
+++ b/_source/logzio_collections/_log-sources/auditd.md
@@ -29,7 +29,7 @@ root access
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/auditd.md
+++ b/_source/logzio_collections/_log-sources/auditd.md
@@ -24,11 +24,21 @@ root access
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -106,7 +116,9 @@ and replace it with this code block.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Auditbeat

--- a/_source/logzio_collections/_log-sources/auditd.md
+++ b/_source/logzio_collections/_log-sources/auditd.md
@@ -26,14 +26,19 @@ root access
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/check-point.md
+++ b/_source/logzio_collections/_log-sources/check-point.md
@@ -62,7 +62,7 @@ to restart the exporter.
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/check-point.md
+++ b/_source/logzio_collections/_log-sources/check-point.md
@@ -59,14 +59,19 @@ to restart the exporter.
 
 ##### Download the Logz.io public certificate to your Filebeat server
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/check-point.md
+++ b/_source/logzio_collections/_log-sources/check-point.md
@@ -57,9 +57,21 @@ If you restart the management server, you'll need to run `cp_log_export` again
 to restart the exporter.
 {:.info-box.note}
 
-##### Download the Logz.io certificate to your Filebeat server
+##### Download the Logz.io public certificate to your Filebeat server
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
+
+For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -126,7 +138,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/cisco-asa.md
+++ b/_source/logzio_collections/_log-sources/cisco-asa.md
@@ -39,7 +39,7 @@ on configuring your Cisco ASA firewall.
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/cisco-asa.md
+++ b/_source/logzio_collections/_log-sources/cisco-asa.md
@@ -34,9 +34,21 @@ Make sure you meet this configuration:
 See [Cisco docs](https://www.cisco.com/c/en/us/support/security/index.html) for more information
 on configuring your Cisco ASA firewall.
 
-##### Download the Logz.io certificate to your Filebeat server
+##### Download the Logz.io public certificate to your Filebeat server
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
+
+For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -103,7 +115,9 @@ If Logz.io is not an output, add it now.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/cisco-asa.md
+++ b/_source/logzio_collections/_log-sources/cisco-asa.md
@@ -36,14 +36,19 @@ on configuring your Cisco ASA firewall.
 
 ##### Download the Logz.io public certificate to your Filebeat server
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/fail2ban.md
+++ b/_source/logzio_collections/_log-sources/fail2ban.md
@@ -20,11 +20,21 @@ root access
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -92,7 +102,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/fail2ban.md
+++ b/_source/logzio_collections/_log-sources/fail2ban.md
@@ -22,14 +22,19 @@ root access
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/fail2ban.md
+++ b/_source/logzio_collections/_log-sources/fail2ban.md
@@ -25,7 +25,7 @@ root access
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/falco.md
+++ b/_source/logzio_collections/_log-sources/falco.md
@@ -178,14 +178,19 @@ Save and exit the falco.yaml file.
 
 ##### Download the Logz.io public certificate to your Filebeat server
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/falco.md
+++ b/_source/logzio_collections/_log-sources/falco.md
@@ -181,7 +181,7 @@ Save and exit the falco.yaml file.
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/falco.md
+++ b/_source/logzio_collections/_log-sources/falco.md
@@ -176,9 +176,21 @@ file_output:
 ```
 Save and exit the falco.yaml file.
 
-##### Download the Logz.io certificate to your Filebeat server
+##### Download the Logz.io public certificate to your Filebeat server
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
+
+For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -222,7 +234,9 @@ processors:
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Replace the placeholders in the Filebeat configuration

--- a/_source/logzio_collections/_log-sources/fortigate.md
+++ b/_source/logzio_collections/_log-sources/fortigate.md
@@ -44,9 +44,21 @@ set port 514
 end
 ```
 
-##### Download the Logz.io certificate to your Filebeat server
+##### Download the Logz.io public certificate to your Filebeat server
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
+
+For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -113,7 +125,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/fortigate.md
+++ b/_source/logzio_collections/_log-sources/fortigate.md
@@ -49,7 +49,7 @@ end
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/fortigate.md
+++ b/_source/logzio_collections/_log-sources/fortigate.md
@@ -46,14 +46,19 @@ end
 
 ##### Download the Logz.io public certificate to your Filebeat server
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -38,11 +38,21 @@ Configuration tl;dr
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -153,7 +163,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | If installed from Omnibus packages: `/var/log/gitlab/...` <br> If installed from source: `/home/git/gitlab/log/...` <br> _See [Log system](https://docs.gitlab.com/ee/administration/logs.html) from GitLab for more information._ |
 | Log type | Production, JSON: `gitlab-production-json` <br> Production, plain text: `gitlab-production` <br> API: `gitlab-api-json` <br> Application: `gitlab-application` |

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -19,6 +19,20 @@ shipping-tags:
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -22,7 +22,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -57,7 +57,7 @@ after June 5, 2020.
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -40,14 +40,19 @@ Configuration tl;dr
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | If installed from Omnibus packages: `/var/log/gitlab/...` <br> If installed from source: `/home/git/gitlab/log/...` <br> _See [Log system](https://docs.gitlab.com/ee/administration/logs.html) from GitLab for more information._ |
 | Log type | Production, JSON: `gitlab-production-json` <br> Production, plain text: `gitlab-production` <br> API: `gitlab-api-json` <br> Application: `gitlab-application` |

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -21,7 +21,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | If installed from Omnibus packages: `/var/log/gitlab/...` <br> If installed from source: `/home/git/gitlab/log/...` <br> _See [Log system](https://docs.gitlab.com/ee/administration/logs.html) from GitLab for more information._ |
 | Log type | Production, JSON: `gitlab-production-json` <br> Production, plain text: `gitlab-production` <br> API: `gitlab-api-json` <br> Application: `gitlab-application` |

--- a/_source/logzio_collections/_log-sources/hashicorp-vault.md
+++ b/_source/logzio_collections/_log-sources/hashicorp-vault.md
@@ -36,14 +36,19 @@ see [File Audit Device](https://www.vaultproject.io/docs/audit/file.html) from H
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/hashicorp-vault.md
+++ b/_source/logzio_collections/_log-sources/hashicorp-vault.md
@@ -39,7 +39,7 @@ see [File Audit Device](https://www.vaultproject.io/docs/audit/file.html) from H
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/hashicorp-vault.md
+++ b/_source/logzio_collections/_log-sources/hashicorp-vault.md
@@ -34,11 +34,21 @@ vault audit enable file file_path=/var/log/vault_audit.log log_raw=true
 For more information on logging and enabling audit devices,
 see [File Audit Device](https://www.vaultproject.io/docs/audit/file.html) from HashiCorp.
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -99,7 +109,9 @@ processors:
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -58,14 +58,19 @@ root access
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -53,7 +53,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log location | `/var/log/jenkins/jenkins.log` |
 | Log type _\(for preconfigured parsing\)_ | `jenkins` |

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -37,6 +37,20 @@ This page covers methods for shipping Jenkins system logs and build console outp
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -53,7 +53,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log location | `/var/log/jenkins/jenkins.log` |
 | Log type _\(for preconfigured parsing\)_ | `jenkins` |

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -39,7 +39,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log location | `/var/log/jenkins/jenkins.log` |
 | Log type _\(for preconfigured parsing\)_ | `jenkins` |

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -56,11 +56,21 @@ root access
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -130,7 +140,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -40,7 +40,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -75,7 +75,7 @@ root access
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/juniper-srx.md
+++ b/_source/logzio_collections/_log-sources/juniper-srx.md
@@ -43,9 +43,21 @@ Configure your Juniper firewall to send logs to your Filebeat server. Make sure 
 
 See [Juniper SRX docs](https://kb.juniper.net/InfoCenter/index?page=content&id=KB16502&actp=METADATA) for more information on configuring your Juniper SRX firewall.
 
-##### Download the Logz.io certificate to your Filebeat server
+##### Download the Logz.io public certificate to your Filebeat server
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
+
+For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -96,7 +108,9 @@ Copy and paste the following code block directly below. It sets Logz.io as the o
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']    
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Replace the placeholders in the Filebeat configuration

--- a/_source/logzio_collections/_log-sources/juniper-srx.md
+++ b/_source/logzio_collections/_log-sources/juniper-srx.md
@@ -48,7 +48,7 @@ See [Juniper SRX docs](https://kb.juniper.net/InfoCenter/index?page=content&id=K
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/juniper-srx.md
+++ b/_source/logzio_collections/_log-sources/juniper-srx.md
@@ -45,14 +45,19 @@ See [Juniper SRX docs](https://kb.juniper.net/InfoCenter/index?page=content&id=K
 
 ##### Download the Logz.io public certificate to your Filebeat server
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/linux.md
+++ b/_source/logzio_collections/_log-sources/linux.md
@@ -18,6 +18,20 @@ shipping-tags:
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-rsyslog-config.conf) |

--- a/_source/logzio_collections/_log-sources/linux.md
+++ b/_source/logzio_collections/_log-sources/linux.md
@@ -21,7 +21,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
+++ b/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
@@ -41,11 +41,21 @@ sudo openssl req -newkey rsa:2048 -nodes \
 -out /etc/filebeat/certificates/McafeeEpo.crt
 ```
 
-##### Download the Logz.io certificate to your Filebeat server
+##### Download the Logz.io public certificate to your Filebeat server
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -116,7 +126,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
+++ b/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
@@ -46,7 +46,7 @@ sudo openssl req -newkey rsa:2048 -nodes \
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
+++ b/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
@@ -43,14 +43,19 @@ sudo openssl req -newkey rsa:2048 -nodes \
 
 ##### Download the Logz.io public certificate to your Filebeat server
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -37,7 +37,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -91,7 +91,7 @@ sudo /etc/init.d/mysql restart
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -74,14 +74,19 @@ sudo /etc/init.d/mysql restart
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -72,11 +72,21 @@ Restart MySQL.
 sudo /etc/init.d/mysql restart
 ```
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -177,7 +187,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -34,6 +34,20 @@ shipping-tags:
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -36,7 +36,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | General query log: `/var/log/mysql/mysql.log` <br> Slow query log: `/var/log/mysql/mysql-slow.log` <br> Error log: `/var/log/mysql/error.log` |
 | Log type _(for preconfigured parsing)_ | General query log: `mysql` <br> Slow query log: `mysql_slow_query` <br> Error log: `mysql_error` |

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -50,7 +50,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | General query log: `/var/log/mysql/mysql.log` <br> Slow query log: `/var/log/mysql/mysql-slow.log` <br> Error log: `/var/log/mysql/error.log` |
 | Log type _(for preconfigured parsing)_ | General query log: `mysql` <br> Slow query log: `mysql_slow_query` <br> Error log: `mysql_error` |

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -50,7 +50,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | General query log: `/var/log/mysql/mysql.log` <br> Slow query log: `/var/log/mysql/mysql-slow.log` <br> Error log: `/var/log/mysql/error.log` |
 | Log type _(for preconfigured parsing)_ | General query log: `mysql` <br> Slow query log: `mysql_slow_query` <br> Error log: `mysql_error` |

--- a/_source/logzio_collections/_log-sources/network-device.md
+++ b/_source/logzio_collections/_log-sources/network-device.md
@@ -25,11 +25,21 @@ root access
 Configure your network device to send logs to your Filebeat server, TCP port 9000.
 See your device's documentation if you're not sure how to do this.
 
-##### Download the Logz.io certificate to your Filebeat server
+##### Download the Logz.io public certificate to your Filebeat server
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -96,7 +106,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/network-device.md
+++ b/_source/logzio_collections/_log-sources/network-device.md
@@ -27,14 +27,19 @@ See your device's documentation if you're not sure how to do this.
 
 ##### Download the Logz.io public certificate to your Filebeat server
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/network-device.md
+++ b/_source/logzio_collections/_log-sources/network-device.md
@@ -30,7 +30,7 @@ See your device's documentation if you're not sure how to do this.
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -41,14 +41,19 @@ root access
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -36,7 +36,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | `/var/log/nginx/access.log` or `/var/log/nginx/error.log` |
 | Log type _(for preconfigured parsing)_ | Access log: `nginx`, `nginx_access`, or `nginx-access` <br> Error log: `nginx-error` |

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -22,7 +22,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | `/var/log/nginx/access.log` or `/var/log/nginx/error.log` |
 | Log type _(for preconfigured parsing)_ | Access log: `nginx`, `nginx_access`, or `nginx-access` <br> Error log: `nginx-error` |

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -39,11 +39,21 @@ root access
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -125,7 +135,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -23,7 +23,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -58,7 +58,7 @@ root access
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -20,6 +20,20 @@ shipping-tags:
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -36,7 +36,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | `/var/log/nginx/access.log` or `/var/log/nginx/error.log` |
 | Log type _(for preconfigured parsing)_ | Access log: `nginx`, `nginx_access`, or `nginx-access` <br> Error log: `nginx-error` |

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | JSON _(recommended)_: `/var/ossec/logs/alerts/alerts.json` <br> Plain text: `/var/ossec/logs/alerts/alerts.log` |
 {:.paramlist}

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | JSON _(recommended)_: `/var/ossec/logs/alerts/alerts.json` <br> Plain text: `/var/ossec/logs/alerts/alerts.log` |
 {:.paramlist}

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -21,7 +21,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | JSON _(recommended)_: `/var/ossec/logs/alerts/alerts.json` <br> Plain text: `/var/ossec/logs/alerts/alerts.log` |
 {:.paramlist}

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -56,14 +56,19 @@ sudo /var/ossec/bin/ossec-control restart
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -19,6 +19,20 @@ shipping-tags:
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -54,11 +54,21 @@ Restart OSSEC.
 sudo /var/ossec/bin/ossec-control restart
 ```
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -126,7 +136,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -22,7 +22,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -73,7 +73,7 @@ sudo /var/ossec/bin/ossec-control restart
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/palo-alto-networks.md
+++ b/_source/logzio_collections/_log-sources/palo-alto-networks.md
@@ -89,11 +89,21 @@ In the upper right corner of the page, click **Commit**.
 Select **Commit All Changes**,
 and click the **Commit** button to save.
 
-##### Download the Logz.io certificate to your Filebeat server
+##### Download the Logz.io public certificate to your Filebeat server
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -160,7 +170,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/palo-alto-networks.md
+++ b/_source/logzio_collections/_log-sources/palo-alto-networks.md
@@ -94,7 +94,7 @@ and click the **Commit** button to save.
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/palo-alto-networks.md
+++ b/_source/logzio_collections/_log-sources/palo-alto-networks.md
@@ -91,14 +91,19 @@ and click the **Commit** button to save.
 
 ##### Download the Logz.io public certificate to your Filebeat server
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -40,14 +40,19 @@ root access
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log location | _Puppet produces lots of different logs. See [Log files installed](https://puppet.com/docs/pe/2018.1/what_gets_installed_and_where.html#log-files-installed) from Puppet Labs for more information._ |
 | Log type _\(for preconfigured parsing\)_ | Puppet server: `puppetserver` <br> Puppet server access: `puppetserver-access` |

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -38,11 +38,21 @@ root access
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -140,7 +150,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log location | _Puppet produces lots of different logs. See [Log files installed](https://puppet.com/docs/pe/2018.1/what_gets_installed_and_where.html#log-files-installed) from Puppet Labs for more information._ |
 | Log type _\(for preconfigured parsing\)_ | Puppet server: `puppetserver` <br> Puppet server access: `puppetserver-access` |

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -19,6 +19,20 @@ shipping-tags:
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -21,7 +21,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log location | _Puppet produces lots of different logs. See [Log files installed](https://puppet.com/docs/pe/2018.1/what_gets_installed_and_where.html#log-files-installed) from Puppet Labs for more information._ |
 | Log type _\(for preconfigured parsing\)_ | Puppet server: `puppetserver` <br> Puppet server access: `puppetserver-access` |

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -22,7 +22,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -57,7 +57,7 @@ root access
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | JSON _(recommended)_: `/var/ossec/logs/alerts/alerts.json` <br> Plain text: `/var/ossec/logs/alerts/alerts.log` |
 {:.paramlist}

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -35,7 +35,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | JSON _(recommended)_: `/var/ossec/logs/alerts/alerts.json` <br> Plain text: `/var/ossec/logs/alerts/alerts.log` |
 {:.paramlist}

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -21,7 +21,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | JSON _(recommended)_: `/var/ossec/logs/alerts/alerts.json` <br> Plain text: `/var/ossec/logs/alerts/alerts.log` |
 {:.paramlist}

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -55,14 +55,19 @@ sudo systemctl restart wazuh-manager
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -19,6 +19,20 @@ shipping-tags:
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -53,11 +53,21 @@ Restart Wazuh.
 sudo systemctl restart wazuh-manager
 ```
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -125,7 +135,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -22,7 +22,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -72,7 +72,7 @@ sudo systemctl restart wazuh-manager
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/windows-defender.md
+++ b/_source/logzio_collections/_log-sources/windows-defender.md
@@ -60,14 +60,19 @@ Now click **OK** to exit all those dialogs you just opened. 😬
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 Download the
 [new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)

--- a/_source/logzio_collections/_log-sources/windows-defender.md
+++ b/_source/logzio_collections/_log-sources/windows-defender.md
@@ -58,11 +58,24 @@ Type "Administrators" in the text box and click **Check Names**.
 
 Now click **OK** to exit all those dialogs you just opened. 😬
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
 
-Download the [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) to your machine.
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
-We'll place the certificate in `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt` for this example.
+Download the
+[new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)
+to `C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt`
+and the
+[old Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt)
+to `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt`
+on your machine.
 
 ##### Configure Windows input
 
@@ -125,7 +138,9 @@ Winlogbeat can have one output only, so remove any other `output` entries.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - 'C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt'
+      - 'C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Restart Winlogbeat

--- a/_source/logzio_collections/_log-sources/windows-defender.md
+++ b/_source/logzio_collections/_log-sources/windows-defender.md
@@ -63,7 +63,7 @@ Now click **OK** to exit all those dialogs you just opened. 😬
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/windows.md
+++ b/_source/logzio_collections/_log-sources/windows.md
@@ -33,7 +33,7 @@ shipping-tags:
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_log-sources/windows.md
+++ b/_source/logzio_collections/_log-sources/windows.md
@@ -28,11 +28,24 @@ shipping-tags:
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
 
-Download the [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) to your machine.
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
-We'll place the certificate in `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt` for this example.
+Download the
+[new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)
+to `C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt`
+and the
+[old Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt)
+to `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt`
+on your machine.
 
 ##### Configure Windows input
 
@@ -94,7 +107,9 @@ Winlogbeat can have one output only, so remove any other `output` entries.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - 'C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt'
+      - 'C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Restart Winlogbeat

--- a/_source/logzio_collections/_log-sources/windows.md
+++ b/_source/logzio_collections/_log-sources/windows.md
@@ -30,14 +30,19 @@ shipping-tags:
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 Download the
 [new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)

--- a/_source/logzio_collections/_log-sources/zeek.md
+++ b/_source/logzio_collections/_log-sources/zeek.md
@@ -38,9 +38,21 @@ Set the value to `T` (true):
 const use_json = T &redef;
 ```
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
+
+For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -131,7 +143,9 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+    certificate_authorities:
+      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/zeek.md
+++ b/_source/logzio_collections/_log-sources/zeek.md
@@ -40,14 +40,19 @@ const use_json = T &redef;
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_log-sources/zeek.md
+++ b/_source/logzio_collections/_log-sources/zeek.md
@@ -43,7 +43,7 @@ const use_json = T &redef;
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_metrics-sources/azure-monitor.md
+++ b/_source/logzio_collections/_metrics-sources/azure-monitor.md
@@ -83,14 +83,19 @@ You'll need this information later on, so paste it in your text editor.
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 You'll need to run this command on the server that hosts Metricbeat:

--- a/_source/logzio_collections/_metrics-sources/azure-monitor.md
+++ b/_source/logzio_collections/_metrics-sources/azure-monitor.md
@@ -81,12 +81,22 @@ You'll need this information later on, so paste it in your text editor.
 "password": "e6ab6d24-4907-5d11-a132-a171ef55355d",
 ```
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 You'll need to run this command on the server that hosts Metricbeat:
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -134,7 +144,9 @@ ignore_older: 3hr
 type: metrics
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
-  ssl.certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+  ssl.certificate_authorities:
+    - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+    - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ###### Parameters

--- a/_source/logzio_collections/_metrics-sources/azure-monitor.md
+++ b/_source/logzio_collections/_metrics-sources/azure-monitor.md
@@ -86,7 +86,7 @@ You'll need this information later on, so paste it in your text editor.
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -31,11 +31,21 @@ shipping-tags:
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
 
-Download the Logz.io public certificate to your certificate authority folder.
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
+
+For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -64,7 +74,9 @@ Remove all other outputs.
 # ===== Outputs =====
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
-  ssl.certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+  ssl.certificate_authorities:
+    - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+    - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
 ```
 
 ##### _(If needed)_ Enable the system module

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -33,14 +33,19 @@ shipping-tags:
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -36,7 +36,7 @@ shipping-tags:
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -43,7 +43,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 {:.paramlist}
 

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -30,7 +30,7 @@ Configuration tl;dr
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\
@@ -72,7 +72,7 @@ after June 5, 2020.
 **Action required**:
 Starting May 26, 2020, we'll transition our listener servers
 to a new public SSL certificate.
-Before that time,
+Before that date,
 you'll need to include both the old and new certificates
 in your configurations. \\
 \\

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -53,11 +53,21 @@ Configuration tl;dr
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+Starting May 26, 2020, we'll be transitioning our listener servers
+to a new public certificate.
+To make sure your shipped data arrives at your account,
+we recommend using both the old and new certificates
+as soon as possible,
+and including both certificates in your Filebeat configuration.
+After June 1, 2020, you can safely remove the old certificate.
+{:.info-box.important}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
 ```
 
@@ -93,7 +103,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -27,6 +27,20 @@ see [Log shipping sources]({{site.baseurl}}/shipping/).
 Configuration tl;dr
 </summary>
 
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
+
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -29,7 +29,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Encryption certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 {:.paramlist}
 

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -55,14 +55,19 @@ Configuration tl;dr
 
 ##### Download the Logz.io public certificate
 
-Starting May 26, 2020, we'll be transitioning our listener servers
-to a new public certificate.
-To make sure your shipped data arrives at your account,
-we recommend using both the old and new certificates
-as soon as possible,
-and including both certificates in your Filebeat configuration.
-After June 1, 2020, you can safely remove the old certificate.
-{:.info-box.important}
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that time,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -43,7 +43,7 @@ after June 5, 2020.
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate (_active from May 27, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Public certificate (_expires May 26, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) <br> [Old public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 {:.paramlist}
 

--- a/shipping-config-samples/logz-filebeat-config.yml
+++ b/shipping-config-samples/logz-filebeat-config.yml
@@ -78,4 +78,6 @@ output:
       # Run this command:
       #   `sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/`
       # For Windows, replace the filepath with the certificate's location.
-      certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+      certificate_authorities:
+        - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
+        - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'


### PR DESCRIPTION
# What changed

Updated docs for transition to new public cert.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- Entire list of files is in Noni's google doc. https://deploy-preview-493--logz-docs.netlify.app/shipping/

## Remaining work

<!-- List any outstanding work here -->
- ~~get an answer on logstash - new cert?~~ - will be in another pr
- [x] Technical review
- [x] Copy Review

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information: liveanu
- Update log shipping pages in the app:
  - [ ] logs - active-directory-winserver
  - [ ] logs - apache
  - [ ] logs - auditd
  - [ ] logs - check-point
  - [ ] logs - cisco-asa
  - [ ] logs - fail2ban
  - [ ] logs - falco
  - [ ] logs - fortigate
  - [ ] logs - gitlab
  - [ ] logs - hashicorp-vault
  - [ ] logs - jenkins
  - [ ] logs - juniper-srx
  - [ ] logs - linux
  - [ ] logs - mcafee-epolicy-orchestrator
  - [ ] logs - mysql
  - [ ] logs - network-device
  - [ ] logs - nginx
  - [ ] logs - ossec
  - [ ] logs - palo-alto-networks
  - [ ] logs - puppet
  - [ ] logs - wazuh
  - [ ] logs - windows-defender
  - [ ] logs - windows
  - [ ] logs - zeek
  - [ ] metrics - azure-monitor
  - [ ] metrics - system
  - [ ] shippers - filebeat

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
