### PR TITLE
7jan/otel trace shipping

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,10 +67,12 @@ collections:
     name: Security
     id: :slug
     in-shipping-manifest: true
-#  tracing-sources:
-#    output: true
-#    permalink: /shipping/tracing-sources/:slug.html
-#    name: Tracing
+  tracing-sources:
+    output: true
+    permalink: /shipping/tracing-sources/:slug.html
+    name: Tracing
+    id: :slug
+    in-shipping-manifest: true
   community-shippers:
     output: false
     permalink: /shipping/community-shippers/:slug.html

--- a/_source/_data/shipper-tabs.yml
+++ b/_source/_data/shipper-tabs.yml
@@ -18,8 +18,8 @@ tabs:
     templated: true
   - collection: metrics-sources
     templated: true
-#  - collection: tracing-sources
-#    templated: true
+  - collection: tracing-sources
+    templated: true
   - collection: security-sources
     templated: true
   - collection: shippers
@@ -64,8 +64,8 @@ tags:
     name: Security
   - slug: database
     name: Databases
-#  - slug: traces
-#    name: Tracing
+  - slug: traces
+    name: Tracing
   - slug: networking
     name: Networking
 

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -1,0 +1,63 @@
+---
+title: Installing the Logz.io Jaeger Collector for Distributed Tracing
+logo:
+  logofile: jaeger.svg
+  orientation: vertical
+data-source: Jaeger
+description: How to deploy a Logz.io Jaeger Collector 
+open-source:
+  - title: 
+    github-repo: jaeger-logzio
+contributors:
+  - yyyogev
+  - yberlinger
+  - doron-bargo
+shipping-tags:
+  - traces
+---
+## Overview
+
+Logz.io's trace exporter for Jaeger allows you to ship distributed traces to Logz.io from different APM (Application Performance Management/Monitoring) agents, including Zipkin.
+
+This topic explains how to install the Logz.io Jaeger Collector. <br> For an overview of the process to send traces to Logz.io, see <a href="/user-guide/distributed-tracing/getting-started-tracing" target ="_blank"> Getting started with Logz.io Distributed Tracing</a>. 
+
+We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. <br> See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Ship traces with OpenTelemetry </a>_ for the procedure to configure and deploy the OpenTelemetry collector. You may consider using the Jaeger Collector as a secondary option, if you experience issues with the OpenTelemetry Collector. 
+
+### Logz.io Jaeger Collector
+
+The Logz.io integration builds on the Jaeger Collector base image and uses the gRPC plugin framework to enable communication between the Collector and Logz.io.
+
+#### Deploy OpenTelemetry Collector with Logz.io Exporter
+
+<div class="tasklist">
+
+##### Deploy Logz.io Jaeger Collector
+
+###### Configure the Logz.io extension
+Configure the Logz.io extension with shell variables or environment variables. <br> The required ports are described 
+<a href ="https://www.jaegertracing.io/docs/latest/deployment/#collectors)" target="_blank">here <i class="fas fa-external-link-alt"></i>.</a> 
+You'll need to change to the version page for your deployment. 
+
+```bash
+docker run -e ACCOUNT_TOKEN=<<SHIPPING-TOKEN>>  # see parameter list below\
+ --network=net-logzio \
+ --name=jaeger-logzio-collector \
+ -p 14268:14268 \
+ -p 9411:9411 \
+ -p 14267:14267 \
+ -p 14269:14269 \
+ -p 14250:14250 \
+logzio/jaeger-logzio-collector:latest
+```
+
+The complete list of Collector parameters is presented below. In addition to these parameters, you can also use 
+ <a href ="https://www.jaegertracing.io/docs/latest/cli/#jaeger-collector-grpc-plugin" target="_blank">Jaeger's collector parameters <i class="fas fa-external-link-alt"></i> </a> . You'll need to change to the version page for your deployment. 
+
+###### Parameters
+
+ Collector Parameter | Description
+ ------------ | -------------
+  ACCOUNT_TOKEN (Required) | - The account token is required when you use the collector to send traces to Logz.io <br> -  Replace `<SHIPPING-TOKEN>` with the token of the Distributed Tracing account you want to send data to <br><a href ="/user-guide/accounts/finding-your-tracing-account-token" target="_blank">How do I look up my Distributed Tracing account token?</a>
+REGION | -   Two-letter region code that determines the suggested listener URL (where you will be sending trace data to)  <br>-   Find your region code in the Regions and URLs table <br>-   This parameter is left blank for US East (Northern Virginia)<br><a href ="/user-guide/accounts/account-region.html#available-regions " target="_blank">How do I look up the Listener host URL for my region?</a>
+GRPC_STORAGE_PLUGIN_LOG_LEVEL| -   The lowest log level to send <br> -   Default: **warn** <br>-   From lowest to highest, log levels are: **trace, debug, info, warn, error** <br>-   Controls logging only for the Jaeger Logz.io Collector  <br>-   Does not affect Jaeger components
+COLLECTOR_ZIPKIN_HTTP_PORT | If you’re using a Zipkin implementation to create traces, set this optional environment variable to the HTTP port for the Zipkin collector service

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -1,5 +1,5 @@
 ---
