### PR TITLE
Log shipping/logstash plugin

### DIFF
--- a/_source/_includes/trust-chain-warning.html
+++ b/_source/_includes/trust-chain-warning.html
@@ -19,14 +19,17 @@
     <b>Action required before {{cutoffDate}}</b>:
     The trust chain previously provided here will expire on May 30,
     and encrypted communication will stop working.
-    We'll transition our data receivers to a new certificate on {{cutoffDate}}.
+    We'll transition our data receivers to a new certificate on {{cutoffDate}}.<br>
+    <br>
     Before {{cutoffDate}},
     you'll need to follow the instructions below
-    to update your encrypted data shipping configurations
-    to include both the old and new certificates.
-    Both of the certificates are contained in a single file. <br>
+    to replace the existing Logstash plugin
+    with a new plugin that can handle multiple certificates.
+    You'll also overwrite your certificate
+    with a new file that contains all the required certificates.<br>
     <br>
-    <b>If you send encrypted data without using both certificates after {{cutoffDate}},
+    <b>If you send encrypted data after {{cutoffDate}}
+    without updating your certificate file,
     that data might not arrive at your Logz.io account or be archived.</b>
   {%- else -%}
     <b>Action required before {{cutoffDate}}</b>:

--- a/_source/_includes/trust-chain-warning.html
+++ b/_source/_includes/trust-chain-warning.html
@@ -1,11 +1,11 @@
-{%- assign cutoffDate = 'May 28' -%}
+{%- assign cutoffDate = 'May 28, 2020 at 13:00 UTC' -%}
 
 <p class="info-box warning">
 
 {% case include.msg -%}
   {%- when 'docker' -%}
-    <b>Action required before {{cutoffDate}}, 2020</b>:
-    The trust chain provided here will expire on May 30,
+    <b>Action required before {{cutoffDate}}</b>:
+    The trust chain previously provided here will expire on May 30,
     and encrypted communication will stop working.
     We'll transition our data receivers to a new certificate on {{cutoffDate}}.
     Before {{cutoffDate}},
@@ -16,8 +16,8 @@
     <b>If you send encrypted data without using both certificates after {{cutoffDate}},
     that data might not arrive at your Logz.io account or be archived.</b>
   {%- when 'logstash' -%}
-    <b>Action required before {{cutoffDate}}, 2020</b>:
-    The trust chain provided here will expire on May 30,
+    <b>Action required before {{cutoffDate}}</b>:
+    The trust chain previously provided here will expire on May 30,
     and encrypted communication will stop working.
     We'll transition our data receivers to a new certificate on {{cutoffDate}}.
     Before {{cutoffDate}},
@@ -29,8 +29,8 @@
     <b>If you send encrypted data without using both certificates after {{cutoffDate}},
     that data might not arrive at your Logz.io account or be archived.</b>
   {%- else -%}
-    <b>Action required before {{cutoffDate}}, 2020</b>:
-    The trust chain provided here will expire on May 30,
+    <b>Action required before {{cutoffDate}}</b>:
+    The trust chain previously provided here will expire on May 30,
     and encrypted communication will stop working.
     We'll transition our data receivers to a new certificate on {{cutoffDate}}.
     Before {{cutoffDate}},

--- a/_source/logzio_collections/_shippers/logstash.md
+++ b/_source/logzio_collections/_shippers/logstash.md
@@ -38,28 +38,43 @@ JDK,
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
 ```shell
-sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /usr/share/logstash/keys/TrustExternalCARoot.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/QuadCA.crt --create-dirs -o /usr/share/logstash/keys/TrustExternalCARoot.crt
 ```
 
-##### _(If needed)_ Install the Lumberjack output plugin
+##### Remove the Lumberjack output plugin
 
-The Lumberjack output plugin is required for SSL shipping.
-For most Logstash versions, the plugin is included by default.
+For most Logstash versions,
+the Lumberjack plugin is included by default.
+In the next step, you'll install Logz.io Lumberjack,
+which can't run alongside the original Lumberjack plugin,
+so you'll need to remove the original plugin if it's installed.
 
 To see if Lumberjack output plugin is installed,
