### PR TITLE
remove wrong response

### DIFF
--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -2167,10 +2167,6 @@ definitions:
         type: string
         description: Name of the account
         example: 404 errors
-      accountToken:
-        type: string
-        description: Account log shipping token (unique to this account)
-        example: f483abe93b
       maxDailyGB:
         type: number
         format: float


### PR DESCRIPTION
Signed-off-by: yyyogev <yogev.metzuyanim@logz.io>

The response example contained a field that's not in the actual response. Checked with the DoD, this is indeed a  documentation bug.
<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL

<!-- Credit goes to Pantheon Systems docs team for most of this template. Thanks, guys! -->
