### PR TITLE
temporary remove link to shipping page for OTEL

### DIFF
--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -28,7 +28,7 @@ Logz.io captures end-to-end distributed transactions from your applications and 
 
 We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. 
 
-See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Ship traces with OpenTelemetry </a>_ for the procedure to configure and deploy the OpenTelemetry collector.
+<!--See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Ship traces with OpenTelemetry </a>_ for the procedure to configure and deploy the OpenTelemetry collector. -->
 
 
 ### Logz.io Jaeger Collector


### PR DESCRIPTION
# What changed

//user-guide/distributed-tracing/deploying-components
removed link to tracing shipping pages taken down in another PR last week. 

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
