### PR TITLE
Changing cloudwatch agent instructions on docker shipper tab

### DIFF
--- a/_source/logzio_collections/_metrics-sources/ec2.md
+++ b/_source/logzio_collections/_metrics-sources/ec2.md
@@ -139,12 +139,8 @@ If you want, you can also monitor advanced EC2 metrics, including disk memory an
 
 To enable this option, you’ll need to install and configure a CloudWatch agent on your machine and specify the **CWAgent** namespace under the AWS_NAMESPACES parameter. For example:
 
-```yml
-metricsets:
-    - cloudwatch
-  metrics: #specify aws namespaces you want to monitor, just add namspaces from AWS list
-    - namespace: AWS/EC2
-    - namespace: CWAgent
+```shell
+--env AWS_NAMESPACES="CWAgent,AWS/EC2"
 ```
 
 For additional instructions, see more about [installing the CloudWatch agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Agent-on-EC2-Instance.html) and [configuring it](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create-cloudwatch-agent-configuration-file-wizard.html).


### PR DESCRIPTION
The current instruction are not applicable on our docker shipper, so i changed it to valid instructions.

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-569--logz-docs.netlify.app/shipping/metrics-sources/ec2.html