### PR TITLE
oke filebeat daemonset - Sara's 

### DIFF
--- a/_source/logzio_collections/_log-sources/oke.md
+++ b/_source/logzio_collections/_log-sources/oke.md
@@ -24,7 +24,7 @@ Customize the command to your specifics:
 
 * {% include log-shipping/replace-vars.html token=true %}
 * {% include log-shipping/replace-vars.html listener=true %}
-* Replace `<<CLUSTER-NAME>>` with your cluster's name. If you manage Kubernetes in AWS or Azure, you can find it in your admin console. Alternatively, you can run the following to obtain your cluster name: `kubectl cluster-info`
+* Replace `<<CLUSTER-NAME>>` with your cluster's name.
 
 ```shell
 kubectl create secret generic logzio-logs-secret \

--- a/_source/logzio_collections/_log-sources/oke.md
+++ b/_source/logzio_collections/_log-sources/oke.md
@@ -1,0 +1,119 @@
+Oracle Cloud Infrastructure Container Engine for Kubernetes (OKE) is a fully-managed, scalable, and highly available service that you can use to deploy your containerized applications to the cloud.
+This implementation uses a Filebeat DaemonSet to collect Kubernetes logs from your OKE cluster and ship them to Logz.io.
+
+You have 3 options for deploying this Daemonset:
+
+* Standard configuration
+* Autodiscover configuration - the standard configuration which also uses Filebeat's autodiscover and hints system
+* Custom configuration - upload a Logz.io Daemonset with your own configuration
+
+
+#### Deploy Filebeat as a DaemonSet on Kubernetes
+
+<div class="tasklist">
+
+**Before you begin, you'll need**:
+
+* Destination port 5015 open on your firewall for outgoing traffic
+
+##### Store your Logz.io credentials
+
+Save your Logz.io shipping credentials as a Kubernetes secret.
+
+Customize the command to your specifics:
+
+* {% include log-shipping/replace-vars.html token=true %}
+* {% include log-shipping/replace-vars.html listener=true %}
+* Replace `<<CLUSTER-NAME>>` with your cluster's name. If you manage Kubernetes in AWS or Azure, you can find it in your admin console. Alternatively, you can run the following to obtain your cluster name: `kubectl cluster-info`
+
+```shell
+kubectl create secret generic logzio-logs-secret \
+  --from-literal=logzio-logs-shipping-token='<<SHIPPING-TOKEN>>' \
+  --from-literal=logzio-logs-listener='<<LISTENER-HOST>>' \
+  --from-literal=cluster-name='<<CLUSTER-NAME>>' \
+  -n kube-system
+```
+
+##### Deploy
+
+Run the relevant command for your type of deployment.
+
+###### Deploy the standard configuration
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/k8s-filebeat-oke.yaml -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/filebeat-standard-configuration.yaml
+```
+
+###### Deploy the autodiscover standard configuration
+
+Autodiscover allows you to adapt settings as changes happen. By defining configuration templates, the autodiscover subsystem can monitor services as they start running. See Elastic documentation to [learn more about Filebeat Autodiscover](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover.html).
+
+```shell
+ kubectl apply -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/k8s-filebeat-oke.yaml -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/filebeat-autodiscovery-configuration.yaml
+```
+
+###### Deploy a custom configuration
+
+If you want to apply your own custom configuration, download the standard-configmap.yaml and apply your changes. Make sure to keep the file structure unchanged.
+
+Run the following command to download the file:
+
+```shell
+wget https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/filebeat-standard-configuration.yaml
+```
+
+Apply your custom configuration to the paramaters under `filebeat.yml` and only there. The filebeat.yml field contains a basic Filebeat configuration. You should not change the 'output' field (indicated in the example below). See Elastic documentation to [learn more about Filebeat configuration options](https://www.elastic.co/guide/en/beats/filebeat/current/configuring-howto-filebeat.html).
+
+**Note**
+Make sure to keep ``token: ${LOGZIO_LOGS_SHIPPING_TOKEN}`` under ``fields``, as it determines the token used to verify your logz.io account.
+
+```
+filebeat.yml: |-
+
+  # ...
+  # Start editing your configuration here
+  filebeat.inputs:
+  - type: container
+    paths:
+      - /var/log/containers/*.log
+    processors:
+      - add_kubernetes_metadata:
+          host: ${NODE_NAME}
+          matchers:
+          - logs_path:
+              logs_path: "/var/log/containers/"
+
+  processors:
+    - add_cloud_metadata: ~
+  # ...
+  # Do not edit anything beyond this point. (Do not change 'fields' and 'output'.)
+
+  fields:
+    logzio_codec: ${LOGZIO_CODEC}
+    token: ${LOGZIO_LOGS_SHIPPING_TOKEN}
+    cluster: ${CLUSTER_NAME}
+    type: ${LOGZIO_TYPE}
+  fields_under_root: true
+  ignore_older: ${IGNORE_OLDER}
+  output:
+    logstash:
+      hosts: ["${LOGZIO_LOGS_LISTENER_HOST}:5015"]
+      ssl:
+        certificate_authorities: ['/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt']
+```
+
+Run the following to deploy your custom Filebeat configuration:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/k8s-filebeat-oke.yaml -f <<Your-custom-configuration-file.yaml>>
+```
+
+##### Check Logz.io for your logs
+
+Give your logs some time to get from your system to ours,
+and then open [Kibana](https://app.logz.io/#/dashboard/kibana).
+
+If you still don't see your logs,
+see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
+
+</div>

--- a/_source/logzio_collections/_log-sources/oracle-kubernetes-engine.md
+++ b/_source/logzio_collections/_log-sources/oracle-kubernetes-engine.md
@@ -1,7 +1,7 @@
 ---
 title: Ship Oracle Kubernetes Engine logs
 logo:
-  logofile: Oracle-OKE.svg
+  logofile: oke.png
   orientation: vertical
 data-source: Oracle Kubernetes Engine
 templates: ["k8s-daemonset"]
@@ -13,22 +13,21 @@ shipping-tags:
 ---
 
 Oracle Cloud Infrastructure Container Engine for Kubernetes (OKE) is a fully-managed, scalable, and highly available service that you can use to deploy your containerized applications to the cloud.
+
 This implementation uses a Filebeat DaemonSet to collect Kubernetes logs from your OKE cluster and ship them to Logz.io.
 
 You have 3 options for deploying this Daemonset:
 
 * Standard configuration
-* Autodiscover configuration - the standard configuration which also uses Filebeat's autodiscover and hints system
-* Custom configuration - upload a Logz.io Daemonset with your own configuration
+* Autodiscover configuration - The standard configuration which also uses Filebeat's autodiscover and hints system. [Learn more about Autodiscover in our blog 🔗](https://logz.io/blog/what-is-autodiscover-filebeat/) and [webinar 🎥](https://logz.io/learn/webinar-collecting-and-shipping-kubernetes-logs-at-scale-with-filebeat-autodiscover/).
+* Custom configuration - Upload a Logz.io Daemonset with your own configuration.
 
 
 #### Deploy Filebeat as a DaemonSet on Kubernetes
 
 <div class="tasklist">
 
-**Before you begin, you'll need**:
-
-* Destination port 5015 open on your firewall for outgoing traffic
+**Before you begin, you'll need**: destination port 5015 open on your firewall for outgoing traffic.
 
 ##### Store your Logz.io credentials
 
@@ -58,9 +57,9 @@ Run the relevant command for your type of deployment.
 kubectl apply -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/k8s-filebeat-oke.yaml -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/filebeat-standard-configuration.yaml
 ```
 
-###### Deploy the autodiscover standard configuration
+###### Deploy the standard configuration with Filebeat autodiscover enabled
 
-Autodiscover allows you to adapt settings as changes happen. By defining configuration templates, the autodiscover subsystem can monitor services as they start running. See Elastic documentation to [learn more about Filebeat Autodiscover](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover.html).
+Autodiscover allows you to adapt settings as changes happen. By defining configuration templates, the autodiscover subsystem can monitor services as they start running.  See Elastic documentation to [learn more about Filebeat Autodiscover](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover.html). 
 
 ```shell
  kubectl apply -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/k8s-filebeat-oke.yaml -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/filebeat-autodiscovery-configuration.yaml
@@ -68,7 +67,7 @@ Autodiscover allows you to adapt settings as changes happen. By defining configu
 
 ###### Deploy a custom configuration
 
-If you want to apply your own custom configuration, download the standard-configmap.yaml and apply your changes. Make sure to keep the file structure unchanged.
+If you want to apply your own custom configuration, download the standard `configmap.yaml` file from the [Logz.io GitHub repo](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/filebeat-standard-configuration.yaml) and apply your changes. Make sure to keep the file structure unchanged.
 
 Run the following command to download the file:
 
@@ -76,10 +75,9 @@ Run the following command to download the file:
 wget https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/filebeat-standard-configuration.yaml
 ```
 
-Apply your custom configuration to the paramaters under `filebeat.yml` and only there. The filebeat.yml field contains a basic Filebeat configuration. You should not change the 'output' field (indicated in the example below). See Elastic documentation to [learn more about Filebeat configuration options](https://www.elastic.co/guide/en/beats/filebeat/current/configuring-howto-filebeat.html).
+Apply your custom configuration to the parameters under `filebeat.yml` and only there. The filebeat.yml field contains a basic Filebeat configuration. You should not change the 'output' field (indicated in the example below). See Elastic documentation to [learn more about Filebeat configuration options](https://www.elastic.co/guide/en/beats/filebeat/current/configuring-howto-filebeat.html).
 
-**Note**
-Make sure to keep ``token: ${LOGZIO_LOGS_SHIPPING_TOKEN}`` under ``fields``, as it determines the token used to verify your logz.io account.
+Note that the parameter `token: ${LOGZIO_LOGS_SHIPPING_TOKEN}` under `fields` determines the token used to verify your Logz.io account. It is required.
 
 ```
 filebeat.yml: |-

--- a/_source/logzio_collections/_log-sources/oracle-kubernetes-engine.md
+++ b/_source/logzio_collections/_log-sources/oracle-kubernetes-engine.md
@@ -62,8 +62,7 @@ kubectl apply -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipp
 Autodiscover allows you to adapt settings as changes happen. By defining configuration templates, the autodiscover subsystem can monitor services as they start running.  See Elastic documentation to [learn more about Filebeat Autodiscover](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover.html). 
 
 ```shell
- kubectl apply -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/k8s-filebeat-oke.yaml -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/filebeat-autodiscovery-configuration.yaml
-```
+kubectl apply -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/k8s-filebeat-oke.yaml -f https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/filebeat-autodiscovery-configuration.yaml
 
 ###### Deploy a custom configuration
 

--- a/shipping-config-samples/k8s-filebeat-oke.yaml
+++ b/shipping-config-samples/k8s-filebeat-oke.yaml
@@ -1,0 +1,185 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: filebeat
+  namespace: kube-system
+  labels:
+    k8s-app: filebeat
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logzio-logs-cert
+  namespace: kube-system
+  labels:
+    k8s-app: filebeat
+data:
+  SectigoRSADomainValidationSecureServerCA.crt: |-
+    -----BEGIN CERTIFICATE-----
+    MIIGEzCCA/ugAwIBAgIQfVtRJrR2uhHbdBYLvFMNpzANBgkqhkiG9w0BAQwFADCB
+    iDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0pl
+    cnNleSBDaXR5MR4wHAYDVQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNV
+    BAMTJVVTRVJUcnVzdCBSU0EgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTgx
+    MTAyMDAwMDAwWhcNMzAxMjMxMjM1OTU5WjCBjzELMAkGA1UEBhMCR0IxGzAZBgNV
+    BAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4GA1UEBxMHU2FsZm9yZDEYMBYGA1UE
+    ChMPU2VjdGlnbyBMaW1pdGVkMTcwNQYDVQQDEy5TZWN0aWdvIFJTQSBEb21haW4g
+    VmFsaWRhdGlvbiBTZWN1cmUgU2VydmVyIENBMIIBIjANBgkqhkiG9w0BAQEFAAOC
+    AQ8AMIIBCgKCAQEA1nMz1tc8INAA0hdFuNY+B6I/x0HuMjDJsGz99J/LEpgPLT+N
+    TQEMgg8Xf2Iu6bhIefsWg06t1zIlk7cHv7lQP6lMw0Aq6Tn/2YHKHxYyQdqAJrkj
+    eocgHuP/IJo8lURvh3UGkEC0MpMWCRAIIz7S3YcPb11RFGoKacVPAXJpz9OTTG0E
+    oKMbgn6xmrntxZ7FN3ifmgg0+1YuWMQJDgZkW7w33PGfKGioVrCSo1yfu4iYCBsk
+    Haswha6vsC6eep3BwEIc4gLw6uBK0u+QDrTBQBbwb4VCSmT3pDCg/r8uoydajotY
+    uK3DGReEY+1vVv2Dy2A0xHS+5p3b4eTlygxfFQIDAQABo4IBbjCCAWowHwYDVR0j
+    BBgwFoAUU3m/WqorSs9UgOHYm8Cd8rIDZsswHQYDVR0OBBYEFI2MXsRUrYrhd+mb
+    +ZsF4bgBjWHhMA4GA1UdDwEB/wQEAwIBhjASBgNVHRMBAf8ECDAGAQH/AgEAMB0G
+    A1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAbBgNVHSAEFDASMAYGBFUdIAAw
+    CAYGZ4EMAQIBMFAGA1UdHwRJMEcwRaBDoEGGP2h0dHA6Ly9jcmwudXNlcnRydXN0
+    LmNvbS9VU0VSVHJ1c3RSU0FDZXJ0aWZpY2F0aW9uQXV0aG9yaXR5LmNybDB2Bggr
+    BgEFBQcBAQRqMGgwPwYIKwYBBQUHMAKGM2h0dHA6Ly9jcnQudXNlcnRydXN0LmNv
+    bS9VU0VSVHJ1c3RSU0FBZGRUcnVzdENBLmNydDAlBggrBgEFBQcwAYYZaHR0cDov
+    L29jc3AudXNlcnRydXN0LmNvbTANBgkqhkiG9w0BAQwFAAOCAgEAMr9hvQ5Iw0/H
+    ukdN+Jx4GQHcEx2Ab/zDcLRSmjEzmldS+zGea6TvVKqJjUAXaPgREHzSyrHxVYbH
+    7rM2kYb2OVG/Rr8PoLq0935JxCo2F57kaDl6r5ROVm+yezu/Coa9zcV3HAO4OLGi
+    H19+24rcRki2aArPsrW04jTkZ6k4Zgle0rj8nSg6F0AnwnJOKf0hPHzPE/uWLMUx
+    RP0T7dWbqWlod3zu4f+k+TY4CFM5ooQ0nBnzvg6s1SQ36yOoeNDT5++SR2RiOSLv
+    xvcRviKFxmZEJCaOEDKNyJOuB56DPi/Z+fVGjmO+wea03KbNIaiGCpXZLoUmGv38
+    sbZXQm2V0TP2ORQGgkE49Y9Y3IBbpNV9lXj9p5v//cWoaasm56ekBYdbqbe4oyAL
+    l6lFhd2zi+WJN44pDfwGF/Y4QA5C5BIG+3vzxhFoYt/jmPQT2BVPi7Fp2RBgvGQq
+    6jG35LWjOhSbJuMLe/0CjraZwTiXWTb2qHSihrZe68Zk6s+go/lunrotEbaGmAhY
+    LcmsJWTyXnW0OMGuf1pGg+pRyrbxmRE1a6Vqe8YAsOf4vmSyrcjC8azjUeqkk+B5
+    yOGBQMkKW+ESPMFgKuOXwIlCypTPRpgSabuY0MLTDXJLR27lk8QyKGOHQ+SwMj4K
+    00u/I5sUKUErmgQfky3xxzlIPK1aEn8=
+    -----END CERTIFICATE-----
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: filebeat
+  labels:
+    k8s-app: filebeat
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    - pods
+    verbs:
+    - get
+    - watch
+    - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: filebeat
+subjects:
+- kind: ServiceAccount
+  name: filebeat
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: filebeat
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: filebeat
+  namespace: kube-system
+  labels:
+    k8s-app: filebeat
+spec:
+  selector:
+    matchLabels:
+      k8s-app: filebeat
+  template:
+    metadata:
+      labels:
+        k8s-app: filebeat
+    spec:
+      serviceAccountName: filebeat
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: filebeat
+        image: "docker.elastic.co/beats/filebeat:7.8.1"
+        args: [
+          "-c", "/etc/filebeat.yml",
+          "-e",
+        ]
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LOGZIO_LOGS_SHIPPING_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: logzio-logs-secret
+              key: logzio-logs-shipping-token
+        - name: LOGZIO_LOGS_LISTENER_HOST
+          valueFrom:
+            secretKeyRef:
+              name: logzio-logs-secret
+              key: logzio-logs-listener
+        - name: CLUSTER_NAME
+          valueFrom:
+            secretKeyRef:
+              name: logzio-logs-secret
+              key: cluster-name
+        - name: IGNORE_OLDER
+          value: 3h
+        - name: LOGZIO_CODEC
+          value: json
+        - name: LOGZIO_TYPE
+          value: filebeat
+        securityContext:
+          runAsUser: 0
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/filebeat/data
+        - name: runlog
+          mountPath: /run/log/
+        - name: u01data
+          mountPath: /u01/data/docker/containers/
+          readOnly: true
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: config
+          mountPath: /etc/filebeat.yml
+          readOnly: true
+          subPath: filebeat.yml
+        - name: cert
+          mountPath: /etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt
+          readOnly: true
+          subPath: SectigoRSADomainValidationSecureServerCA.crt
+      volumes:
+      - name: runlog
+        hostPath:
+          path: /run/log/
+      - name: u01data
+        hostPath:
+            path: /u01/data/docker/containers/
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: data
+        hostPath:
+          path: /var/lib/filebeat-data
+          type: DirectoryOrCreate
+      - name: cert
+        configMap:
+          defaultMode: 384
+          name: logzio-logs-cert
+      - name: config
+        configMap:
+          defaultMode: 416
+          name: filebeat-config

--- a/shipping-config-samples/k8s-filebeat-oke.yaml
+++ b/shipping-config-samples/k8s-filebeat-oke.yaml
@@ -133,7 +133,7 @@ spec:
         - name: LOGZIO_CODEC
           value: json
         - name: LOGZIO_TYPE
-          value: filebeat
+          value: filebeat-oke
         securityContext:
           runAsUser: 0
         resources:


### PR DESCRIPTION
# What changed

Added a new daemonset for deploying filebeat to Oracle Kubernetes Engine (OKE).
The structure is almost identical to our documentation of filebeat for k8s.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

https://deploy-preview-803--logz-docs.netlify.app/shipping/log-sources/oracle-kubernetes-engine.html

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
