### PR TITLE
fix secret typo

### DIFF
--- a/_source/logzio_collections/_log-sources/filebeat-kubernetes.md
+++ b/_source/logzio_collections/_log-sources/filebeat-kubernetes.md
@@ -38,7 +38,7 @@ Customize the command to your specifics:
 
 ```shell
 kubectl create secret generic logzio-logs-secret \
-  --from-literal=logzio-log-shipping-token='<<SHIPPING-TOKEN>>' \
+  --from-literal=logzio-logs-shipping-token='<<SHIPPING-TOKEN>>' \
   --from-literal=logzio-logs-listener='<<LISTENER-HOST>>' \
   --from-literal=cluster-name='<<CLUSTER-NAME>>' \
   -n kube-system


### PR DESCRIPTION
# What changed

We had a typo on the create secret command. It said logzio-log-shipping-token when it supposed to be logzio-log**s**-shipping-token and so when people were using it they encountered an error.
Fixed it to be log**s**

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
