### PR TITLE
PR #754 - k8s ref fixes & put instrumentation 1st

### DIFF
--- a/_source/_data/toc.yml
+++ b/_source/_data/toc.yml
@@ -118,12 +118,12 @@ firstLevel:
   - title: Getting started
     url: /user-guide/distributed-tracing/getting-started-tracing/
     thirdLevel:
+    - title: Setting up instrumentation and ingesting traces
+      url: /user-guide/distributed-tracing/tracing-instrumentation       
     - title: Deploying components in your system
       url: /user-guide/distributed-tracing/deploying-components
     - title: Kubernetes deployment reference
       url: /user-guide/distributed-tracing/k8s-deployment
-    - title: Setting up instrumentation and ingesting traces
-      url: /user-guide/distributed-tracing/tracing-instrumentation 
   - title: The Grand Distributed Tracing Tour
     url: /user-guide/distributed-tracing/tracing-tour/
     thirdLevel: 

--- a/_source/user-guide/distributed-tracing/getting-started-tracing.md
+++ b/_source/user-guide/distributed-tracing/getting-started-tracing.md
@@ -18,6 +18,10 @@ Get set and get ready: This section describes what you have to do to get set up 
 
 <div class="tasklist">
 
+##### Set up instrumentation
+Determine the best instrumentation strategy for your system: Manual or automatic instrumentation.
+<a href="/user-guide/distributed-tracing/tracing-instrumentation.html" target ="_blank"> Read more about setting up instrumentation.</a>
+
 ##### Look up your Distributed Tracing Token and Region information in Logz.io
 You’ll find your Distributed Tracing account information in the <a href="https://app.logz.io/#/dashboard/settings/manage-accounts" target ="_blank"> **Manage Accounts page**</a> of your Operations workspace, 
 
@@ -40,9 +44,6 @@ Decide on your tracing source, make deployment decisions, and decide whether or 
 
 If you’re deploying distributed tracing on Kubernetes, we recommend the following blog post: <a href="https://logz.io/blog/jaeger-kubernetes-best-practices/" target ="_blank">A Guide to Deploying Jaeger on Kubernetes in Production. </a>
 
-##### Set up instrumentation
-Determine the best instrumentation strategy for your system: Manual or automatic instrumentation.
-<a href="/user-guide/distributed-tracing/tracing-instrumentation.html" target ="_blank"> Read more about setting up instrumentation.</a>
 
 
 

--- a/_source/user-guide/distributed-tracing/k8s-deployment.md
+++ b/_source/user-guide/distributed-tracing/k8s-deployment.md
@@ -25,7 +25,7 @@ _Before you begin:_
 apiVersion: apps/v1
 kind: List
 items:
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: jaeger-logzio-collector
@@ -70,7 +70,7 @@ items:
             value: # obtained from Logz.io Regions and Listener hosts table for your region
 {{- end }}
 
-- apiVersion: v1
+- apiVersion: apps/v1
   kind: Service
   metadata:
     name: jaeger-logzio-collector
@@ -103,7 +103,7 @@ items:
     type: ClusterIP
 
 
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: DaemonSet
   metadata:
     name: jaeger-agent
@@ -112,19 +112,24 @@ items:
       app.kubernetes.io/name: jaeger
       app.kubernetes.io/component: agent
     namespace: monitoring
-  spec:
-    template:
-      metadata:
-        labels:
-          app: jaeger
-          app.kubernetes.io/name: jaeger
-          app.kubernetes.io/component: agent
-      spec:
-        containers:
-        - name: jaeger-agent
-          image: jaegertracing/jaeger-agent:1.18.0   # Relace "1.18.0" with the latest Jaeger version
-          args: ["--reporter.grpc.host-port=jaeger-logzio-collector:14250"]
-          ports:
+spec:
+  selector:
+    matchLabels:
+      app: jaeger
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/component: agent
+  template:
+    metadata:
+      labels:
+        app: jaeger
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: agent
+    spec:
+      containers:
+      - name: jaeger-agent
+        image: jaegertracing/jaeger-agent:1.9.0   # Relace "1.9.0" with the latest Jaeger version
+          args: ["--reporter.tchannel.host-port=jaeger-logzio-collector:14267"]
+        ports:
           - containerPort: 5775
             protocol: UDP
           - containerPort: 6831


### PR DESCRIPTION
# What changed
1. https://deploy-preview-756--logz-docs.netlify.app/user-guide/distributed-tracing/getting-started-tracing/
2.  https://deploy-preview-756--logz-docs.netlify.app/user-guide/distributed-tracing/k8s-deployment


- Fixes to handle PR#754 - issues with k8s reference in Distributed Tracing Getting started section
- change in order of Getting started: Moved Instrumentation to be 1st process. 

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
