### PR TITLE
Docs tooling/protect master

### DIFF
--- a/.githooks/pre-commit/protect-local-master.sh
+++ b/.githooks/pre-commit/protect-local-master.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# prevent commit to local master branch
+
+branch=`git symbolic-ref HEAD`
+if [ "$branch" = "refs/heads/master" ]; then
+    echo "pre-commit hook: master branch is protected. Make your changes on a new branch and merge to master through a pull request."
+    exit 1
+fi
+
+exit 0

--- a/.githooks/pre-push/protect-remote-master.sh
+++ b/.githooks/pre-push/protect-remote-master.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Prevent push to remote master branch
+
+while read local_ref local_sha remote_ref remote_sha
+do
+	if [ "$remote_ref" = "refs/heads/master" ]; then
+    echo "pre-push hook: master branch is protected. Make your changes on a new branch and merge to master through a pull request."
+		exit 1
+	fi
+done
+
+exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -505,6 +505,12 @@
         "pump": "^3.0.0"
       }
     },
+    "git-hooks": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/git-hooks/-/git-hooks-1.1.10.tgz",
+      "integrity": "sha512-23nto1qLsqJdY0daAUYqeKPyTvzefR2wZv1krgFRnPg0FxrmITCeWAIv/QfR+fAD7eZC7Rp5OSicJB4hDKyp1A==",
+      "dev": true
+    },
     "global": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,5 +37,7 @@
     "styled-components": "^4.4.1",
     "tablesorter": "^2.31.2"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "git-hooks": "^1.1.10"
+  }
 }


### PR DESCRIPTION
# What changed

- added npm dev dependency to manage githooks through git
- added scripts to protect master branch from commits & pushes

----

No review necessary. Just make sure everyone runs `npm install` so they get the githooks scripts working. 