### PR TITLE
Log shipping/use chained certs

### DIFF
--- a/_source/_includes/trust-chain-warning.html
+++ b/_source/_includes/trust-chain-warning.html
@@ -36,7 +36,8 @@
     Before {{cutoffDate}},
     you'll need to follow the instructions below
     to update your encrypted data shipping configurations
-    to include both the old and new certificates. <br>
+    to include both the old and new certificates.
+    Both of the certificates are contained in a single file.<br>
     <br>
     <b>If you send encrypted data without using both certificates after {{cutoffDate}},
     that data might not arrive at your Logz.io account or be archived.</b> <br>

--- a/_source/logzio_collections/_docs-admin/in-app-docs.md
+++ b/_source/logzio_collections/_docs-admin/in-app-docs.md
@@ -282,7 +282,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
 {:.paramlist}
 
@@ -299,7 +299,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
 {:.paramlist}
 

--- a/_source/logzio_collections/_log-sources/active-directory-winserver.md
+++ b/_source/logzio_collections/_log-sources/active-directory-winserver.md
@@ -24,10 +24,7 @@ shipping-tags:
 {% include trust-chain-warning.html %}
 
 Download the
-[new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)
-to `C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt`
-and the
-[old Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt)
+[Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt)
 to `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt`
 on your machine.
 
@@ -95,9 +92,7 @@ Winlogbeat can have one output only, so remove any other `output` entries.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - 'C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt'
-      - 'C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Restart Winlogbeat

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -47,7 +47,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Apache as an input

--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -23,7 +23,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | Ubuntu, Debian: `/var/log/apache2/access.log` <br> RHEL, CentOS, Fedora: `/var/log/httpd/access_log` |
 | Log type _\(for preconfigured parsing\)_ | `apache`, `apache_access`, or `apache-access`|
@@ -47,8 +47,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Apache as an input
@@ -135,9 +134,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/auditd.md
+++ b/_source/logzio_collections/_log-sources/auditd.md
@@ -31,8 +31,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Install Auditbeat
@@ -109,9 +108,7 @@ and replace it with this code block.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Auditbeat

--- a/_source/logzio_collections/_log-sources/auditd.md
+++ b/_source/logzio_collections/_log-sources/auditd.md
@@ -31,7 +31,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Install Auditbeat

--- a/_source/logzio_collections/_log-sources/check-point.md
+++ b/_source/logzio_collections/_log-sources/check-point.md
@@ -64,7 +64,7 @@ to restart the exporter.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add UDP traffic as an input

--- a/_source/logzio_collections/_log-sources/check-point.md
+++ b/_source/logzio_collections/_log-sources/check-point.md
@@ -64,8 +64,7 @@ to restart the exporter.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add UDP traffic as an input
@@ -131,9 +130,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/cisco-asa.md
+++ b/_source/logzio_collections/_log-sources/cisco-asa.md
@@ -41,8 +41,7 @@ on configuring your Cisco ASA firewall.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add TCP traffic as an input
@@ -108,9 +107,7 @@ If Logz.io is not an output, add it now.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/cisco-asa.md
+++ b/_source/logzio_collections/_log-sources/cisco-asa.md
@@ -41,7 +41,7 @@ on configuring your Cisco ASA firewall.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add TCP traffic as an input

--- a/_source/logzio_collections/_log-sources/fail2ban.md
+++ b/_source/logzio_collections/_log-sources/fail2ban.md
@@ -27,8 +27,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Fail2ban as an input
@@ -95,9 +94,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/fail2ban.md
+++ b/_source/logzio_collections/_log-sources/fail2ban.md
@@ -27,7 +27,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Fail2ban as an input

--- a/_source/logzio_collections/_log-sources/falco.md
+++ b/_source/logzio_collections/_log-sources/falco.md
@@ -183,7 +183,7 @@ Save and exit the falco.yaml file.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Configure Filebeat

--- a/_source/logzio_collections/_log-sources/falco.md
+++ b/_source/logzio_collections/_log-sources/falco.md
@@ -183,8 +183,7 @@ Save and exit the falco.yaml file.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Configure Filebeat
@@ -227,9 +226,7 @@ processors:
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Replace the placeholders in the Filebeat configuration

--- a/_source/logzio_collections/_log-sources/fortigate.md
+++ b/_source/logzio_collections/_log-sources/fortigate.md
@@ -51,7 +51,7 @@ end
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add UDP traffic as an input

