### PR TITLE
Docker n/w, + collector name in agent config

### DIFF
--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -33,9 +33,13 @@ The Logz.io integration builds on the Jaeger Collector base image and uses the g
 <div class="tasklist">
 
 ##### Create a Docker network
-```bash
+Run the following command to create a Docker network: 
+
+```yaml
 docker network create net-logzio
 ```
+
+To enable communication between the collector and the agent, include the name of the network you create in this step (for example, `net-logzio`) in the config file for each component. 
 
 ##### Configure the Logz.io extension
 Configure the Logz.io extension with shell variables or environment variables. 
@@ -43,10 +47,10 @@ Configure the Logz.io extension with shell variables or environment variables.
 The required ports are described [here. ](https://www.jaegertracing.io/docs/latest/deployment/#collectors) 
 You'll need to change to the version page for your deployment. 
 
-```bash
+```yaml
 docker run -e ACCOUNT_TOKEN=<<SHIPPING-TOKEN>>  # see parameter list below\
- --network=net-logzio \
- --name=jaeger-logzio-collector \
+ --network=net-logzio \  # This is the name of the network you created in step 1 above.
+ --name=jaeger-logzio-collector \ # This is the name of the collector
  -p 14268:14268 \
  -p 9411:9411 \
  -p 14267:14267 \
@@ -67,4 +71,4 @@ You'll need to change to the version page for your deployment.
   ACCOUNT_TOKEN (Required) | The account token is required when you use the collector to send traces to Logz.io. Replace `<SHIPPING-TOKEN>` with the token of the Distributed Tracing account you want to send data to. [_How do I look up my Distributed Tracing account token?_](/user-guide/accounts/finding-your-tracing-account-token)|
 REGION | Two-letter region code that determines the suggested listener URL (where you will be sending trace data to).   Find your region code in the Regions and URLs table. This parameter is left blank for US East (Northern Virginia).  [_How do I look up the Listener host URL for my region?_](/user-guide/accounts/account-region.html#available-regions)|
 GRPC_STORAGE_PLUGIN_LOG_LEVEL| The lowest log level to send.  Default: **warn**.  From lowest to highest, log levels are: **trace, debug, info, warn, error**.  Controls logging only for the Jaeger Logz.io Collector.  Does not affect Jaeger components.|
-COLLECTOR_ZIPKIN_HTTP_PORT | If you’re using a Zipkin implementation to create traces, set this optional environment variable to the HTTP port for the Zipkin collector service
+COLLECTOR_ZIPKIN_HTTP_PORT | If you’re using a Zipkin implementation to create traces, set this optional environment variable to the HTTP port for the Zipkin collector service.|

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -49,8 +49,8 @@ You'll need to change to the version page for your deployment.
 
 ```yaml
 docker run -e ACCOUNT_TOKEN=<<SHIPPING-TOKEN>>  # see parameter list below\
- --network=net-logzio \  # This is the name of the network you created in step 1 above.
- --name=jaeger-logzio-collector \ # This line specifies the name of the collector: In this example, "jaeger-logzio-collector"
+ --network=net-logzio \  ## This is the name of the network you created in step 1 above.
+ --name=jaeger-logzio-collector \ ## This line specifies the name of the collector: In this example, "jaeger-logzio-collector"
  -p 14268:14268 \
  -p 9411:9411 \
  -p 14267:14267 \

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -50,7 +50,7 @@ You'll need to change to the version page for your deployment.
 ```yaml
 docker run -e ACCOUNT_TOKEN=<<SHIPPING-TOKEN>>  # see parameter list below\
  --network=net-logzio \  # This is the name of the network you created in step 1 above.
- --name=jaeger-logzio-collector \ # This is the name of the collector
+ --name=jaeger-logzio-collector \ # This line specifies the name of the collector: In this example, "jaeger-logzio-collector"
  -p 14268:14268 \
  -p 9411:9411 \
  -p 14267:14267 \

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -35,9 +35,18 @@ OpenTelemetry also includes extensions for additional functionality, such as dia
 
 <div class="tasklist">
 
+##### Create a Docker network
+Run the following command to create a Docker network: 
+
+```yaml
+docker network create net-logzio
+```
+
+To enable communication between the collector and the agent, include the name of the network you create in this step (for example, `net-logzio`) in the config file for each component. 
+
 ##### Pull the opentelemetry-collector-contrib image:
 
-```
+```yaml
 docker pull otel/opentelemetry-collector-contrib:0.17.0
 ```
 
