### PR TITLE
Deprecated APIs Removed In Kubernetes 1.16

### DIFF
--- a/shipping-config-samples/k8s-metricbeat-http.yml
+++ b/shipping-config-samples/k8s-metricbeat-http.yml
@@ -175,7 +175,7 @@ data:
         - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 ---
 # Deploy a Metricbeat instance per node for node metrics retrieval
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: metricbeat-new
@@ -183,6 +183,9 @@ metadata:
   labels:
     k8s-app: metricbeat
 spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
   template:
     metadata:
       labels:
@@ -372,7 +375,7 @@ metadata:
     k8s-app: metricbeat
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metricbeat
@@ -380,6 +383,9 @@ metadata:
   labels:
     k8s-app: metricbeat
 spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
   template:
     metadata:
       labels:

--- a/shipping-config-samples/k8s-metricbeat-https.yml
+++ b/shipping-config-samples/k8s-metricbeat-https.yml
@@ -175,7 +175,7 @@ data:
         - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 ---
 # Deploy a Metricbeat instance per node for node metrics retrieval
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: metricbeat-new
@@ -183,6 +183,9 @@ metadata:
   labels:
     k8s-app: metricbeat
 spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
   template:
     metadata:
       labels:
@@ -372,7 +375,7 @@ metadata:
     k8s-app: metricbeat
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metricbeat
@@ -380,6 +383,9 @@ metadata:
   labels:
     k8s-app: metricbeat
 spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
   template:
     metadata:
       labels:


### PR DESCRIPTION
# What changed

This pull request adds support for Kubernetes v1.16 which has deprecated older API's. [Reference](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
