### PR TITLE
remove env vars

### DIFF
--- a/_source/logzio_collections/_metrics-sources/docker.md
+++ b/_source/logzio_collections/_metrics-sources/docker.md
@@ -92,8 +92,6 @@ logzio/docker-collector-metrics
 
 | Parameter | Description |
 |---|---|
-| DOCKER_MATCH_CONTAINER_NAME | Comma-separated list of containers you want to collect the metrics from. If a container's name partially matches a name on the list, that container's metrics are shipped. Otherwise, its metrics are ignored.    **Note**: Can't be used with `DOCKER_SKIP_CONTAINER_NAME`. |
-| DOCKER_SKIP_CONTAINER_NAME | Comma-separated list of containers you want to ignore. If a container's name partially matches a name on the list, that container's metrics are ignored. Otherwise, its metrics are shipped.    **Note**: Can't be used with `DOCKER_MATCH_CONTAINER_NAME`. |
 | DOCKER_PERIOD <span class="default-param">`10s`</span> | Sampling rate of metrics. The Docker API takes up to 2 seconds to respond, so we recommend setting this to `3s` or longer. |
 | DOCKER_CERTIFICATE_AUTHORITY | Filepath to certificate authority for connecting to Docker over TLS. |
 | DOCKER_CERTIFICATE | Filepath to CA certificate for connecting to Docker over TLS. |

--- a/_source/logzio_collections/_metrics-sources/docker.md
+++ b/_source/logzio_collections/_metrics-sources/docker.md
@@ -88,15 +88,6 @@ logzio/docker-collector-metrics
 | CLOUD_METADATA <span class="default-param">`"false"`</span> | Set to `true` to enrich events with instance metadata from the machine’s hosting provider. |
 {:.paramlist}
 
-###### Parameters for the Docker module
-
-| Parameter | Description |
-|---|---|
-| DOCKER_PERIOD <span class="default-param">`10s`</span> | Sampling rate of metrics. The Docker API takes up to 2 seconds to respond, so we recommend setting this to `3s` or longer. |
-| DOCKER_CERTIFICATE_AUTHORITY | Filepath to certificate authority for connecting to Docker over TLS. |
-| DOCKER_CERTIFICATE | Filepath to CA certificate for connecting to Docker over TLS. |
-| DOCKER_KEY | Filepath to Docker key for connecting to Docker over TLS. |
-{:.paramlist}
 
 {% include metric-shipping/open-dashboard.md title="Docker overview" %}
 


### PR DESCRIPTION
# What changed

Removed the modules for docker module table. Those envs weren't supposed to be there in the first place.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
