### PR TITLE
add public cert update warning to logstash doc

### DIFF
--- a/_source/logzio_collections/_shippers/logstash.md
+++ b/_source/logzio_collections/_shippers/logstash.md
@@ -31,12 +31,26 @@ JDK,
 
 <div class="tasklist">
 
-##### Download the Logz.io certificate
+##### Download the Logz.io public certificate
+
+**Action required**:
+Starting May 26, 2020, we'll transition our listener servers
+to a new public SSL certificate.
+Before that date,
+you'll need to include both the old and new certificates
+in your configurations. \\
+\\
+**If you send encrypted data without using both certificates after May 26,
+that data might not arrive at your Logz.io account or be archived.** \\
+\\
+You can safely remove the old certificate
+after June 5, 2020.
+{:.info-box.warning}
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/logz-docs/master/certs/TrustExternalCARoot.crt -P /usr/share/logstash/keys/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -P /usr/share/logstash/keys/
 ```
 
 ##### _(If needed)_ Install the Lumberjack output plugin


### PR DESCRIPTION
# What changed

added the public cert warning to the logstash doc

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-497--logz-docs.netlify.app/shipping/shippers/logstash.html

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review

## Post launch

To be completed by the docs team upon merge:

- [ ] Update the logstash over ssl page in the app

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