-title: Ship traces with OpenTelemetry
+title: Installing the OpenTelemetry Collector for Distributed Tracing
 logo:
   logofile: opentelemetry-icon-color.png
   orientation: vertical
@@ -15,8 +15,13 @@ contributors:
 shipping-tags:
   - traces
 ---
+## Overview
 
 Logz.io's trace exporter for OpenTelemetry allows you to ship distributed traces to Logz.io from different APM (Application Performance Management/Monitoring) agents, such as Jaeger, Zipkin, and so on.
+
+This topic explains how to install the OpenTelemetry Collector. For an overview of the process to send traces to Logz.io, see <a href="/user-guide/distributed-tracing/getting-started-tracing" target ="_blank"> Getting started with Logz.io Distributed Tracing</a>. 
+
+### OpenTelemetry components
 
 The OpenTelemetry Collector pipeline has the following main components: 
 
@@ -25,7 +30,7 @@ The OpenTelemetry Collector pipeline has the following main components:
 * Processors are used at various stages of your pipeline to pre-process data before exporting it.  Processors may be used to modify attributes or sample the data. This component is used to ensure that your data successfully makes it through a pipeline.  <!-- how do you control what processors do? -->
 * Exporters are used to send data to your designated tracing (or metrics, or logging) backends/destinations. Your system must have at least one exporter configured to move data from collector to backend.
 
-OpenTelemetry also includes extensions for additional functionality, such as diagnostics and health checks, as well as a dedicated collector for components contributed by the community, such as the Logz.io exporter.
+OpenTelemetry also includes extensions for additional functionality, such as diagnostics and health checks for components contributed by the community, such as the Logz.io exporter, as well as a dedicated collector.
 
 #### Deploy OpenTelemetry Collector with Logz.io Exporter
 
@@ -66,14 +71,13 @@ docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 
 For a complete working example, you can run <a href ="https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/docker-compose.yaml" target = "_blank"> this docker compose file <i class="fas fa-external-link-alt"></i>.</a>
 
   1. Download the docker compose file.
-  2. Edit the Account Token and the other necessary parameters.
+  2. Edit the Account Token and the other necessary parameters, according to the the parameter list in step 2, above.
   3. Run `docker-compose up`. 
