### PR TITLE
fix link to JSON upload instructions...

### DIFF
--- a/_source/user-guide/infrastructure-monitoring/p8s-importing-dashbds.md
+++ b/_source/user-guide/infrastructure-monitoring/p8s-importing-dashbds.md
@@ -47,7 +47,7 @@ In the left navigation pane, click <i class="fas fa-plus"></i> and select **Impo
 
   - To import your existing Prometheus dashboards, first export the relevant dashboards as JSON files, then click **Upload json file** and select the files to upload. 
     
-    For more information see [Upload JSON logs]({{site.baseurl}}/user-guide/shipping/log-sources/json-uploads.html). 
+    For related information see [Upload JSON logs]({{site.baseurl}}/shipping/log-sources/json-uploads). 
   - To import dashboards from Grafana.com, enter the relevant dashboard URL or ID in **Import via grafana.com** and **Load** them. 
 </div>
 


### PR DESCRIPTION
# What changed
https://deploy-preview-907--logz-docs.netlify.app/user-guide/infrastructure-monitoring/p8s-importing-dashbds

Fixed link in upload dashboard instructions for P8s getting started to point to instructions for uploading log files via JSON. 
points to : https://deploy-preview-907--logz-docs.netlify.app/shipping/log-sources/json-uploads


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
