### PR TITLE
Switch dict config variable name

### DIFF
--- a/_source/logzio_collections/_log-sources/python.md
+++ b/_source/logzio_collections/_log-sources/python.md
@@ -142,7 +142,7 @@ import logging.config
 # If you're using a serverless function, uncomment.
 # from logzio.flusher import LogzioFlusher
 
-# Say I have saved my dictionary configuration in a variable named 'LOGGING' - see 'Dict Config' sample section
+# Say I have saved my configuration as a dictionary in a variable named 'LOGGING' - see 'Dict Config' sample section
 logging.config.dictConfig(LOGGING)
 logger = logging.getLogger('superAwesomeLogzioLogger')
 

--- a/_source/logzio_collections/_log-sources/python.md
+++ b/_source/logzio_collections/_log-sources/python.md
@@ -142,8 +142,8 @@ import logging.config
 # If you're using a serverless function, uncomment.
 # from logzio.flusher import LogzioFlusher
 
-# Say i have saved my configuration in a dictionary form in variable named myconf
-logging.config.dictConfig(myconf)
+# Say I have saved my dictionary configuration in a variable named 'LOGGING' - see 'Dict Config' sample section
+logging.config.dictConfig(LOGGING)
 logger = logging.getLogger('superAwesomeLogzioLogger')
 
 # If you're using a serverless function, uncomment.


### PR DESCRIPTION
Switch 'myconf' variable name in the code sample to 'LOGGING' so it will match our 'Dict config' section.

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
