### PR TITLE
Update Okta with multiple tenants

### DIFF
--- a/_source/logzio_collections/_log-sources/okta.md
+++ b/_source/logzio_collections/_log-sources/okta.md
@@ -11,9 +11,11 @@ shipping-tags:
   - security
 ---
 
+# logzio-okta
+
 To ship Okta logs,
 you'll deploy a Docker container
-to collect the logs and forward them to Logz.io.
+to collect the logs and forward them to Logz.io using Logstash.
 
 #### Configuration
 
@@ -22,7 +24,7 @@ Okta administrator privileges
 
 <div class="tasklist">
 
-##### Get the API token and issuer URI from Okta
+#### Get the API token and Okta domain from Okta
 
 In the Okta developer console,
 navigate to **API > Tokens**.
@@ -31,14 +33,12 @@ Create a token and paste it in your text editor.
 ![Create Okta API token](https://dytvr9ot2sszz.cloudfront.net/logz-docs/log-shipping/okta-create-token.png)
 
 Click the **Authorization Servers** tab.
-Copy your Okta subdomain from the **Issuer URI** column,
-and paste it in your text editor.
+Copy your Okta domain from the **Issuer URI** column,
+and paste it in your text editor. In the following example, you'd have copied "dev-123456.okta.com".
 
 ![Okta URL](https://dytvr9ot2sszz.cloudfront.net/logz-docs/log-shipping/okta-issuer-uri.png)
 
-In the example above, you'd have copied "dev-123456".
-
-##### Pull the Docker image
+#### Pull the Docker image
 
 Download the logzio/logzio-okta image.
 
@@ -46,35 +46,78 @@ Download the logzio/logzio-okta image.
 docker pull logzio/logzio-okta
 ```
 
-##### Run the Docker image
+#### Run the Docker image
 
-For a complete list of options, see the parameters below the code block.👇
+Build your tenants-credentials.yml:
+
+``` 
+touch tenants-credentials.yml
+```
+
+Insert your tenants credentials in the following format:
+```
+tenants_credentials:
+    - okta_api_key: <<OKTA-API-KEY>
+      okta_domain: <<OKTA-DOMAIN>>
+```
+
+This shipper supports up to 50 tenants. For multiple tenants, add your Okta API key and domain for each tenant. See the following example:
+```
+tenants_credentials:
+    - okta_api_key: 123456a
+      okta_domain: logzio-dev-123.okta.com
+    - okta_api_key: 123456b
+      okta_domain: logzio-dev-123.okta.com
+    - okta_api_key: 123456c
+      okta_domain: logzio-dev-123.oktapreview.com
+```
+** Note that YAML files are sensitive to spaces and tabs. We recommend using a YAML validator to make sure that the file structure is correct. 
+
+
+#### Parameters
+For every tenant replace the parameters by:  
+
+| Parameter | Description |
+|---|---|
+| OKTA_API_KEY <span class="required-param"></span> | The Okta API key you copied in step 1. |
+| OKTA_DOMAIN <span class="required-param"></span> | Insert your Okta domain that you copied in step 1 from the issuer URI column. Supports these [Okta domains](https://developer.okta.com/docs/guides/find-your-domain/findorg/): example.oktapreview.com, example.okta.com, example.okta-emea.com |
+
+Save the file on your working directory (where you're running the docker from) and run:
 
 ```shell
 docker run \
---detach \
 --restart always \
 --name Okta \
 --env LOGZIO_TOKEN=<<SHIPPING-TOKEN>> \
 --env LOGZIO_LISTENER_HOST=<<LISTENER-HOST>> \
---env OKTA_API_KEY=<<OKTA-API-KEY>> \
---env OKTA_TENANT=<<OKTA-ISSUER-URI>> \
+-v $(pwd)/tenants-credentials.yml:/usr/share/logstash/tenants-credentials.yml \
 -t logzio/logzio-okta
 ```
 
-###### Parameters
+#### Parameters
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account token. {% include log-shipping/replace-vars.html token=true %} <!-- logzio-inject:account-token --> |
-| LOGZIO_LISTENER_HOST <span class="required-param"></span> | Logz.io listener URL to ship the logs to. {% include log-shipping/replace-vars.html listener=true %} |
-| OKTA_API_KEY <span class="required-param"></span> | The Okta API key you copied in step 1. |
-| OKTA_TENANT <span class="required-param"></span> | The Okta issuer URI you copied in step 1. |
-{:.paramlist}
+| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account [token]((https://app.logz.io/#/dashboard/settings/general)). |
+| LOGZIO_LISTENER_HOST <span class="required-param"></span> | Logz.io [listener URL](https://docs.logz.io/user-guide/accounts/account-region.html) to ship the logs to (for example, listener.logz.io). |
 
-##### Check Logz.io for your logs
+
+#### Check Logz.io for your logs
 
 Give your logs some time to get from your system to ours,
 and then open [Kibana](https://app.logz.io/#/dashboard/kibana).
 
+
+## Versions
+
+0.1.0:
+* Sending logs from multiple Okta tenants
+* Sending logs with from every kind of okta domain (not limited to 'okta.com')
+* Note that 'okta_api_key' and 'okta_domain' are now being set in 'tenants-credentials.yml' and no longer as environment parameters.
+
+0.0.2:
+* Sending logs from Okta tenants
+
 </div>
+
+

--- a/_source/logzio_collections/_log-sources/okta.md
+++ b/_source/logzio_collections/_log-sources/okta.md
@@ -7,24 +7,27 @@ data-source: Okta
 templates: ["docker"]
 contributors:
   - imnotashrimp
+  - ronish31
+  - shalper
 shipping-tags:
   - security
 ---
-
-# logzio-okta
 
 To ship Okta logs,
 you'll deploy a Docker container
 to collect the logs and forward them to Logz.io using Logstash.
 
+You can send logs from multiple Okta tenants and very every kind of okta domain.
+
 #### Configuration
 
 **Before you begin, you'll need**:
-Okta administrator privileges
+
+* Okta administrator privileges
 
 <div class="tasklist">
 
-#### Get the API token and Okta domain from Okta
+##### Get the API token and Okta domain from Okta
 
 In the Okta developer console,
 navigate to **API > Tokens**.
@@ -38,30 +41,32 @@ and paste it in your text editor. In the following example, you'd have copied "d
 
 ![Okta URL](https://dytvr9ot2sszz.cloudfront.net/logz-docs/log-shipping/okta-issuer-uri.png)
 
-#### Pull the Docker image
+##### Pull the Docker image
 
-Download the logzio/logzio-okta image.
+Download the logzio/logzio-okta Docker image:
 
 ```shell
 docker pull logzio/logzio-okta
 ```
 
-#### Run the Docker image
+##### Create your tenants-credentials YAML
 
 Build your tenants-credentials.yml:
 
-``` 
+```
 touch tenants-credentials.yml
 ```
 
-Insert your tenants credentials in the following format:
+Insert your tenants credentials into the YAML file in the following format:
+
 ```
 tenants_credentials:
-    - okta_api_key: <<OKTA-API-KEY>
+    - okta_api_key: <<OKTA-API-KEY>>
       okta_domain: <<OKTA-DOMAIN>>
 ```
 
 This shipper supports up to 50 tenants. For multiple tenants, add your Okta API key and domain for each tenant. See the following example:
+
 ```
 tenants_credentials:
     - okta_api_key: 123456a
@@ -71,18 +76,24 @@ tenants_credentials:
     - okta_api_key: 123456c
       okta_domain: logzio-dev-123.oktapreview.com
 ```
-** Note that YAML files are sensitive to spaces and tabs. We recommend using a YAML validator to make sure that the file structure is correct. 
 
 
-#### Parameters
-For every tenant replace the parameters by:  
+###### Parameters
 
 | Parameter | Description |
 |---|---|
-| OKTA_API_KEY <span class="required-param"></span> | The Okta API key you copied in step 1. |
-| OKTA_DOMAIN <span class="required-param"></span> | Insert your Okta domain that you copied in step 1 from the issuer URI column. Supports these [Okta domains](https://developer.okta.com/docs/guides/find-your-domain/findorg/): example.oktapreview.com, example.okta.com, example.okta-emea.com |
+| OKTA_API_KEY <span class="required-param"></span> | The Okta API key copied in step 1. |
+| OKTA_DOMAIN <span class="required-param"></span> | The Okta domain copied in step 1. It is found under the **Issuer URI column** in your Okta developer console. <br> Supports these [Okta domains](https://developer.okta.com/docs/guides/find-your-domain/findorg/): <br> example.oktapreview.com, example.okta.com, example.okta-emea.com |
 
-Save the file on your working directory (where you're running the docker from) and run:
+Save the file on your working directory. That's the same one you're running the docker from.
+
+YAML files are sensitive to spaces and tabs. It's a good idea to run your code through a YAML validator to make sure that its structure is correct.
+{:.info-box.tip}
+
+
+##### Run the Docker image
+
+Replace the placeholders in the code sample below before running it. Run:
 
 ```shell
 docker run \
@@ -94,30 +105,18 @@ docker run \
 -t logzio/logzio-okta
 ```
 
-#### Parameters
+###### Parameters
 
 | Parameter | Description |
 |---|---|
-| LOGZIO_TOKEN <span class="required-param"></span> | Your Logz.io account [token]((https://app.logz.io/#/dashboard/settings/general)). |
-| LOGZIO_LISTENER_HOST <span class="required-param"></span> | Logz.io [listener URL](https://docs.logz.io/user-guide/accounts/account-region.html) to ship the logs to (for example, listener.logz.io). |
+| LOGZIO_TOKEN <span class="required-param"></span> | {% include log-shipping/replace-vars.html token=true %} |
+| LOGZIO_LISTENER_HOST <span class="required-param"></span> | {% include log-shipping/replace-vars.html listener=true %} |
 
 
-#### Check Logz.io for your logs
+##### Check Logz.io for your logs
 
-Give your logs some time to get from your system to ours,
-and then open [Kibana](https://app.logz.io/#/dashboard/kibana).
+Give your logs some time to get from your system to ours, and then open [Kibana](https://app.logz.io/#/dashboard/kibana).
 
-
-## Versions
-
-0.1.0:
-* Sending logs from multiple Okta tenants
-* Sending logs with from every kind of okta domain (not limited to 'okta.com')
-* Note that 'okta_api_key' and 'okta_domain' are now being set in 'tenants-credentials.yml' and no longer as environment parameters.
-
-0.0.2:
-* Sending logs from Okta tenants
+If you still don't see your logs, see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
 
 </div>
-
-

--- a/_source/logzio_collections/_log-sources/okta.md
+++ b/_source/logzio_collections/_log-sources/okta.md
@@ -41,13 +41,6 @@ and paste it in your text editor. In the following example, you'd have copied "d
 
 ![Okta URL](https://dytvr9ot2sszz.cloudfront.net/logz-docs/log-shipping/okta-issuer-uri.png)
 
-##### Pull the Docker image
-
-Download the logzio/logzio-okta Docker image:
-
-```shell
-docker pull logzio/logzio-okta
-```
 
 ##### Create your tenants-credentials YAML
 
@@ -65,19 +58,6 @@ tenants_credentials:
       okta_domain: <<OKTA-DOMAIN>>
 ```
 
-This shipper supports up to 50 tenants. For multiple tenants, add your Okta API key and domain for each tenant. See the following example:
-
-```
-tenants_credentials:
-    - okta_api_key: 123456a
-      okta_domain: logzio-dev-123.okta.com
-    - okta_api_key: 123456b
-      okta_domain: logzio-dev-123.okta.com
-    - okta_api_key: 123456c
-      okta_domain: logzio-dev-123.oktapreview.com
-```
-
-
 ###### Parameters
 
 | Parameter | Description |
@@ -91,9 +71,29 @@ YAML files are sensitive to spaces and tabs. It's a good idea to run your code t
 {:.info-box.tip}
 
 
+This shipper supports up to 50 tenants. For multiple tenants, add your Okta API key and domain for each tenant. See the following example:
+
+```
+tenants_credentials:
+    - okta_api_key: 123456a
+      okta_domain: logzio-dev-123.okta.com
+    - okta_api_key: 123456b
+      okta_domain: logzio-dev-123.okta.com
+    - okta_api_key: 123456c
+      okta_domain: logzio-dev-123.oktapreview.com
+```
+
+##### Pull the Docker image
+
+Download the logzio/logzio-okta image:
+
+```shell
+docker pull logzio/logzio-okta
+```
+
 ##### Run the Docker image
 
-Replace the placeholders in the code sample below before running it. Run:
+Replace the placeholders in the code sample below before running it. Then run:
 
 ```shell
 docker run \

--- a/_source/logzio_collections/_log-sources/okta.md
+++ b/_source/logzio_collections/_log-sources/okta.md
@@ -81,7 +81,7 @@ tenants_credentials:
 YAML files are sensitive to spaces and tabs. It's a good idea to run your code through a YAML validator to make sure that its structure is correct.
 {:.info-box.tip}
 
-Save the file on your working directory. That's the same one you're running the docker from.
+Save the file in your working directory. That's the same one you're running the docker from.
 
 
 ##### Pull the Docker image

--- a/_source/logzio_collections/_log-sources/okta.md
+++ b/_source/logzio_collections/_log-sources/okta.md
@@ -52,10 +52,22 @@ touch tenants-credentials.yml
 
 Insert your tenants credentials into the YAML file in the following format:
 
-```
+```yml
 tenants_credentials:
     - okta_api_key: <<OKTA-API-KEY>>
       okta_domain: <<OKTA-DOMAIN>>
+```
+
+This shipper supports up to 50 tenants. For multiple tenants, add your Okta API key and domain for each tenant. See the following example:
+
+```yml
+tenants_credentials:
+    - okta_api_key: 123456a
+      okta_domain: logzio-dev-123.okta.com
+    - okta_api_key: 123456b
+      okta_domain: logzio-dev-123.okta.com
+    - okta_api_key: 123456c
+      okta_domain: logzio-dev-123.oktapreview.com
 ```
 
 ###### Parameters
@@ -65,23 +77,12 @@ tenants_credentials:
 | OKTA_API_KEY <span class="required-param"></span> | The Okta API key copied in step 1. |
 | OKTA_DOMAIN <span class="required-param"></span> | The Okta domain copied in step 1. It is found under the **Issuer URI column** in your Okta developer console. <br> Supports these [Okta domains](https://developer.okta.com/docs/guides/find-your-domain/findorg/): <br> example.oktapreview.com, example.okta.com, example.okta-emea.com |
 
-Save the file on your working directory. That's the same one you're running the docker from.
 
 YAML files are sensitive to spaces and tabs. It's a good idea to run your code through a YAML validator to make sure that its structure is correct.
 {:.info-box.tip}
 
+Save the file on your working directory. That's the same one you're running the docker from.
 
-This shipper supports up to 50 tenants. For multiple tenants, add your Okta API key and domain for each tenant. See the following example:
-
-```
-tenants_credentials:
-    - okta_api_key: 123456a
-      okta_domain: logzio-dev-123.okta.com
-    - okta_api_key: 123456b
-      okta_domain: logzio-dev-123.okta.com
-    - okta_api_key: 123456c
-      okta_domain: logzio-dev-123.oktapreview.com
-```
 
 ##### Pull the Docker image
 

--- a/_source/logzio_collections/_log-sources/okta.md
+++ b/_source/logzio_collections/_log-sources/okta.md
@@ -17,7 +17,7 @@ To ship Okta logs,
 you'll deploy a Docker container
 to collect the logs and forward them to Logz.io using Logstash.
 
-You can send logs from multiple Okta tenants and very every kind of okta domain.
+You can send logs from multiple Okta tenants and any okta domain.
 
 #### Configuration
 


### PR DESCRIPTION
## What changed

Update Okta version to 0.1.0:
Sending logs from multiple Okta tenants
Sending logs with from every kind of okta domain (not limited to 'okta.com')
Note that 'okta_api_key' and 'okta_domain' are now being set in 'tenants-credentials.yml' and no longer as environment parameters.

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- https://deploy-preview-580--logz-docs.netlify.app/shipping/log-sources/okta.html