### PR TITLE
Add new parameter "CLOUD_METADATA"

### DIFF
--- a/_source/logzio_collections/_metrics-sources/docker.md
+++ b/_source/logzio_collections/_metrics-sources/docker.md
@@ -83,7 +83,7 @@ logzio/docker-collector-metrics
 | LOGZIO_EXTRA_DIMENSIONS | Semicolon-separated list of dimensions to be included with your metrics (formatted as `dimensionName1=value1;dimensionName2=value2`). <br> To use an environment variable as a value, format as `dimensionName=$ENV_VAR_NAME`. Environment variables must be the only value in the field. If an environment variable can't be resolved, the field is omitted. |
 | DEBUG <span class="default-param">`"false"`</span> | Set to `true` if you want Metricbeat to run in debug mode.<br/> **Note:** Debug mode tends to generate a lot of debugging output, so you should probably enable it temporarily only when an error occurs while running the docker-collector in production.  |
 | HOSTNAME <span class="default-param">``</span> | Insert your host name if you want it to appear in the metrics' `host.name`. If null, host.name will show the container's ID. |
-| CLOUD_METADATA <span class="default-param">`"false"`</span> | Set to `true` enriches each event with instance metadata from the machine’s hosting provider. |
+| CLOUD_METADATA <span class="default-param">`"false"`</span> | Set to `true` to enrich events with instance metadata from the machine’s hosting provider. |
 {:.paramlist}
 
 ###### Parameters for the Docker module

--- a/_source/logzio_collections/_metrics-sources/docker.md
+++ b/_source/logzio_collections/_metrics-sources/docker.md
@@ -83,6 +83,7 @@ logzio/docker-collector-metrics
 | LOGZIO_EXTRA_DIMENSIONS | Semicolon-separated list of dimensions to be included with your metrics (formatted as `dimensionName1=value1;dimensionName2=value2`). <br> To use an environment variable as a value, format as `dimensionName=$ENV_VAR_NAME`. Environment variables must be the only value in the field. If an environment variable can't be resolved, the field is omitted. |
 | DEBUG <span class="default-param">`"false"`</span> | Set to `true` if you want Metricbeat to run in debug mode.<br/> **Note:** Debug mode tends to generate a lot of debugging output, so you should probably enable it temporarily only when an error occurs while running the docker-collector in production.  |
 | HOSTNAME <span class="default-param">``</span> | Insert your host name if you want it to appear in the metrics' `host.name`. If null, host.name will show the container's ID. |
+| CLOUD_METADATA <span class="default-param">`"false"`</span> | Set to `true` enriches each event with instance metadata from the machine’s hosting provider. |
 {:.paramlist}
 
 ###### Parameters for the Docker module


### PR DESCRIPTION
# What changed
----

-  Adds new parameter on the section "Parameters for all modules":
parameter name: "CLOUD_METADATA"
what it is for? Set to `true` enriches each event with instance metadata from the machine’s hosting provider.
----

https://deploy-preview-688--logz-docs.netlify.app/shipping/metrics-sources/docker.html