### PR TITLE
added Otel to tracing "Deploying Components"

### DIFF
--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -23,8 +23,16 @@ We support the Jaeger, Zipkin, OpenTracing, and OpenTelemetry instrumentation li
 ## Component overview
 Because Logz.io embraces open source, we opted for Jaeger. Except for the collector integration, everything you need to deploy is created and maintained by the open source community, which means that the Logz.io support team can focus more effectively on the issues that the community can’t resolve. 
 
+### OpenTelemetry Collector
+Logz.io captures end-to-end distributed transactions from your applications and infrastructure with trace spans sent directly to Logz.io via the OpenTelemetry collector which you install inside your environment.
+
+We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. 
+
+See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Ship traces with OpenTelemetry </a>_ for the procedure to configure and deploy the OpenTelemetry collector.
+
+
 ### Logz.io Jaeger Collector
-Logz.io captures end-to-end distributed transactions from your applications and infrastructure with trace spans sent directly to Logz.io via the Jaeger Collector which you install inside your environment.
+As a secondary option, you may consider using the Jaeger Collector if you experience issues with the OpenTelemetry Collector. 
 
 The Logz.io integration builds on the Jaeger Collector base image and uses the gRPC plugin framework, to enable communication between the collector and Logz.io.
 


### PR DESCRIPTION
# What changed
  https://deploy-preview-821--logz-docs.netlify.app/user-guide/distributed-tracing/deploying-components

1.  OpenTelemetry is recommended as preferred collector for Distributed Tracing. Jaeger collector is presented as a secondary option. 

29 Dec: merge is on hold until OpenTelemetry shipping page is corrected and @yyyogev provides the k8s config info. 

10 Jan 2021: This PR is rendered obsolete by https://github.com/logzio/logz-docs/pull/853

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
