### PR TITLE
9dec/otel fixes

### DIFF
--- a/_source/logzio_collections/_shippers/opentelemetry.md
+++ b/_source/logzio_collections/_shippers/opentelemetry.md
@@ -37,14 +37,14 @@ docker pull otel/opentelemetry-collector-contrib:latest
 
 ##### Create a config file to mount to the container. 
 The config file must include the required components for the OpenTelemetry Collector - receivers, processors, exporters, services and optional extensions.
-You can use [this config file](https://github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter/example/config.yaml) as a starting point, with the logzio exporter parameters, below.
+You can use <a href ="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/logzioexporter/example/config.yaml" target = "_blank"> this config file <i class="fas fa-external-link-alt"></i></a> as a starting point, with the Logz.io exporter parameters, below.
 
 ###### Parameters
 
 | Parameter | Description |
 |---|---|
 | ACCOUNT_TOKEN <span class="required-param"></span> | The Logz.io token for your Distributed Tracing account. Required when using as a collector to ship traces to Logz.io.  |
-| REGION <span class="default-param">_Blank (US East)_</span> |  Your two-letter Logz.io account region code. Defaults to US, required only if your Logz.io region is different than US. You can find your region code in the [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions) table. |
+| REGION <span class="default-param">_Blank (US East)_</span> |  Your two-letter Logz.io account region code. Defaults to US, required only if your Logz.io region is different than US. You can find your region code in the <a href = "https://docs.logz.io/user-guide/accounts/account-region.html#available-regions" target = "_blank">  Available regions <i class="fas fa-external-link-alt"></i></a> table. |
 | CUSTOM_LISTENER_ADDRESS | Custom traces endpoint, for dev. This optional parameter overrides the region parameter.|
 {:.paramlist}
 
@@ -61,14 +61,17 @@ docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 
 ```
 
 ##### Run a working example.
-For a complete working example, you can run [this docker-compose file](https://docs.logz.io/shipping-config-samples/docker-compose.yaml). 
+For a complete working example, you can run <a href ="https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/docker-compose.yaml" target = "_blank"> this docker compose file <i class="fas fa-external-link-alt"></i>.</a>
 
   1. Download the file.
   2. Edit the Account Token and the other necessary parameters.
-  3. Run `docker-compse up`. 
+  3. Run `docker-compose up`. 
   4. Head to http://0.0.0.0:8080/ to trigger the event that will generate and send traces to your logz.io account.
 
 ##### Check Jaeger for your traces.
 
 Give your traces some time to get from your system to ours,
 and then open your Jaeger UI.
+
+To learn more about tracing instrumentation, see <a href ="/user-guide/distributed-tracing/tracing-instrumentation#instrumentation-recommendations-and-resources" target = "_blank"> Instrumentation recommendations and resources <i class="fas fa-external-link-alt"></i>.</a>
+

--- a/_source/logzio_collections/_shippers/opentelemetry.md
+++ b/_source/logzio_collections/_shippers/opentelemetry.md
@@ -53,7 +53,7 @@ You can use <a href ="https://github.com/open-telemetry/opentelemetry-collector-
 
 ##### Deploy the OpenTelemetry collector and mount the config file you saved.
 
-```
+```yaml
 docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 -p 9411:9411 \
     -v config.yaml:/etc/otel-collector-config.yaml:ro \
     --name otelcontribcol otel/opentelemetry-collector-contrib:0.5.0 \
@@ -66,7 +66,7 @@ For a complete working example, you can run <a href ="https://raw.githubusercont
   1. Download the file.
   2. Edit the Account Token and the other necessary parameters.
   3. Run `docker-compose up`. 
-  4. Head to http://0.0.0.0:8080/ to trigger the event that will generate and send traces to your logz.io account.
+  4. Head to [http://0.0.0.0:8080/](http://0.0.0.0:8080/) to trigger the event that will generate and send traces to your logz.io account.
 
 ##### Check Jaeger for your traces.
 

--- a/_source/user-guide/distributed-tracing/trace-hotrod-demo.md
+++ b/_source/user-guide/distributed-tracing/trace-hotrod-demo.md
@@ -98,7 +98,7 @@ _To run the demo:_
 2. To open the application, navigate to the main HotROD service at [http://127.0.0.1:18080](http://127.0.0.1:18080).
 3. To send traces, click the buttons.
     You can view the logs in the foreground in the terminal. 
-4. To stop the demo, run: `contrl+c`.
+4. To stop the demo, run: `ctrl+c`.
 5. To remove the docker container, run: `docker-compose down`.
 
 ### Command summary


### PR DESCRIPTION
# What changed

https://deploy-preview-795--logz-docs.netlify.app/shipping/shippers/opentelemetry.html

Fixed dead links and added link to docs instrumentation resources page - pointed out by Mike E
Fixed ctrl+c typo in hotrod demo content - pointed out by Gedalyah R

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
