### PR TITLE
Fix toml example

### DIFF
--- a/_source/logzio_collections/_shippers/vector.md
+++ b/_source/logzio_collections/_shippers/vector.md
@@ -49,8 +49,8 @@ at [http sink](https://docs.vector.dev/usage/configuration/sinks/http) from Vect
   compression = "gzip" # no default, must be: "gzip" (if supplied)
 
   # OPTIONAL - Batching
-  batch_size = 9000000 # bytes - Logz.io max batch is 10MB
-  batch_timeout = 3
+  batch.max_bytes = 9000000 # bytes - Logz.io max batch is 10MB
+  batch.timeout_secs = 3
 
   # OPTIONAL - Buffer
   [sinks.logzio.buffer]


### PR DESCRIPTION
## What changed

Should be batch.max_bytes and batch.max_events under the batching section in version 0.10.0 of Vector.
https://vector.dev/docs/reference/sinks/http/


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

https://deploy-preview-695--logz-docs.netlify.app/shipping/shippers/vector.html