### PR TITLE
remove cert warning from linux doc

### DIFF
--- a/_source/logzio_collections/_log-sources/linux.md
+++ b/_source/logzio_collections/_log-sources/linux.md
@@ -18,20 +18,6 @@ shipping-tags:
 Configuration tl;dr
 </summary>
 
-**Action required**:
-Starting May 26, 2020, we'll transition our listener servers
-to a new public SSL certificate.
-Before that date,
-you'll need to include both the old and new certificates
-in your configurations. \\
-\\
-**If you send encrypted data without using both certificates after May 26,
-that data might not arrive at your Logz.io account or be archived.** \\
-\\
-You can safely remove the old certificate
-after June 5, 2020.
-{:.info-box.warning}
-
 | Item | Description |
 |---|---|
 | Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-rsyslog-config.conf) |


### PR DESCRIPTION
# What changed

Removes the "update your public cert" warning from the linux doc. Was added in error. Not needed because Linux uses rsyslog.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-495--logz-docs.netlify.app/shipping/log-sources/linux.html

## Remaining work

<!-- List any outstanding work here -->
no remaining work

## Post launch

To be completed by the docs team upon merge:

no tasks

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
