### PR TITLE
Update filebeat.md

### DIFF
--- a/_source/logzio_collections/_shippers/filebeat.md
+++ b/_source/logzio_collections/_shippers/filebeat.md
@@ -105,7 +105,7 @@ For HTTPS shipping, download the Logz.io public certificate to your certificate 
 
 Download the
 [Logz.io public certificate](https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt)
-to `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt`
+to `C:\ProgramData\Filebeat\COMODORSADomainValidationSecureServerCA.crt`
 on your machine.
 
 ##### Make your configuration file


### PR DESCRIPTION
windows page had a cert path to winlogbeat instead of filebeat

# What changed
windows page had a cert path to winlogbeat instead of filebeat

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->
