### PR TITLE
fix link to Getting Started in jaeger_collector

### DIFF
--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -21,7 +21,7 @@ Logz.io's trace exporter for Jaeger allows you to ship distributed traces to Log
 
 This topic explains how to install the Logz.io Jaeger Collector. 
 
-For an overview of the process to send traces to Logz.io, see [Getting started with Logz.io Distributed Tracing](/user-guide/distributed-tracing/getting-started-tracing"). 
+For an overview of the process to send traces to Logz.io, see [Getting started with Logz.io Distributed Tracing](/user-guide/distributed-tracing/getting-started-tracing). 
 
 We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. 
 See [_Ship traces with OpenTelemetry_](/shipping/tracing-sources/opentelemetry) for the procedure to configure and deploy the OpenTelemetry collector. You may consider using the Jaeger Collector as a secondary option, if you experience issues with the OpenTelemetry Collector. 


### PR DESCRIPTION
# What changed
https://deploy-preview-873--logz-docs.netlify.app/shipping/tracing-sources/jaeger-collector.html

fixed link to https://deploy-preview-873--logz-docs.netlify.app/user-guide/distributed-tracing/getting-started-tracing 
Fixed broken link reported by Masha.


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
