### PR TITLE
clean up hierarchy in metrics alert page

### DIFF
--- a/_source/user-guide/distributed-tracing/trace-hotrod-demo.md
+++ b/_source/user-guide/distributed-tracing/trace-hotrod-demo.md
@@ -49,7 +49,7 @@ This topic explains how to set up the Logz.io sample application to send demo tr
 + The Jaeger agent
 + The Logz.io Jaeger collector
 
-The <a href ="https://github.com/logzio/tracing-demo"  target="_blank">  Logz.io **tracing-demo** project repository <i class="fas fa-external-link-alt"></i> </a> includes modified configuration paramaters to create the the HotROD web app. The app sends data to a Logz.io Jaeger collector that you configure to work with your Distributed Tracing account.  Click to open the <a href ="https://github.com/logzio/tracing-demo/blob/main/README.md" target="_blank"> **README** for the tracing demo project </a>
+The <a href ="https://github.com/logzio/tracing-demo"  target="_blank">  Logz.io **tracing-demo** project repository <i class="fas fa-external-link-alt"></i> </a> includes modified configuration paramaters to create the HotROD web app. The app sends data to a Logz.io Jaeger collector that you configure to work with your Distributed Tracing account.  Click to open the <a href ="https://github.com/logzio/tracing-demo/blob/main/README.md" target="_blank"> **README** for the tracing demo project </a>
 
 <!--The configuration repository <a href ="https://github.com/logzio/tracing-demo"  target="_blank">  is here <i class="fas fa-external-link-alt"></i> </a>. -->
 

--- a/_source/user-guide/infrastructure-monitoring/grafana-alerts.md
+++ b/_source/user-guide/infrastructure-monitoring/grafana-alerts.md
@@ -95,6 +95,13 @@ Next, set your alert conditions.
 
 ![Add Grafana alert to graph panel](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/alert-condition.png)
 
+**Grafana tags for alert Severity levels**
+
+Use Grafana tags as a Severity field for your alerts when integrating Grafana with PagerDuty as an alert notification endpoint.
+Follow the link for more information on <a href="https://grafana.com/docs/grafana/latest/alertinnotifications/#pagerduty" target="_blank"> the syntax for setting up Grafana tags for PagerDuty.  <i class="fas fa-external-link-alt"></i> </a>
+
+<!-- OpsGenie integration is coming too: Use tags as Priority fields for alerts when integrating Grafana withOpsGenie aas an alert notification endpoint.     Follow the link for more information on <a href="https:/grafana.com/docs/grafana/latest/alerting/notifications/" target="_blank"> the syntax for setting up Grafanatags for OpsGenie <i class="fas fa-external-link-alt"></i> </a> -->   
+
 ##### Add notifications
 
 If you want to send notifications or emails when the alert is triggered,
@@ -125,14 +132,7 @@ your Metrics dashboard will show the orange marker on the graph, indicating that
     When you receive an alert with the same alert ID, if the alert has the Acknowledge status, your notification endpoint will not repeat the notification.
 
     The Acknowledge status is available for the PagerDuty notification endpoint.
-
-+ _**Grafana tags for alert Severity levels**_ 
-
-    Use Grafana tags as a Severity field for your alerts when integrating Grafana with PagerDuty as an alert notification endpoint.
-
-    Follow the link for more information on <a href="https://grafana.com/docs/grafana/latest/alerting/notifications/#pagerduty" target="_blank"> the syntax for setting up Grafana tags for PagerDuty.  <i class="fas fa-external-link-alt"></i> </a>
-
- <!-- OpsGenie integration is coming too: Use tags as Priority fields for alerts when integrating Grafana withOpsGenie aas an alert notification endpoint.     Follow the link for more information on <a href="https:/grafana.com/docs/grafana/latest/alerting/notifications/" target="_blank"> the syntax for setting up Grafanatags for OpsGenie <i class="fas fa-external-link-alt"></i> </a> -->   
+ 
 
 
 ##### Save it!

--- a/_source/user-guide/infrastructure-monitoring/grafana-alerts.md
+++ b/_source/user-guide/infrastructure-monitoring/grafana-alerts.md
@@ -25,32 +25,6 @@ If you're running multiple servers for load balancing purposes, you'll be happy 
 1. toc list
 {:toc}
 
