### PR TITLE
created tabs for OpenTelemetry & Jaeger collectors

### DIFF
--- a/_source/user-guide/distributed-tracing/k8s-deployment.md
+++ b/_source/user-guide/distributed-tracing/k8s-deployment.md
@@ -38,7 +38,19 @@ kubectl --namespace=monitoring create secret generic logzio-monitoring-secret \
 ##### Deploy agent and collector
 Deploy Jaeger agents and a collector - either the OpenTelemetry collector (recommended) or the Jaeger collector:
 
-### OpenTelemetry collector + Jaeger agents
+
+<!-- tabContainer:start -->
+<div class="branching-container">
+
+* [OpenTelemetry collector + Jaeger agents](#opentelemetry-collector)
+* [Jaeger collector and agents](#jaeger-collector)
+{:.branching-tabs}
+
+
+<!-- tab:start -->
+<div id="opentelemetry-collector">
+
+
 * Save the yaml below to a file and name it `config.yaml`
 * Edit the 2-letter region code if necessary (line 86)
 * Deploy the yaml:
@@ -227,7 +239,12 @@ spec:
   type: ClusterIP
 ```
 
-### Jaeger collector and agents
+
+</div>
+<!-- tab:end -->
+<!-- tab:start -->
+<div id="jaeger-collector">
+
 * Save the yaml below to a file and name it `config.yaml`
 * Edit the 2-letter region code if necessary (line 44)
 
@@ -360,3 +377,5 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
 ```
+</div>
+<!-- tab:end -->

--- a/_source/user-guide/distributed-tracing/k8s-deployment.md
+++ b/_source/user-guide/distributed-tracing/k8s-deployment.md
@@ -245,10 +245,9 @@ spec:
 <!-- tab:start -->
 <div id="jaeger-collector">
 
-* Save the yaml below to a file and name it `config.yaml`
-* Edit the 2-letter region code if necessary (line 44)
-
-* Deploy the yaml:
+1. Save the yaml below to a file and name it `config.yaml`.
+2. Edit the 2-letter region code if necessary (line 44).
+3. Deploy the yaml:
 
 ```
 kubectl apply -f config.yaml

--- a/_source/user-guide/distributed-tracing/k8s-deployment.md
+++ b/_source/user-guide/distributed-tracing/k8s-deployment.md
@@ -51,9 +51,9 @@ Deploy Jaeger agents and a collector - either the OpenTelemetry collector (recom
 <div id="opentelemetry-collector">
 
 
-* Save the yaml below to a file and name it `config.yaml`
-* Edit the 2-letter region code if necessary (line 86)
-* Deploy the yaml:
+1. Save the yaml below to a file and name it `config.yaml`.
+2. Edit the 2-letter region code if necessary (line 86).
+3. Deploy the yaml:
 
 ```
 kubectl apply -f config.yaml


### PR DESCRIPTION
# What changed
https://deploy-preview-838--logz-docs.netlify.app/user-guide/distributed-tracing/k8s-deployment
Created tabs for OpenTelemetry and Jaeger collector for K8s distributed tracing topic.

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