--- a/_source/logzio_collections/_log-sources/fortigate.md
+++ b/_source/logzio_collections/_log-sources/fortigate.md
@@ -51,8 +51,7 @@ end
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add UDP traffic as an input
@@ -118,9 +117,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -47,8 +47,7 @@ Configuration tl;dr
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add GitLab as an input
@@ -158,9 +157,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -23,7 +23,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | If installed from Omnibus packages: `/var/log/gitlab/...` <br> If installed from source: `/home/git/gitlab/log/...` <br> _See [Log system](https://docs.gitlab.com/ee/administration/logs.html) from GitLab for more information._ |
 | Log type | Production, JSON: `gitlab-production-json` <br> Production, plain text: `gitlab-production` <br> API: `gitlab-api-json` <br> Application: `gitlab-application` |

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -47,7 +47,7 @@ Configuration tl;dr
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add GitLab as an input

--- a/_source/logzio_collections/_log-sources/hashicorp-vault.md
+++ b/_source/logzio_collections/_log-sources/hashicorp-vault.md
@@ -41,7 +41,7 @@ see [File Audit Device](https://www.vaultproject.io/docs/audit/file.html) from H
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Create your configuration file for Vault

--- a/_source/logzio_collections/_log-sources/hashicorp-vault.md
+++ b/_source/logzio_collections/_log-sources/hashicorp-vault.md
@@ -41,8 +41,7 @@ see [File Audit Device](https://www.vaultproject.io/docs/audit/file.html) from H
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Create your configuration file for Vault
@@ -102,9 +101,7 @@ processors:
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -65,7 +65,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Jenkins as an input

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -41,7 +41,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log location | `/var/log/jenkins/jenkins.log` |
 | Log type _\(for preconfigured parsing\)_ | `jenkins` |

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -65,8 +65,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Jenkins as an input
@@ -135,9 +134,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/json-uploads.md
+++ b/_source/logzio_collections/_log-sources/json-uploads.md
@@ -155,7 +155,7 @@ Keep to these practices when shipping JSON logs over TCP:
 To send JSON logs over TCP, download the Logz.io public certificate to a local folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 Using the certificate you just downloaded,

--- a/_source/logzio_collections/_log-sources/json-uploads.md
+++ b/_source/logzio_collections/_log-sources/json-uploads.md
@@ -155,8 +155,7 @@ Keep to these practices when shipping JSON logs over TCP:
 To send JSON logs over TCP, download the Logz.io public certificate to a local folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 Using the certificate you just downloaded,

--- a/_source/logzio_collections/_log-sources/juniper-srx.md
+++ b/_source/logzio_collections/_log-sources/juniper-srx.md
@@ -50,7 +50,7 @@ See [Juniper SRX docs](https://kb.juniper.net/InfoCenter/index?page=content&id=K
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Configure Filebeat

--- a/_source/logzio_collections/_log-sources/juniper-srx.md
+++ b/_source/logzio_collections/_log-sources/juniper-srx.md
@@ -50,8 +50,7 @@ See [Juniper SRX docs](https://kb.juniper.net/InfoCenter/index?page=content&id=K
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Configure Filebeat
@@ -101,9 +100,7 @@ Copy and paste the following code block directly below. It sets Logz.io as the o
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Replace the placeholders in the Filebeat configuration

--- a/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
+++ b/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
@@ -48,7 +48,7 @@ sudo openssl req -newkey rsa:2048 -nodes \
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add TCP traffic as an input

--- a/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
+++ b/_source/logzio_collections/_log-sources/mcafee-epolicy-orchestrator.md
@@ -48,8 +48,7 @@ sudo openssl req -newkey rsa:2048 -nodes \
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add TCP traffic as an input
@@ -119,9 +118,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -38,7 +38,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | General query log: `/var/log/mysql/mysql.log` <br> Slow query log: `/var/log/mysql/mysql-slow.log` <br> Error log: `/var/log/mysql/error.log` |
 | Log type _(for preconfigured parsing)_ | General query log: `mysql` <br> Slow query log: `mysql_slow_query` <br> Error log: `mysql_error` |

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -81,7 +81,7 @@ sudo /etc/init.d/mysql restart
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add MySQL as an input

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -81,8 +81,7 @@ sudo /etc/init.d/mysql restart
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add MySQL as an input
@@ -182,9 +181,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/network-device.md
+++ b/_source/logzio_collections/_log-sources/network-device.md
@@ -32,8 +32,7 @@ See your device's documentation if you're not sure how to do this.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add TCP traffic as an input
@@ -99,9 +98,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/network-device.md
+++ b/_source/logzio_collections/_log-sources/network-device.md
@@ -32,7 +32,7 @@ See your device's documentation if you're not sure how to do this.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add TCP traffic as an input

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -48,8 +48,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add nginx as an input
@@ -130,9 +129,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -48,7 +48,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add nginx as an input

--- a/_source/logzio_collections/_log-sources/nginx.md
+++ b/_source/logzio_collections/_log-sources/nginx.md
@@ -24,7 +24,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | `/var/log/nginx/access.log` or `/var/log/nginx/error.log` |
 | Log type _(for preconfigured parsing)_ | Access log: `nginx`, `nginx_access`, or `nginx-access` <br> Error log: `nginx-error` |

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -23,7 +23,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | JSON _(recommended)_: `/var/ossec/logs/alerts/alerts.json` <br> Plain text: `/var/ossec/logs/alerts/alerts.log` |
 {:.paramlist}

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -63,7 +63,7 @@ sudo /var/ossec/bin/ossec-control restart
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add OSSEC as an input

--- a/_source/logzio_collections/_log-sources/ossec.md
+++ b/_source/logzio_collections/_log-sources/ossec.md
@@ -63,8 +63,7 @@ sudo /var/ossec/bin/ossec-control restart
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add OSSEC as an input
@@ -131,9 +130,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/palo-alto-networks.md
+++ b/_source/logzio_collections/_log-sources/palo-alto-networks.md
@@ -96,7 +96,7 @@ and click the **Commit** button to save.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add TCP traffic as an input

--- a/_source/logzio_collections/_log-sources/palo-alto-networks.md
+++ b/_source/logzio_collections/_log-sources/palo-alto-networks.md
@@ -96,8 +96,7 @@ and click the **Commit** button to save.
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add TCP traffic as an input
@@ -163,9 +162,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -47,7 +47,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Puppet as an input

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -47,8 +47,7 @@ root access
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Puppet as an input
@@ -145,9 +144,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -23,7 +23,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log location | _Puppet produces lots of different logs. See [Log files installed](https://puppet.com/docs/pe/2018.1/what_gets_installed_and_where.html#log-files-installed) from Puppet Labs for more information._ |
 | Log type _\(for preconfigured parsing\)_ | Puppet server: `puppetserver` <br> Puppet server access: `puppetserver-access` |

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -62,8 +62,7 @@ sudo systemctl restart wazuh-manager
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Wazuh as an input
@@ -130,9 +129,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -23,7 +23,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 | Default log locations | JSON _(recommended)_: `/var/ossec/logs/alerts/alerts.json` <br> Plain text: `/var/ossec/logs/alerts/alerts.log` |
 {:.paramlist}

--- a/_source/logzio_collections/_log-sources/wazuh.md
+++ b/_source/logzio_collections/_log-sources/wazuh.md
@@ -62,7 +62,7 @@ sudo systemctl restart wazuh-manager
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Wazuh as an input

--- a/_source/logzio_collections/_log-sources/windows-defender.md
+++ b/_source/logzio_collections/_log-sources/windows-defender.md
@@ -63,10 +63,7 @@ Now click **OK** to exit all those dialogs you just opened. 😬
 {% include trust-chain-warning.html %}
 
 Download the
-[new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)
-to `C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt`
-and the
-[old Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt)
+[Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt)
 to `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt`
 on your machine.
 
@@ -131,9 +128,7 @@ Winlogbeat can have one output only, so remove any other `output` entries.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - 'C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt'
-      - 'C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Restart Winlogbeat

--- a/_source/logzio_collections/_log-sources/windows.md
+++ b/_source/logzio_collections/_log-sources/windows.md
@@ -33,10 +33,7 @@ shipping-tags:
 {% include trust-chain-warning.html %}
 
 Download the
-[new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)
-to `C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt`
-and the
-[old Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt)
+[Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt)
 to `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt`
 on your machine.
 
@@ -100,9 +97,7 @@ Winlogbeat can have one output only, so remove any other `output` entries.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - 'C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt'
-      - 'C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt
+    certificate_authorities: ['C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Restart Winlogbeat

--- a/_source/logzio_collections/_log-sources/zeek.md
+++ b/_source/logzio_collections/_log-sources/zeek.md
@@ -45,7 +45,7 @@ const use_json = T &redef;
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Zeek as an input

--- a/_source/logzio_collections/_log-sources/zeek.md
+++ b/_source/logzio_collections/_log-sources/zeek.md
@@ -45,8 +45,7 @@ const use_json = T &redef;
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Zeek as an input
@@ -136,9 +135,7 @@ Remove all other outputs.
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
   ssl:
-    certificate_authorities:
-      - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-      - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### Start Filebeat

--- a/_source/logzio_collections/_metrics-sources/azure-monitor.md
+++ b/_source/logzio_collections/_metrics-sources/azure-monitor.md
@@ -89,7 +89,7 @@ For HTTPS shipping, download the Logz.io public certificate to your certificate 
 You'll need to run this command on the server that hosts Metricbeat:
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### _(Optional)_ Disable the system module

--- a/_source/logzio_collections/_metrics-sources/azure-monitor.md
+++ b/_source/logzio_collections/_metrics-sources/azure-monitor.md
@@ -89,8 +89,7 @@ For HTTPS shipping, download the Logz.io public certificate to your certificate 
 You'll need to run this command on the server that hosts Metricbeat:
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### _(Optional)_ Disable the system module

--- a/_source/logzio_collections/_metrics-sources/azure-monitor.md
+++ b/_source/logzio_collections/_metrics-sources/azure-monitor.md
@@ -136,9 +136,7 @@ ignore_older: 3hr
 type: metrics
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
-  ssl.certificate_authorities:
-    - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-    - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+  ssl.certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ###### Parameters

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -38,7 +38,7 @@ shipping-tags:
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Logz.io configuration

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -38,8 +38,7 @@ shipping-tags:
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Add Logz.io configuration

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -66,9 +66,7 @@ Remove all other outputs.
 # ===== Outputs =====
 output.logstash:
   hosts: ["<<LISTENER-HOST>>:5015"]
-  ssl.certificate_authorities:
-    - '/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt'
-    - '/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt'
+    ssl.certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
 ```
 
 ##### _(If needed)_ Enable the system module

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -62,8 +62,7 @@ Configuration tl;dr
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs/
+sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Make your configuration file
@@ -105,10 +104,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 Download the
-[new Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt)
-to `C:\ProgramData\Winlogbeat\SectigoRSADomainValidationSecureServerCA.crt`
-and the
-[old Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt)
+[Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt)
 to `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt`
 on your machine.
 

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -31,7 +31,7 @@ Configuration tl;dr
 
 | Item | Description |
 |---|---|
-| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> **Use both certificates**: [New public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt) and [Old public certificate (_until June 5, 2020_)](https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt) |
+| Files | [Sample configuration](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/logz-filebeat-config.yml) <br> [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt) |
 | Listener | Port 5015. For help finding your region's listener host, see [Account region]({{site.baseurl}}/user-guide/accounts/account-region.html). |
 {:.paramlist}
 

--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -62,7 +62,7 @@ Configuration tl;dr
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -O /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 ##### Make your configuration file

--- a/_source/logzio_collections/_shippers/logstash.md
+++ b/_source/logzio_collections/_shippers/logstash.md
@@ -38,8 +38,7 @@ JDK,
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt \
--O /usr/share/logstash/keys/TrustExternalCARoot.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /usr/share/logstash/keys/TrustExternalCARoot.crt
 ```
 
 ##### _(If needed)_ Install the Lumberjack output plugin

--- a/_source/logzio_collections/_shippers/logstash.md
+++ b/_source/logzio_collections/_shippers/logstash.md
@@ -39,7 +39,7 @@ For HTTPS shipping, download the Logz.io public certificate to your certificate 
 
 ```shell
 sudo wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt \
--P /usr/share/logstash/keys/TrustExternalCARoot.crt
+-O /usr/share/logstash/keys/TrustExternalCARoot.crt
 ```
 
 ##### _(If needed)_ Install the Lumberjack output plugin


### PR DESCRIPTION
# What changed

Updated log shipping configurations to use chained cert. This means we can continue to use the same filename, and users won't have to update their configurations. They will still need to restart their shippers, but that's it.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
See https://deploy-preview-500--logz-docs.netlify.app/shipping/

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review

## Post launch

To be completed by the docs team upon merge:

- [x] Teams to update with the new information: Support & CSEs
- Update these log shipping pages in the app:
  - Logs:
    - [x] active-directory-winserver - liveanu
    - [x] apache - liveanu
    - [x] auditd - liveanu
    - [x] check-point - liveanu
    - [x] cisco-asa - liveanu
    - [x] fail2ban - liveanu
    - [x] falco - liveanu
    - [x] fortigate - liveanu
    - [x] gitlab - liveanu
    - [x] hashicorp-vault - irit
    - [x] jenkins - irit
    - [x] json-uploads - irit
    - [x] juniper-srx - irit
    - [x] mcafee-epolicy-orchestrator - irit
    - [x] mysql - irit
    - [x] network-device - itai
    - [x] nginx - itai
    - [x] ossec - itai
    - [x] palo-alto-networks - itai
    - [x] puppet - itai
    - [x] wazuh - itai
    - [x] windows-defender - arie
    - [x] windows - arie
    - [x] zeek - arie
  - Metrics:
    - [x] azure-monitor - arie
    - [x] system - arie
  - Shippers:
    - [x] filebeat - shalom
    - [x] logstash - shalom