@@ -74,7 +83,7 @@ For a complete working example, you can run [this docker compose file](https://r
 
   1. Download the docker compose file.
 
-  2. Edit the Account Token and the other necessary parameters, according to the parameters listed in step 2, above.
+  2. Edit the Account Token and the other necessary parameters, according to the parameters listed in step 3, above.
   3. Run `docker-compose up`. 
   4. Head to [http://0.0.0.0:8080/](http://0.0.0.0:8080/) to trigger the event that will generate and send traces to your Logz.io account.
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -74,7 +74,7 @@ You can use [this config file](https://github.com/open-telemetry/opentelemetry-c
 ```yaml
 docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 -p 9411:9411 \
     -v config.yaml:/etc/otel-collector-config.yaml:ro \
-    --name otelcontribcol otel/opentelemetry-collector-contrib:0.5.0 \  # This line specifies the name of the collector: In this example, "otelcontribcol"
+    --name otelcontribcol otel/opentelemetry-collector-contrib:0.5.0 \  ## This line specifies the name of the collector: In this example, "otelcontribcol"
         --config /etc/otel-collector-config.yaml
 ```
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -74,7 +74,7 @@ You can use [this config file](https://github.com/open-telemetry/opentelemetry-c
 ```yaml
 docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 -p 9411:9411 \
     -v config.yaml:/etc/otel-collector-config.yaml:ro \
-    --name otelcontribcol otel/opentelemetry-collector-contrib:0.5.0 \
+    --name otelcontribcol otel/opentelemetry-collector-contrib:0.5.0 \  # This line specifies the name of the collector: In this example, "otelcontribcol"
         --config /etc/otel-collector-config.yaml
 ```
 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -23,6 +23,16 @@ We support the Jaeger, Zipkin, OpenTracing, and OpenTelemetry instrumentation li
 ## Component overview
 Because Logz.io embraces open source, we opted for Jaeger. Except for the collector integration, everything you need to deploy is created and maintained by the open source community, which means that the Logz.io support team can focus more effectively on the issues that the community can’t resolve. 
 
+To enable communication between the collector and agent, you'll need to create a Docker network that will be shared by these compontents. 
+
+When you configure the components, make sure that you:
+
++ Specify the same network name in the code for both the collector and the agent.
++ Specify the relevant collector name when you configure your agent.  
+
+## Collector options
+
+You can use either the OpenTelemetry Collector or the Logz.io Jaeger Collector.
 ### OpenTelemetry Collector
 Logz.io captures end-to-end distributed transactions from your applications and infrastructure with trace spans sent directly to Logz.io via the OpenTelemetry collector which you install inside your environment.
 
@@ -30,13 +40,14 @@ We recommend that you use the OpenTelemetry collector to gather trace transactio
 
 See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Installing the OpenTelemetry Collector for Distributed Tracing</a>_ for the procedure to configure and deploy the OpenTelemetry collector.
 
-
 ### Logz.io Jaeger Collector
-As a secondary option, you may consider using the Jaeger Collector if you experience issues with the OpenTelemetry Collector. See _<a href ="/shipping/tracing-sources/jaeger_collector" target="_blank">Installing the Logz.io Jaeger Collector for Distributed Tracing </a>_ for the procedure to configure and deploy the Logz.io Jaeger collector.
+As a secondary option, you may consider using the Jaeger Collector if you experience issues with the OpenTelemetry Collector. See _<a href ="/shipping/tracing-sources/jaeger-collector" target="_blank">Installing the Logz.io Jaeger Collector for Distributed Tracing</a>_ for the procedure to configure and deploy the Logz.io Jaeger collector.
 
-### Agent
+## Agent
 
 You can deploy an agent as a sidecar container or as a Host Daemon. Although deploying an agent is not absolutely required for the instrumentation libraries which support sending spans directly to the collector, an agent can help with load balancing and enriching spans with additional tags that are not available at the collector level. 
+
+Make sure you include both the relevant Docker network and the collector name in the agent configuration.
 
 When deciding the best approach for your environment, consider the following factors: 
 
@@ -47,15 +58,19 @@ When deciding the best approach for your environment, consider the following fac
 
 ### *To deploy a Jaeger agent in a Docker environment*
 
-```bash
-docker run \  ## make sure to expose only the ports you use in your deployment scenario!
-  --rm \
+When you deploy a Jaeger agent in a Docker environment, make sure you include the Docker network name and your collector name in the configuration.
+
+In the agent configuration below, the Docker network name is `net-logzio` and the collector name is `jaeger-logzio-collector`:
+
+```yaml
+docker run \ --rm --name=jaeger-agent --network=net-logzio \ ## make sure to expose only the ports you use in your deployment scenario!
  -p6831:6831/udp \
  -p6832:6832/udp \
  -p5778:5778/tcp \
  -p5775:5775/udp \
- jaegertracing/jaeger-agent:1.20  ## Use the relevant agent version
-  ```
+ jaegertracing/jaeger-agent:1.18.0  ## Use the relevant Jaeger version for the agent. Logz.io has tested this file for version 1.18. It is possible that the reference may not work for other versions.
+--reporter.grpc.host-port=jaeger-logzio-collector:14250
+```
 
 Refer to the <a href="https://www.jaegertracing.io/docs/latest/deployment/#agent" target="_blank"> Jaeger documentation <i class="fas fa-external-link-alt"></i> </a> for the agent version.
 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -33,6 +33,7 @@ When you configure the components, make sure that you:
 ## Collector options
 
 You can use either the OpenTelemetry Collector or the Logz.io Jaeger Collector.
+
 ### OpenTelemetry Collector
 Logz.io captures end-to-end distributed transactions from your applications and infrastructure with trace spans sent directly to Logz.io via the OpenTelemetry collector which you install inside your environment.
 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -71,9 +71,9 @@ docker run \ --rm --name=jaeger-agent --network=net-logzio \ ## make sure to exp
 --reporter.grpc.host-port=logzio-collector:14250  ##This line specifies which collector the agent communicates with. 
 ```
 
-Logz.io has tested this Docker deployment file for version 1.18 of the Jaeger agent. It is possible that the reference may not work for other versions.
+While youu can always refer to the <a href="https://www.jaegertracing.io/docs/latest/deployment/#agent" target="_blank"> Jaeger documentation <i class="fas fa-external-link-alt"></i> </a> for the latest agent version, we recommend you use version 1.18.
 
-Refer to the <a href="https://www.jaegertracing.io/docs/latest/deployment/#agent" target="_blank"> Jaeger documentation <i class="fas fa-external-link-alt"></i> </a> for the latest agent version.
+ Logz.io has tested the Docker deployment file for version 1.18 of the Jaeger agent. It is possible that the reference may not work for other versions.
 
 ### *Kubernetes deployment reference*
 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -57,9 +57,9 @@ When deciding the best approach for your environment, consider the following fac
 
 ### *To deploy a Jaeger agent in a Docker environment*
 
-When you deploy a Jaeger agent in a Docker environment, make sure you include the Docker network name and your collector name in the configuration.
+When you deploy a Jaeger agent in a Docker environment, make sure you include the Docker network name and the relevant collector name in the configuration.
 
-In the agent configuration below, the Docker network name is `net-logzio` and the collector name is `jaeger-logzio-collector`:
+In the agent configuration below, the Docker network name is `net-logzio` and the collector name is `logzio-collector`:
 
 ```yaml
 docker run \ --rm --name=jaeger-agent --network=net-logzio \ ## make sure to expose only the ports you use in your deployment scenario!
@@ -68,10 +68,12 @@ docker run \ --rm --name=jaeger-agent --network=net-logzio \ ## make sure to exp
  -p5778:5778/tcp \
  -p5775:5775/udp \
  jaegertracing/jaeger-agent:1.18.0  ## Use the relevant Jaeger version for the agent. Logz.io has tested this file for version 1.18. It is possible that the reference may not work for other versions.
---reporter.grpc.host-port=jaeger-logzio-collector:14250
+--reporter.grpc.host-port=logzio-collector:14250  ##This line specifies which collector the agent communicates with. 
 ```
 
-Refer to the <a href="https://www.jaegertracing.io/docs/latest/deployment/#agent" target="_blank"> Jaeger documentation <i class="fas fa-external-link-alt"></i> </a> for the agent version.
+Logz.io has tested this Docker deployment file for version 1.18 of the Jaeger agent. It is possible that the reference may not work for other versions.
+
+Refer to the <a href="https://www.jaegertracing.io/docs/latest/deployment/#agent" target="_blank"> Jaeger documentation <i class="fas fa-external-link-alt"></i> </a> for the latest agent version.
 
 ### *Kubernetes deployment reference*
 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -48,8 +48,6 @@ As a secondary option, you may consider using the Jaeger Collector if you experi
 
 You can deploy an agent as a sidecar container or as a Host Daemon. Although deploying an agent is not absolutely required for the instrumentation libraries which support sending spans directly to the collector, an agent can help with load balancing and enriching spans with additional tags that are not available at the collector level. 
 
-Make sure you include both the relevant Docker network and the collector name in the agent configuration.
-
 When deciding the best approach for your environment, consider the following factors: 
 
 1.  **Do you need to lower the number of open connections?** 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -62,13 +62,13 @@ When you deploy a Jaeger agent in a Docker environment, make sure you include th
 In the agent configuration below, the Docker network name is `net-logzio` and the collector name is `logzio-collector`:
 
 ```yaml
-docker run \ --rm --name=jaeger-agent --network=net-logzio \ ## make sure to expose only the ports you use in your deployment scenario!
+docker run \ --rm --name=jaeger-agent --network=net-logzio \ ## Make sure to expose only the ports you use in your deployment scenario!
  -p6831:6831/udp \
  -p6832:6832/udp \
  -p5778:5778/tcp \
  -p5775:5775/udp \
  jaegertracing/jaeger-agent:1.18.0  ## Use the relevant Jaeger version for the agent. Logz.io has tested this file for version 1.18. It is possible that the reference may not work for other versions.
---reporter.grpc.host-port=logzio-collector:14250  ##This line specifies which collector the agent communicates with. 
+--reporter.grpc.host-port=logzio-collector:14250  ## This line specifies which collector the agent communicates with. 
 ```
 
 While youu can always refer to the <a href="https://www.jaegertracing.io/docs/latest/deployment/#agent" target="_blank"> Jaeger documentation <i class="fas fa-external-link-alt"></i> </a> for the latest agent version, we recommend you use version 1.18.

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -71,7 +71,7 @@ docker run \ --rm --name=jaeger-agent --network=net-logzio \ ## Make sure to exp
 --reporter.grpc.host-port=logzio-collector:14250  ## This line specifies which collector the agent communicates with. 
 ```
 
-While youu can always refer to the <a href="https://www.jaegertracing.io/docs/latest/deployment/#agent" target="_blank"> Jaeger documentation <i class="fas fa-external-link-alt"></i> </a> for the latest agent version, we recommend you use version 1.18.
+While you can always refer to the <a href="https://www.jaegertracing.io/docs/latest/deployment/#agent" target="_blank"> Jaeger documentation <i class="fas fa-external-link-alt"></i> </a> for the latest agent version, we recommend you use version 1.18.
 
  Logz.io has tested the Docker deployment file for version 1.18 of the Jaeger agent. It is possible that the reference may not work for other versions.
 


### PR DESCRIPTION
# What changed: 

https://deploy-preview-883--logz-docs.netlify.app/user-guide/distributed-tracing/deploying-components
https://deploy-preview-883--logz-docs.netlify.app/shipping/tracing-sources/opentelemetry.html
https://deploy-preview-883--logz-docs.netlify.app/shipping/tracing-sources/jaeger-collector.html

- Added step to create Docker network in Jaeger and OpenTelemetry Collector config pages
- added instructions to include the name of the Docker network in both collector and agent config files
- added instructions to include name of the collector in the Jaeger agent config file. 

**Merged to master -still needs tech review.**

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