-  4. Head to [http://0.0.0.0:8080/](http://0.0.0.0:8080/) to trigger the event that will generate and send traces to your logz.io account.
+  4. Head to [http://0.0.0.0:8080/](http://0.0.0.0:8080/) to trigger the event that will generate and send traces to your Logz.io account.
 
-##### Check Jaeger for your traces.
+##### Check the Distributed Tracing tab for your traces.
 
-Give your traces some time to get from your system to ours,
-and then open your Jaeger UI.
+Give your traces some time to get from your system to ours, then check the Distributed Tracing tab in Logz.io to see the traces in the Jaeger UI.
 
 To learn more about tracing instrumentation, see <a href ="/user-guide/distributed-tracing/tracing-instrumentation#instrumentation-recommendations-and-resources" target = "_blank"> Instrumentation recommendations and resources <i class="fas fa-external-link-alt"></i>.</a>
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -45,7 +45,7 @@ You can use <a href ="https://github.com/open-telemetry/opentelemetry-collector-
 
 | Parameter | Description |
 |---|---|
-| ACCOUNT_TOKEN <span class="required-param"></span> | The Logz.io token for your Distributed Tracing account. Required when using as a collector to ship traces to Logz.io. Replace `<ACCOUNT_TOKEN>` with the token of the Distributed Tracing account you want to send data to <br><a href ="/user-guide/accounts/finding-your-tracing-account-token" target="_blank">How do I look up my Distributed Tracing account token?</a> |
+| ACCOUNT_TOKEN <span class="required-param"></span> | The Logz.io token for your Distributed Tracing account. Required when you use the collector to ship traces to Logz.io. <br>Replace `<ACCOUNT_TOKEN>` with the token of the Distributed Tracing account you want to send data to <br><a href ="/user-guide/accounts/finding-your-tracing-account-token" target="_blank">How do I look up my Distributed Tracing account token?</a> |
 | REGION <span class="default-param">_Blank (US East)_</span> |  Your two-letter Logz.io account region code. Defaults to US, required only if your Logz.io region is different than US. You can find your region code in the <a href = "https://docs.logz.io/user-guide/accounts/account-region.html#available-regions" target = "_blank">  Available regions <i class="fas fa-external-link-alt"></i></a> table. |
 | CUSTOM_LISTENER_ADDRESS | Custom traces endpoint, for dev. This optional parameter overrides the region parameter. <br> You can find your Listener Address in the <a href = "https://docs.logz.io/user-guide/accounts/account-region.html#available-regions" target = "_blank">  Available regions <i class="fas fa-external-link-alt"></i></a> table.|
 {:.paramlist}

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -4,13 +4,14 @@ logo:
   logofile: opentelemetry-icon-color.png
   orientation: vertical
 data-source: OpenTelemetry
-description: How to deploy an OpenTelemetry Collector for traces to logz.io
+description: How to deploy an OpenTelemetry Collector for traces to Logz.io
 open-source:
   - title: Logz.io-OpenTelemetry trace exporter
     github-repo: https://github.com/open-telemetry/opentelemetry-collector-contrib
 contributors:
   - yyyogev
   - yberlinger
+  - doron-bargo
 shipping-tags:
   - traces
 ---
@@ -19,11 +20,12 @@ Logz.io's trace exporter for OpenTelemetry allows you to ship distributed traces
 
 The OpenTelemetry Collector pipeline has the following main components: 
 
-* Receivers
-* Processors 
-* Exporters
+* Receivers are used to gather data from your environment (pull-based) or receive it from external sources (push-based). Your system must have at least one receiver configured. Receivers are typically HTTP/gRPC endpoints or daemon-like processes. 
 
-OpenTelemetry also includes extentions for additional functionality such as diagnostics and health checks, as well as a dedicated collector for components contributed by the community, such as the Logz.io exporter.
+* Processors are used at various stages of your pipeline to pre-process data before exporting it.  Processors may be used to modify attributes or sample the data. This component is used to ensure that your data successfully makes it through a pipeline.  <!-- how do you control what processors do? -->
+* Exporters are used to send data to your designated tracing (or metrics, or logging) backends/destinations. Your system must have at least one exporter configured to move data from collector to backend.
+
+OpenTelemetry also includes extensions for additional functionality, such as diagnostics and health checks, as well as a dedicated collector for components contributed by the community, such as the Logz.io exporter.
 
 #### Deploy OpenTelemetry Collector with Logz.io Exporter
 
@@ -43,9 +45,9 @@ You can use <a href ="https://github.com/open-telemetry/opentelemetry-collector-
 
 | Parameter | Description |
 |---|---|
-| ACCOUNT_TOKEN <span class="required-param"></span> | The Logz.io token for your Distributed Tracing account. Required when using as a collector to ship traces to Logz.io.  |
+| ACCOUNT_TOKEN <span class="required-param"></span> | The Logz.io token for your Distributed Tracing account. Required when using as a collector to ship traces to Logz.io. Replace `<ACCOUNT_TOKEN>` with the token of the Distributed Tracing account you want to send data to <br><a href ="/user-guide/accounts/finding-your-tracing-account-token" target="_blank">How do I look up my Distributed Tracing account token?</a> |
 | REGION <span class="default-param">_Blank (US East)_</span> |  Your two-letter Logz.io account region code. Defaults to US, required only if your Logz.io region is different than US. You can find your region code in the <a href = "https://docs.logz.io/user-guide/accounts/account-region.html#available-regions" target = "_blank">  Available regions <i class="fas fa-external-link-alt"></i></a> table. |
-| CUSTOM_LISTENER_ADDRESS | Custom traces endpoint, for dev. This optional parameter overrides the region parameter.|
+| CUSTOM_LISTENER_ADDRESS | Custom traces endpoint, for dev. This optional parameter overrides the region parameter. <br> You can find your Listener Address in the <a href = "https://docs.logz.io/user-guide/accounts/account-region.html#available-regions" target = "_blank">  Available regions <i class="fas fa-external-link-alt"></i></a> table.|
 {:.paramlist}
 
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -65,7 +65,7 @@ docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 
 ##### Run a working example.
 For a complete working example, you can run <a href ="https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/docker-compose.yaml" target = "_blank"> this docker compose file <i class="fas fa-external-link-alt"></i>.</a>
 
-  1. Download the file.
+  1. Download the docker compose file.
   2. Edit the Account Token and the other necessary parameters.
   3. Run `docker-compose up`. 
   4. Head to [http://0.0.0.0:8080/](http://0.0.0.0:8080/) to trigger the event that will generate and send traces to your logz.io account.

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -26,14 +26,10 @@ Because Logz.io embraces open source, we opted for Jaeger. Except for the collec
 ### OpenTelemetry Collector
 Logz.io captures end-to-end distributed transactions from your applications and infrastructure with trace spans sent directly to Logz.io via the OpenTelemetry collector which you install inside your environment.
 
-We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. 
-
-See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Installing the OpenTelemetry Collector for Distributed Tracing</a>_ for the procedure to configure and deploy the OpenTelemetry collector.
+We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Installing the OpenTelemetry Collector for Distributed Tracing</a>_ for the procedure to configure and deploy the OpenTelemetry collector.
 
 ### Logz.io Jaeger Collector
-As a secondary option, you may consider using the Jaeger Collector if you experience issues with the OpenTelemetry Collector. 
-
-See _<a href ="/shipping/tracing-sources/jaeger_collector" target="_blank">Installing the Logz.io Jaeger Collector for Distributed Tracing </a>_ for the procedure to configure and deploy the Logz.io Jaeger collector.
+As a secondary option, you may consider using the Jaeger Collector if you experience issues with the OpenTelemetry Collector. See _<a href ="/shipping/tracing-sources/jaeger_collector" target="_blank">Installing the Logz.io Jaeger Collector for Distributed Tracing </a>_ for the procedure to configure and deploy the Logz.io Jaeger collector.
 
 ### Agent
 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -28,7 +28,7 @@ Logz.io captures end-to-end distributed transactions from your applications and 
 
 We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. 
 
-See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Ship traces with OpenTelemetry </a>_ for the procedure to configure and deploy the OpenTelemetry collector.
+See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Installing the OpenTelemetry Collector for Distributed Tracing</a>_ for the procedure to configure and deploy the OpenTelemetry collector.
 
 ### Logz.io Jaeger Collector
 As a secondary option, you may consider using the Jaeger Collector if you experience issues with the OpenTelemetry Collector. 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -30,36 +30,10 @@ We recommend that you use the OpenTelemetry collector to gather trace transactio
 
 See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Ship traces with OpenTelemetry </a>_ for the procedure to configure and deploy the OpenTelemetry collector.
 
-
 ### Logz.io Jaeger Collector
 As a secondary option, you may consider using the Jaeger Collector if you experience issues with the OpenTelemetry Collector. 
 
-The Logz.io integration builds on the Jaeger Collector base image and uses the gRPC plugin framework, to enable communication between the collector and Logz.io.
-
-Configure the Logz.io extension with shell variables or environment variables. The required ports are described 
-<a href ="https://www.jaegertracing.io/docs/latest/deployment/#collectors)" target="_blank">here <i class="fas fa-external-link-alt"></i>.</a> You'll need to change to the version page for your deployment. 
-
-```bash
-docker run -e ACCOUNT_TOKEN=<<SHIPPING-TOKEN>> \
- --network=net-logzio \
- --name=jaeger-logzio-collector \
- -p 14268:14268 \
- -p 9411:9411 \
- -p 14267:14267 \
- -p 14269:14269 \
- -p 14250:14250 \
-logzio/jaeger-logzio-collector:latest
-```
-
-The complete list of collector parameters is presented below. In addition to these parameters, you can also use 
- <a href ="https://www.jaegertracing.io/docs/latest/cli/#jaeger-collector-grpc-plugin" target="_blank">Jaeger's collector parameters <i class="fas fa-external-link-alt"></i> </a> . You'll need to change to the version page for your deployment. 
-
- Collector Parameter | Description
- ------------ | -------------
-  ACCOUNT_TOKEN (Required) | - The account token is required when you use the collector to send traces to Logz.io <br> -  Replace `<SHIPPING-TOKEN>` with the token of the Distributed Tracing account you want to send data to <br><a href ="/user-guide/accounts/finding-your-tracing-account-token" target="_blank">How do I look up my Distributed Tracing account token?</a>
-REGION | -   Two-letter region code that determines the suggested listener URL (where you will be sending trace data to)  <br>-   Find your region code in the Regions and URLs table <br>-   This parameter is left blank for US East (Northern Virginia)<br><a href ="/user-guide/accounts/account-region.html#available-regions " target="_blank">How do I look up the Listener host URL for my region?</a>
-GRPC_STORAGE_PLUGIN_LOG_LEVEL| -   The lowest log level to send <br> -   Default: **warn** <br>-   From lowest to highest, log levels are: **trace, debug, info, warn, error** <br>-   Controls logging only for the Jaeger Logz.io Collector  <br>-   Does not affect Jaeger components
-COLLECTOR_ZIPKIN_HTTP_PORT | If you’re using a Zipkin implementation to create traces, set this optional environment variable to the HTTP port for the Zipkin collector service
+See _<a href ="/shipping/tracing-sources/jaeger_collector" target="_blank">Installing the Logz.io Jaeger Collector for Distributed Tracing </a>_ for the procedure to configure and deploy the Logz.io Jaeger collector.
 
 ### Agent
 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -28,7 +28,7 @@ Logz.io captures end-to-end distributed transactions from your applications and 
 
 We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. 
 
-<!--See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Ship traces with OpenTelemetry </a>_ for the procedure to configure and deploy the OpenTelemetry collector. -->
+See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Ship traces with OpenTelemetry </a>_ for the procedure to configure and deploy the OpenTelemetry collector.
 
 
 ### Logz.io Jaeger Collector


### PR DESCRIPTION
# What changed
https://deploy-preview-853--logz-docs.netlify.app/shipping/tracing-sources/opentelemetry.html
https://deploy-preview-853--logz-docs.netlify.app/shipping/tracing-sources/jaeger-collector.html
Shipping tab visible: https://deploy-preview-853--logz-docs.netlify.app/shipping/


- Returned the Tracing tab to *Ship your data*, and updated the content for OpenTelemetry collector for tracing. 
- Created a parallel Jaeger collector topic

10 Jan: Merging even though there are 2 questions open with Yogev. 

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