-`cd` to your [Logstash bin directory](https://www.elastic.co/guide/en/logstash/current/dir-layout.html)
+`cd` to your
+[Logstash bin directory](https://www.elastic.co/guide/en/logstash/current/dir-layout.html)
 and run this command:
 
 ```shell
 ./logstash-plugin list | grep logstash-output-lumberjack
 ```
 
-If you see `logstash-output-lumberjack`, skip to step 3.
+If you don't see `logstash-output-lumberjack`, skip to step 3.
 
-Otherwise, you'll need to install the plugin.
+Otherwise, you'll need to remove the plugin.
 
 ```shell
-./logstash-plugin install logstash-output-lumberjack
+./logstash-plugin remove logstash-output-lumberjack
+```
+
+##### Install the Logz.io Lumberjack output plugin
+
+The Logz.io Lumberjack output plugin is required for SSL shipping.
+Run this command from your
+[Logstash bin directory](https://www.elastic.co/guide/en/logstash/current/dir-layout.html)
+to install the plugin:
+
+```shell
+./logstash-plugin install logstash-output-lumberjack-logzio
 ```
 
 ##### Add Logz.io to your configuration file

--- a/_source/logzio_collections/_technical-notes/chain-of-trust.md
+++ b/_source/logzio_collections/_technical-notes/chain-of-trust.md
@@ -50,19 +50,16 @@ This also does not affect any of the code libraries covered in the docs.
 ## How to replace your certificate
 
 The actions you need to take depend on how you’re shipping your data.
-For shipping methods covered in the docs, these fall into two main categories:
+For shipping methods covered in the docs,
+we've covered the main update processes here:
 
-* **If you're using a Beats family shipper** (such as Filebeat or Metricbeat):
-  See _[To replace the certificate file for Beats](#replace-the-cert-file)_ (below)
-* **If you're shipping with rsyslog**:
-  See
-  _[To check your rsyslog configuration](#check-rsyslog-config)_
-  (below)
-* **If you deployed a Docker container managed by Logz.io**:
-  See _[To update a Docker container](#update-container)_ (below)
-* **If you deployed the Kubernetes Metricbeat configmap**:
-  Re-deploy using the instructions in
-  _[Ship Kubernetes metrics]({{site.baseurl}}/shipping/metrics-sources/kubernetes.html)_
+| For this shipping method... | ...see these instructions |
+|---|---|---|
+| Beats family shipper (such as Filebeat or Metricbeat) | See _[To replace the certificate file for Beats](#replace-the-cert-file)_ (below) |
+| Logstash over SSL | See _[To configure Logstash for multiple certificates](#logstash-multiple-certs)_ (below) |
+| rsyslog | See _[To check your rsyslog configuration](#check-rsyslog-config)_ (below) |
+| A Docker image managed by Logz.io | See _[To update a Docker container](#update-container)_ (below) |
+| The Kubernetes Metricbeat daemonset | Re-deploy using the instructions in _[Ship Kubernetes metrics]({{site.baseurl}}/shipping/metrics-sources/kubernetes.html)_ |
 
 #### To replace the certificate file for Beats {#replace-the-cert-file}
 

--- a/_source/logzio_collections/_technical-notes/chain-of-trust.md
+++ b/_source/logzio_collections/_technical-notes/chain-of-trust.md
@@ -57,8 +57,8 @@ we've covered the main update processes here:
 |---|---|---|
 | Beats family shipper (such as Filebeat or Metricbeat) | See _[To replace the certificate file for Beats](#replace-the-cert-file)_ (below) |
 | Logstash over SSL | See _[To configure Logstash for multiple certificates](#logstash-multiple-certs)_ (below) |
-| rsyslog | See _[To check your rsyslog configuration](#check-rsyslog-config)_ (below) |
 | A Docker image managed by Logz.io | See _[To update a Docker container](#update-container)_ (below) |
+| rsyslog | See _[To check your rsyslog configuration](#check-rsyslog-config)_ (below) |
 | The Kubernetes Metricbeat daemonset | Re-deploy using the instructions in _[Ship Kubernetes metrics]({{site.baseurl}}/shipping/metrics-sources/kubernetes.html)_ |
 
 #### To replace the certificate file for Beats {#replace-the-cert-file}

--- a/_source/logzio_collections/_technical-notes/chain-of-trust.md
+++ b/_source/logzio_collections/_technical-notes/chain-of-trust.md
@@ -52,8 +52,8 @@ This also does not affect any of the code libraries covered in the docs.
 The actions you need to take depend on how you’re shipping your data.
 For shipping methods covered in the docs, these fall into two main categories:
 
-* **If you're managing a shipping app** (such as Filebeat or Metricbeat):
-  See _[To replace the certificate file](#replace-the-cert-file)_ (below)
+* **If you're using a Beats family shipper** (such as Filebeat or Metricbeat):
+  See _[To replace the certificate file for Beats](#replace-the-cert-file)_ (below)
 * **If you're shipping with rsyslog**:
   See
   _[To check your rsyslog configuration](#check-rsyslog-config)_
@@ -64,7 +64,7 @@ For shipping methods covered in the docs, these fall into two main categories:
   Re-deploy using the instructions in
   _[Ship Kubernetes metrics]({{site.baseurl}}/shipping/metrics-sources/kubernetes.html)_
 
-#### To replace the certificate file {#replace-the-cert-file}
+#### To replace the certificate file for Beats {#replace-the-cert-file}
 
 This covers instructions for any of the Beats shippers
 (such as Filebeat, Metricbeat, Winlogbeat, or Auditbeat)
@@ -106,12 +106,6 @@ Download the
 * For **Winlogbeat**: Copy to `C:\ProgramData\Winlogbeat\COMODORSADomainValidationSecureServerCA.crt`
 * For **Filebeat**: Copy to `C:\ProgramData\Filebeat\Logzio.crt`
 
-###### For Logstash over SSL
-
-```shell
-sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /usr/share/logstash/keys/TrustExternalCARoot.crt
-```
-
 ##### Check your configuration
 
 Double-check your shipper's configuration file
@@ -121,16 +115,8 @@ If the certificate location in the configuration doesn't match
 where you downloaded the file to,
 update the configuration or move the certificate.
 
-###### For a Beats family shipper
-
 The certificate is included
 in the `ssl.certificate_authorities` array
-in your configuration file.
-
-###### For Logstash over SSL
-
-The certificate is included
-in `output` > `lumberjack` > `ssl_certificate` setting
 in your configuration file.
 
 ##### Restart your shipper and test

--- a/_source/logzio_collections/_technical-notes/chain-of-trust.md
+++ b/_source/logzio_collections/_technical-notes/chain-of-trust.md
@@ -125,6 +125,58 @@ for information on our testing listeners.
 
 </div>
 
+#### To configure Logstash for multiple certificates {#logstash-multiple-certs}
+
+The default Lumberjack plugin
+is limited to using one certificate at a time.
+We've released a fork of the plugin
+that allows you to use multiple certificates,
+allowing an uninterrupted data flow
+while we update our listeners to the new chain of trust.
+
+This means that
+you'll need to replace the plugin _and_ the certificate
+wherever you're using Logstash to ship over SSL.
+
+The new Logz.io Lumberjack plugin retains the same name
+in your configuration file,
+so there's no need to update the configuration itself.
+
+<div class="tasklist">
+
+##### Download the Logz.io public certificates
+
+This will overwrite your current certificate file.
+Double-check your Logstash configuration to make sure
+it's pointing to this file location:
+
+```shell
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/QuadCA.crt --create-dirs -o /usr/share/logstash/keys/TrustExternalCARoot.crt
+```
+
+##### Replace the Logstash output plugin
+
+From your
+[Logstash bin directory](https://www.elastic.co/guide/en/logstash/current/dir-layout.html),
+replace the default Logstash plugin
+with the Logz.io Logstash plugin:
+
+```shell
+./logstash-plugin remove logstash-output-lumberjack
+./logstash-plugin install logstash-output-lumberjack-logzio
+```
+
+You don't need to update your configuration file.
+
+##### Restart Logstash and test
+
+Restart Logstash to load the new plugin and certificates.
+
+See _[Testing your new configuration](#testing)_ (below)
+for information on our testing listeners.
+
+</div>
+
 #### To update a Docker container {#update-container}
 
 This covers instructions for any of the


### PR DESCRIPTION
# What changed

In the Logstash shipping page:

* new logstash plugin, including quad cert file
* updated warning for logstash
* added cutover time to the warning message

In the chain of trust technical note:

* reorganize the procedures into a table, making it easier to follow
* remove logstash from the "replace your cert" procedure
* new logstash procedure

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- The Logstash shipper doc: https://deploy-preview-515--logz-docs.netlify.app/shipping/shippers/logstash.html
- The chain of trust technical note: https://deploy-preview-515--logz-docs.netlify.app/technical-notes/chain-of-trust/#logstash-multiple-certs

## Remaining work

<!-- List any outstanding work here -->
- [x] Technical review
- [x] Copy Review

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information: liveanu
- [ ] Update the logstash over ssl page in contentful
- [ ] Update the warning images in S3

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
