### PR TITLE
Temporary remove OpenTelemetry in Tracing shipping tab

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,10 +58,10 @@ collections:
     output: true
     permalink: /shipping/metrics-sources/:slug.html
     name: Metrics
-  tracing-sources:
-    output: true
-    permalink: /shipping/tracing-sources/:slug.html
-    name: Tracing
+#  tracing-sources:
+#    output: true
+#    permalink: /shipping/tracing-sources/:slug.html
+#    name: Tracing
   security-sources:
     output: true
     permalink: /shipping/security-sources/:slug.html

--- a/_source/_data/shipper-tabs.yml
+++ b/_source/_data/shipper-tabs.yml
@@ -18,8 +18,8 @@ tabs:
     templated: true
   - collection: metrics-sources
     templated: true
-  - collection: tracing-sources
-    templated: true
+#  - collection: tracing-sources
+#    templated: true
   - collection: security-sources
     templated: true
   - collection: shippers
@@ -64,8 +64,8 @@ tags:
     name: Security
   - slug: database
     name: Databases
-  - slug: traces
-    name: Tracing
+#  - slug: traces
+#    name: Tracing
   - slug: networking
     name: Networking
 


### PR DESCRIPTION
# What changed
https://deploy-preview-822--logz-docs.netlify.app/shipping/
commented out 3 areas in 2 yml files to disable Tracing shipping tab. 
_config.yml
_source/_data/shipper-tabs.yml


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
