### PR TITLE
Grafana tags: PagerDuty alerts and a typo fix for p8s stealth docs

### DIFF
--- a/_source/no-search/p8s-getting-started.md
+++ b/_source/no-search/p8s-getting-started.md
@@ -31,7 +31,7 @@ Once your metrics are flowing, import your existing Prometheus and Grafana dashb
 For the record, notification endpoints and dashboard annotations are not imported: You'll need to recreate them in Logz.io.  See [Notification endpoints](/user-guide/integrations/endpoints.html) and [Annotations](/user-guide/infrastructure-monitoring/annotations/) for more information.
 
 ### Steps to get started
-1. [Locate your Metrics account token, Listener URL, and Region.](/user-guide/accounts/finding-your-metrics-account-token/)
+1. [Locate your Metrics account token ](/user-guide/accounts/finding-your-metrics-account-token/)and [Listener host](/user-guide/accounts/account-region.html#available-regions). 
 2. [Configure Remote Write.](/user-guide/infrastructure-monitoring/p8s-remote-write#configuring-remote-write-to-logzio)
 3. [Import dashboards.](/user-guide/infrastructure-monitoring/p8s-importing-dashbds)
 4. [Configure notification endpoints.](/user-guide/integrations/endpoints.html)

--- a/_source/no-search/p8s-getting-started.md
+++ b/_source/no-search/p8s-getting-started.md
@@ -31,11 +31,11 @@ Once your metrics are flowing, import your existing Prometheus and Grafana dashb
 For the record, notification endpoints and dashboard annotations are not imported: You'll need to recreate them in Logz.io.  See [Notification endpoints](/user-guide/integrations/endpoints.html) and [Annotations](/user-guide/infrastructure-monitoring/annotations/) for more information.
 
 ### Steps to get started
-1. [Locate your Metrics account token ](/user-guide/accounts/finding-your-metrics-account-token/)and [Listener host](/user-guide/accounts/account-region.html#available-regions). 
-2. [Configure Remote Write.](/user-guide/infrastructure-monitoring/p8s-remote-write#configuring-remote-write-to-logzio)
-3. [Import dashboards.](/user-guide/infrastructure-monitoring/p8s-importing-dashbds)
-4. [Configure notification endpoints.](/user-guide/integrations/endpoints.html)
-5. [Recreate your dashboard annotations.](/user-guide/infrastructure-monitoring/annotations/)
+1. [Configure Remote Write.](/user-guide/infrastructure-monitoring/p8s-remote-write#configuring-remote-write-to-logzio) <br>
+    For this step, you'll need to [locate your Metrics account token ](/user-guide/accounts/finding-your-metrics-account-token/)and [Listener host](/user-guide/accounts/account-region.html#available-regions) information. 
+1. [Import dashboards.](/user-guide/infrastructure-monitoring/p8s-importing-dashbds)
+1. [Configure notification endpoints.](/user-guide/integrations/endpoints.html)
+1. [Recreate your dashboard annotations.](/user-guide/infrastructure-monitoring/annotations/)
 
 <!-- 
 1. Highlight the value: 

--- a/_source/no-search/p8s-getting-started.md
+++ b/_source/no-search/p8s-getting-started.md
@@ -28,7 +28,7 @@ For the beta program, your incoming raw data has a 30-day retention period.
 
 Once your metrics are flowing, import your existing Prometheus and Grafana dashboards to Logz.io Infrastructure Monitoring as JSON files.  
 
-For the record, notification endpoints and dashboard annotations are not imported: You'll need to recreate them in Logz.io.  See [Notification endpoints](/user-guide/integrations/endpoints.html) and [Annotations](/user-guide/infrastructure-monitoring/annotations/)for more information.
+For the record, notification endpoints and dashboard annotations are not imported: You'll need to recreate them in Logz.io.  See [Notification endpoints](/user-guide/integrations/endpoints.html) and [Annotations](/user-guide/infrastructure-monitoring/annotations/) for more information.
 
 ### Steps to get started
 1. [Locate your Metrics account token, Listener URL, and Region.](/user-guide/accounts/finding-your-metrics-account-token/)

--- a/_source/no-search/p8s-importing-dashbds.md
+++ b/_source/no-search/p8s-importing-dashbds.md
@@ -12,7 +12,7 @@ contributors:
 ---
 You can import your existing dashboards to Logz.io via a manual process. The option to import your dashboords via a bulk process will be available in the future!
 
-For the record, notification endpoints and dashboard annotations are not imported: You'll need to recreate them in Logz.io.  See [Notification endpoints](/user-guide/integrations/endpoints.html) and [Annotations](/user-guide/infrastructure-monitoring/annotations/)for more information. 
+For the record, notification endpoints and dashboard annotations are not imported: You'll need to recreate them in Logz.io.  See [Notification endpoints](/user-guide/integrations/endpoints.html) and [Annotations ](/user-guide/infrastructure-monitoring/annotations/)for more information. 
 
 ### Importing individual dashboards
 

--- a/_source/no-search/p8s-remote-write.md
+++ b/_source/no-search/p8s-remote-write.md
@@ -33,26 +33,27 @@ Once your metrics are flowing, export your existing Prometheus and Grafana dashb
 
 1. Within Logz.io, look up the Logz.io Metrics Account token and Listener address for your region (URL).
 
-    - You’ll find your Metrics account information in the <a href ="https://app.logz.io/#/dashboard/settings/manage-accounts" target="_blank">Manage Accounts **(<i class="li li-gear"></i> > Settings > Manage accounts)**</a> page of your Operations workspace, when you click the relevant Metrics account to display its details.
+    1. You’ll find your Metrics account information in the <a href ="https://app.logz.io/#/dashboard/settings/manage-accounts" target="_blank">Manage Accounts **(<i class="li li-gear"></i> > Settings > Manage accounts)**</a> page of your Operations workspace, when you click the relevant Metrics account to display its details.
     ![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
 
-    - Look up the correct Listener URL for your region in the <a href ="user-guide/accounts/account-region.html#available-regions" target="_blank">_Regions and Listener Hosts_</a> table. 
+    1. Look up the correct Listener URL for your region in the <a href ="{{site.baseurl}}/user-guide/accounts/account-region.html#available-regions" target="_blank">_Regions and Listener Hosts_</a> table. 
   
 2. Within Prometheus, add a new remote_write URL for Logz.io to your Prometheus yaml file. 
-    A logical location to add this information is under the `global_config` section, at the same indentation level as the `global` section.  <a href ="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write" target="_blank">Prometheus configuration file remote write demo <i class="fas fa-external-link-alt"></i>   </a>
+    Add this information at the same indentation level as the `global` section.  <a href ="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write" target="_blank">Prometheus configuration file remote write demo <i class="fas fa-external-link-alt"></i>   </a>
 
     ```yaml
-    global_config
-      remote_write:
-        - url: <the Logz.io Listener URL for your region>
-          bearer_token: <your Logz.io Metrics account token> 
-          remote_timeout: 30s
-          queue_config:
-            batch_send_deadline: 5s  #default = 5s
-            max_shards: 10  #default = 1000
-            min_shards: 1
-            max_samples_per_send: 500 #default = 100
-            capacity: 10000  #default = 500
+    global
+    
+    remote_write:
+      - url: <the Logz.io Listener URL for your region>
+        bearer_token: <your Logz.io Metrics account token> 
+        remote_timeout: 30s
+        queue_config:
+          batch_send_deadline: 5s  #default = 5s
+          max_shards: 10  #default = 1000
+          min_shards: 1
+          max_samples_per_send: 500 #default = 100
+          capacity: 10000  #default = 500
     ```
 
     |Parameter | Description

--- a/_source/no-search/p8s-remote-write.md
+++ b/_source/no-search/p8s-remote-write.md
@@ -62,5 +62,5 @@ Once your metrics are flowing, export your existing Prometheus and Grafana dashb
     |url| Logz.io Listener address for your region
     |bearer_token| Logz.io Metrics account token
    
-3. To check that the remote_write configuration is working properly, run a query for `metric prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
+3. To check that the remote_write configuration is working properly, on your Prometheus instance, run a query for the metric `prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
 

--- a/_source/no-search/p8s-remote-write.md
+++ b/_source/no-search/p8s-remote-write.md
@@ -20,8 +20,8 @@ By default, all metrics in your Prometheus server(s) will be sent to Logz.io. To
 
 * _in dev_: Set parallelism level for sending data - how many connections to open to the remote write listener. While the default is 1000, but we recommend configuring much fewer connections. 
 
-* _in dev_: This is set in the configuration file. Parameter for # of connections (more data --o--> more channels)
-  Sending data - best practice in configuring connection channels: 
+* _in dev_: This is set in the configuration file. Parameter for # of connections (if you're sending more data you'll need to open more channels)
+  We're in the process of refining best practices for configuring connection channels when sending data
 
 * _in dev_: If you have both Prometheus & Grafana, you can activate a dashboard as part of the remote write configuration that will show you the queue size and how many metrics you're sending. If your queue size increases, it might be necessary to open an additional channel. 
 
@@ -33,9 +33,11 @@ Once your metrics are flowing, export your existing Prometheus and Grafana dashb
 
 1. Within Logz.io, look up the Logz.io Metrics Account token and Listener address for your region (URL).
     1. You’ll find your Metrics account information in the <a href ="https://app.logz.io/#/dashboard/settings/manage-accounts" target="_blank">Manage Accounts **(<i class="li li-gear"></i> > Settings > Manage accounts)**</a> page of your Operations workspace, when you click the relevant **Metrics account plan**, to display its details.
-      ![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
 
     1. Look up the correct Listener URL for your region in the <a href ="{{site.baseurl}}/user-guide/accounts/account-region.html#available-regions" target="_blank">_Regions and Listener Hosts_</a> table. 
+
+    Here's how to find your Metrics account token information: 
+      ![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
 
   
 2. Within Prometheus, add a new remote_write URL for Logz.io to your Prometheus yaml file at the same indentation level as the `global` section.  For more details, see the  <a href ="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write" target="_blank">Prometheus configuration file remote write reference.  <i class="fas fa-external-link-alt"></i>   </a>

--- a/_source/no-search/p8s-remote-write.md
+++ b/_source/no-search/p8s-remote-write.md
@@ -32,14 +32,13 @@ Once your metrics are flowing, export your existing Prometheus and Grafana dashb
 ### Configuring Remote Write to Logz.io
 
 1. Within Logz.io, look up the Logz.io Metrics Account token and Listener address for your region (URL).
-
-    1. You’ll find your Metrics account information in the <a href ="https://app.logz.io/#/dashboard/settings/manage-accounts" target="_blank">Manage Accounts **(<i class="li li-gear"></i> > Settings > Manage accounts)**</a> page of your Operations workspace, when you click the relevant Metrics account to display its details.
-    ![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
+    1. You’ll find your Metrics account information in the <a href ="https://app.logz.io/#/dashboard/settings/manage-accounts" target="_blank">Manage Accounts **(<i class="li li-gear"></i> > Settings > Manage accounts)**</a> page of your Operations workspace, when you click the relevant **Metrics account plan**, to display its details.
+      ![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
 
     1. Look up the correct Listener URL for your region in the <a href ="{{site.baseurl}}/user-guide/accounts/account-region.html#available-regions" target="_blank">_Regions and Listener Hosts_</a> table. 
+
   
-2. Within Prometheus, add a new remote_write URL for Logz.io to your Prometheus yaml file. 
-    Add this information at the same indentation level as the `global` section.  <a href ="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write" target="_blank">Prometheus configuration file remote write demo <i class="fas fa-external-link-alt"></i>   </a>
+2. Within Prometheus, add a new remote_write URL for Logz.io to your Prometheus yaml file at the same indentation level as the `global` section.  For more details, see the  <a href ="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write" target="_blank">Prometheus configuration file remote write reference.  <i class="fas fa-external-link-alt"></i>   </a>
 
     ```yaml
     global

--- a/_source/user-guide/infrastructure-monitoring/grafana-alerts.md
+++ b/_source/user-guide/infrastructure-monitoring/grafana-alerts.md
@@ -19,6 +19,12 @@ You can also add a condition so an alert holds off for a certain time before it 
 
 If you're running multiple servers for load balancing purposes, you'll be happy to know that Logz.io Metrics won't send duplicte alerts. A deduplication mechanism protects against that.
 
+###### On this page
+{:.no_toc}
+
+1. toc list
+{:toc}
+
 ### Resolved alerts
 
 For better alerts management and to help you focus only on active alerts, when a tracked metric returns to its accepted values (below the current alert threshold), you'll get notified automatically that the triggered alert was resolved. 
@@ -35,11 +41,19 @@ When you receive an alert with the same alert ID, if the alert has the Acknowled
 
 The Acknowledge status is available for the PagerDuty notification endpoint.
 
-###### On this page
-{:.no_toc}
+### Grafana tags for alert Severity levels
 
-1. toc list
-{:toc}
+Use Grafana tags as a Severity field for your alerts when integrating Grafana with PagerDuty as an alert notification endpoint.
+
+Follow the link for more information on <a href="https://grafana.com/docs/grafana/latest/alerting/notifications/#pagerduty" target="_blank"> the syntax for setting up Grafana tags for PagerDuty.  <i class="fas fa-external-link-alt"></i> </a>
+
+<!-- OpsGenie integration is coming too: Use tags as Priority fields for alerts when integrating Grafana with OpsGenie aas an alert notification endpoint. 
+
+Follow the link for more information on <a href="https://grafana.com/docs/grafana/latest/alerting/notifications/" target="_blank"> the syntax for setting up Grafana tags for OpsGenie <i class="fas fa-external-link-alt"></i> </a> -->
+
+
+### Adding Alerts
+Navigate to the Logz.io Infrastructure Monitoring **Metrics** tab.
 
 #### To add an alert
 {:.no_toc}


### PR DESCRIPTION
# What changed
- https://deploy-preview-763--logz-docs.netlify.app/user-guide/infrastructure-monitoring/alerts.html
- fixed link to Listener Host URL tables: 
https://deploy-preview-763--logz-docs.netlify.app/user-guide/infrastructure-monitoring/p8s-getting-started
https://deploy-preview-763--logz-docs.netlify.app/user-guide/infrastructure-monitoring/p8s-remote-write
- typo fix in 2nd paragraph Annotations link: https://deploy-preview-763--logz-docs.netlify.app/user-guide/infrastructure-monitoring/p8s-importing-dashbds
- fixed link to Listener Host URL tables

More details: 
- Infrastructure Monitoring > Alerts: draft content for new feature: Grafana tags can be used as Severity level for alerts when using PagerDuty as the notification endpoint.  
- small restructure to make topic numbering work better

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
