### PR TITLE
fixed reference to general settings page image - hotrod demo content for tracing

### DIFF
--- a/_source/user-guide/distributed-tracing/trace-hotrod-demo.md
+++ b/_source/user-guide/distributed-tracing/trace-hotrod-demo.md
@@ -77,7 +77,7 @@ _To update your parameters, in the **.env** file:_
    
    You can find your the region code for your account in the General settings page, here: <a href="https://app.logz.io/#/dashboard/settings/general" target ="_blank"> **<i class="li li-gear"></i> >Settings > General**.
 
-   ![Navigate to general settings](https://dytvr9ot2sszz.cloudfront.net/logz-docs/distributed-tracing/general-settings1.png)
+   ![Navigate to general settings](https://dytvr9ot2sszz.cloudfront.net/logz-docs/distributed-tracing/general-settings.png)
 
 
 1. Save and close the updated **.env** file.     


### PR DESCRIPTION
# What changed

https://deploy-preview-839--logz-docs.netlify.app/user-guide/distributed-tracing/trace-hotrod-demo

@albertteoh pointed out a missing image, which had been updated last week: Image reference was updated on one page: Reference to image was not updated on another page that used it.

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
