### PR TITLE
21dec/instrumentation fixes

### DIFF
--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -23,8 +23,16 @@ We support the Jaeger, Zipkin, OpenTracing, and OpenTelemetry instrumentation li
 ## Component overview
 Because Logz.io embraces open source, we opted for Jaeger. Except for the collector integration, everything you need to deploy is created and maintained by the open source community, which means that the Logz.io support team can focus more effectively on the issues that the community can’t resolve. 
 
+### OpenTelemetry Collector
+Logz.io captures end-to-end distributed transactions from your applications and infrastructure with trace spans sent directly to Logz.io via the OpenTelemetry collector which you install inside your environment.
+
+We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. 
+
+See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Ship traces with OpenTelemetry </a>_ for the procedure to configure and deploy the OpenTelemetry collector.
+
+
 ### Logz.io Jaeger Collector
-Logz.io captures end-to-end distributed transactions from your applications and infrastructure with trace spans sent directly to Logz.io via the Jaeger Collector which you install inside your environment.
+As a secondary option, you may consider using the Jaeger Collector if you experience issues with the OpenTelemetry Collector. 
 
 The Logz.io integration builds on the Jaeger Collector base image and uses the gRPC plugin framework, to enable communication between the collector and Logz.io.
 

--- a/_source/user-guide/distributed-tracing/tracing-instrumentation.md
+++ b/_source/user-guide/distributed-tracing/tracing-instrumentation.md
@@ -42,7 +42,6 @@ While both instrumentations may cause performance overhead, the pros and cons of
 |   |Less flexibility compared to manual instrumentation          |Can include business metrics within the trace, such as events or messages you want to use for monitoring or business observability                 |                |
 |-----------------+------------+-----------------+----------------|
 
-Check out this related blog post for additional insights:  <a href="https://logz.io/blog/jaeger-instrumentation-introduction/#intro" target="_blank"> Jaeger Essentials: Introduction to Jaeger Instrumentation <i class="fas fa-external-link-alt"></i></a>. 
 
 ## Instrumentation recommendations and resources
 We recommend that you first instrument the frameworks that are supported out-of-the-box, before proceeding with manual instrumentation to fine-tune the data. This will make instrumentation much easier and minimize the code you must write.
@@ -72,3 +71,10 @@ The following open infrastructure projects include built-in auto instrumentation
 * <a href ="https://docs.traefik.io/observability/tracing/jaeger/" target="_blank">Traefik <i class="fas fa-external-link-alt"></i></a> 
 * <a href ="https://vertx-ci.github.io/vertx-4-preview/docs/vertx-opentracing/java/" target="_blank">VertX <i class="fas fa-external-link-alt"></i></a>
 * <a href ="https://docs.konghq.com/hub/kong-inc/zipkin/" target="_blank">Kong <i class="fas fa-external-link-alt"></i></a>
+
+### Expand your Instrumentation horizons: Logz.io blogs for inspiration and insights
+We have some blog posts that you might be interested in: 
+
+* <a href="https://logz.io/blog/jaeger-tracing-nodejs/" target="_blank"> Instrumenting Node.js for Tracing in Jaeger <i class="fas fa-external-link-alt"></i></a>
+* <a href="https://logz.io/blog/go-instrumentation-distributed-tracing-jaeger/"> Beginner’s Guide to Jaeger + OpenTracing Instrumentation for Go <i class="fas fa-external-link-alt"></i></a>
+* <a href="https://logz.io/blog/jaeger-instrumentation-introduction/#intro" target="_blank"> Jaeger Essentials: Introduction to Jaeger Instrumentation <i class="fas fa-external-link-alt"></i></a>

--- a/_source/user-guide/distributed-tracing/what-is-tracing.md
+++ b/_source/user-guide/distributed-tracing/what-is-tracing.md
@@ -46,12 +46,17 @@ All of these spans together make up the full trace.
 
 
 
-### Further reading 
 
-* <a href ="https://logz.io/tag/distributed-tracing/" target="_blank">Logz.io Distributing Tracing blog</a>  
+### Expand your Distributed Tracing horizons: Logz.io blogs for inspiration and insights
+We have some posts that you might be interested in: 
+
+* <a href ="https://logz.io/tag/distributed-tracing/" target="_blank">Logz.io Distributing Tracing blogs</a>  
 * <a href ="https://logz.io/tag/Jaeger/" target="_blank">Logz.io blog articles on Jaeger</a> 
 * <a href ="https://logz.io/blog/jaeger-kubernetes-best-practices/" target="_blank">Deploying Jaeger on Kubernetes</a> 
 * <a href ="https://logz.io/blog/jaeger-persistence/" target="_blank">Jaeger Persistent Storage</a>
+
+**Additional Jaeger tracing resources** 
+
 * <a href ="https://www.youtube.com/watch?v=zb0fdU6c0KU" target="_blank">Jaeger deep-dive <i class="fas fa-external-link-alt"></i></a> 
 * <a href ="https://www.jaegertracing.io" target="_blank">Jaegertracing.io <i class="fas fa-external-link-alt"></i></a> 
 * <a href ="https://medium.com/jaegertracing" target="_blank">Jaeger on Medium <i class="fas fa-external-link-alt"></i></a>


### PR DESCRIPTION
# What changed

https://deploy-preview-824--logz-docs.netlify.app/user-guide/distributed-tracing/getting-started-tracing/

per YotamB's request, removed link to blog from in-app shipper page &  moved links to blogs to end of topic, emphasizing that they are for inspiration/insights - not instruction.
https://app.logz.io/#/dashboard/data-sources/Tracing-gettingstarted

Related Trello card: https://trello.com/c/UDAWdIZH/112-tracing-shipping-instructions

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
