### PR TITLE
notifications are suppressed - group by

### DIFF
--- a/_source/user-guide/alerts/configure-alerts.md
+++ b/_source/user-guide/alerts/configure-alerts.md
@@ -111,7 +111,7 @@ To limit how often recipients are notified,
 choose a time period to suppress notifications.
 
 When notifications are suppressed,
-Logz.io will continue to log triggered alerts without sending notifications.
+Logz.io will continue to log triggered alerts without sending notifications; even if a 'group by' operator is applied.
 You can search triggered alert logs at any time.
 {:.info-box.note}
 


### PR DESCRIPTION
Added clarification regarding using 'group by' with suppressed notifications.

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