-### Resolved alerts
-
-For better alerts management and to help you focus only on active alerts, when a tracked metric returns to its accepted values (below the current alert threshold), you'll get notified automatically that the triggered alert was resolved. 
-
-Resolved alert notifications are available for Slack, PagerDuty, Opsgenie, and email notification endpoints.
-
-See [Opsgenie notifications for resolved metrics alerts]({{site.baseurl}}/user-guide/integrations/resolved-metrics-alerts.html) for more information.
-
-### Acknowledged alerts
-
-To help you reduce the noise associated with receiving notifications for multiple instances of the same alert, you can use the Acknowledge status to assign the alert to a team member or to yourself, as well as manage alerts that are already under investigation (as determined by the ACK policy you manage in your notification software).
-
-When you receive an alert with the same alert ID, if the alert has the Acknowledge status, your notification endpoint will not repeat the notification.
-
-The Acknowledge status is available for the PagerDuty notification endpoint.
-
-### Grafana tags for alert Severity levels
-
-Use Grafana tags as a Severity field for your alerts when integrating Grafana with PagerDuty as an alert notification endpoint.
-
-Follow the link for more information on <a href="https://grafana.com/docs/grafana/latest/alerting/notifications/#pagerduty" target="_blank"> the syntax for setting up Grafana tags for PagerDuty.  <i class="fas fa-external-link-alt"></i> </a>
-
-<!-- OpsGenie integration is coming too: Use tags as Priority fields for alerts when integrating Grafana with OpsGenie aas an alert notification endpoint. 
-
-Follow the link for more information on <a href="https://grafana.com/docs/grafana/latest/alerting/notifications/" target="_blank"> the syntax for setting up Grafana tags for OpsGenie <i class="fas fa-external-link-alt"></i> </a> -->
-
 
 ### Adding Alerts
 Navigate to the Logz.io Infrastructure Monitoring **Metrics** tab.
@@ -133,6 +107,33 @@ To limit how often recipients are notified - you'll need to scroll up to the **E
 When notifications are suppressed,
 your Metrics dashboard will show the orange marker on the graph, indicating that an alert is triggered, but not yet reached its notification threshold.
 {:.info-box.note}
+
+**Additional alert notifications**
+
++ _**Resolved alerts**_
+
+    For better alerts management and to help you focus only on active alerts, when a tracked metric returns to its    accepted values (below the current alert threshold), you'll get notified automatically that the triggered alert   was resolved. 
+
+    Resolved alert notifications are available for Slack, PagerDuty, Opsgenie, and email notification endpoints.
+
+    See [Opsgenie notifications for resolved metrics alerts]({{site.baseurl}}/user-guide/integrations/    resolved-metrics-alerts.html) for more information.
+
++ _**Acknowledged alerts**_
+
+    To help you reduce the noise associated with receiving notifications for multiple instances of the same alert, you can use the Acknowledge status to assign the alert to a team member or to yourself, as well as manage alerts that are already under investigation (as determined by the ACK policy you manage in your notification software).
+
+    When you receive an alert with the same alert ID, if the alert has the Acknowledge status, your notification endpoint will not repeat the notification.
+
+    The Acknowledge status is available for the PagerDuty notification endpoint.
+
++ _**Grafana tags for alert Severity levels**_ 
+
+    Use Grafana tags as a Severity field for your alerts when integrating Grafana with PagerDuty as an alert notification endpoint.
+
+    Follow the link for more information on <a href="https://grafana.com/docs/grafana/latest/alerting/notifications/#pagerduty" target="_blank"> the syntax for setting up Grafana tags for PagerDuty.  <i class="fas fa-external-link-alt"></i> </a>
+
+ <!-- OpsGenie integration is coming too: Use tags as Priority fields for alerts when integrating Grafana withOpsGenie aas an alert notification endpoint.     Follow the link for more information on <a href="https:/grafana.com/docs/grafana/latest/alerting/notifications/" target="_blank"> the syntax for setting up Grafanatags for OpsGenie <i class="fas fa-external-link-alt"></i> </a> -->   
+
 
 ##### Save it!
 


### PR DESCRIPTION
# What changed
https://deploy-preview-790--logz-docs.netlify.app/user-guide/infrastructure-monitoring/alerts.html

moved several small topics on page to Notifications section of process - instead of topic headings, they are now bulleted items in a list.  (Resolved & acknowledged alerts, Grafana severity tags in alerts.)

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
