### PR TITLE
P8sRemoteWrite in Send your data & bulk import 1st

### DIFF
--- a/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
+++ b/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
@@ -46,9 +46,9 @@ Once your metrics are flowing, export your existing Prometheus and Grafana dashb
 ##### Get your Logz.io Infrastructure Monitoring account information
 Within Logz.io, look up the Listener host for your region (URL) and the Logz.io Metrics Account token.
 
-+ You'll find the correct Region and Listener URL for your region in the <a href ="{{site.baseurl}}/user-guide/accounts/account-region.html#available-regions" target="_blank">_Regions and Listener Hosts_</a> table. 
++ You'll find the correct Region and Listener URL for your region in the [_Regions and Listener Hosts_]({{site.baseurl}}/user-guide/accounts/account-region.html#available-regions) table. 
 
-+ Look up your Metrics account information in the <a href ="https://app.logz.io/#/dashboard/settings/manage-accounts" target="_blank">Manage Accounts **(<i class="li li-gear"></i> > Settings > Manage accounts)**</a> page of your Operations workspace. Click the relevant **Metrics account plan** to display its details, including your <a href ="/user-guide/accounts/finding-your-metrics-account-token/" target="_blank">Metrics account token. </a> 
++ Look up your Metrics account information in the [Manage Accounts **gear icon > Settings > Manage accounts)**](https://app.logz.io/#/dashboard/settings/manage-accounts) page of your Operations workspace. Click the relevant **Metrics account plan** to display its details, including your [Metrics account token.]({{site.baseurl}}//user-guide/accounts/finding-your-metrics-account-token/)
 ![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
 
 ##### Add a remote_write url
@@ -78,8 +78,14 @@ Add the following parameters to your Prometheus yaml file:
           capacity: 10000  #default = 500
 
 ```
-
    
 ##### Verify the remote_write configuration
-To check that the remote_write configuration is working properly, run a query on your local Prometheus for the metric `prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
 
+
++ To check that the remote_write configuration is working properly, run a query on your local Prometheus for the metric `prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
+
++ **Check via Grafana Explore**: To verify that metrics are arriving to Logz,io: 
+1. Click the **Explore icon <i class="far fa-compass"></i>** in the left menu to open Grafana’s Explore. 
+
+1. Examine the Metrics drop down next to the **Explore** heading in the upper left of the pane. 
+  An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 

--- a/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
+++ b/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
@@ -1,0 +1,85 @@
+---
+title: Configuring remote write for Prometheus 
+logo:
+  logofile: prometheusio-icon.svg
+  orientation: vertical
+data-source: Remote write for Prometheus
+flags:
+  logzio-plan:  
+  beta: true
+templates: ["docker"]
+contributors:
+  - yberlinger
+shipping-tags:
+contributors:
+  - yberlinger
+---
+
+{% include page-info/early-access.md type="beta" %}
+
+To send your Prometheus application metrics to a Logz.io Infrastructure Monitoring account, use remote write to connect to Logz.io as the endpoint. Your data is formatted as JSON documents by the Logz.io listener. 
+
+### Plan ahead
+
+* **Multiple server environments**: If you have multiple Prometheus server instances, you'll have to add Logz.io as an endpoint for each instance. 
+
+* **Reduce tagging**: By default, all the metrics from your Prometheus server(s) are sent to Logz.io. To drop or send specific metrics, add Prometheus labeling _before_ enabling the remote write, or as part of the remote write configuration.  Learn more about Prometheus relabeling tricks [here.](https://medium.com/quiq-blog/prometheus-relabeling-tricks-6ae62c56cbda)
+
+
+* **Paralleism levels**: Set the parallelism level for sending data in the configuration file. 
+    This parameter determines the number of connections to open to the remote write listener.  The default parallelism level is 1000. We recommend configuring much fewer connections. Of course, if you're sending more data you'll need to open more channels. _(currently in development)_
+    
+    We're currently refining our best practice recommendations for configuring connection channels when sending data.
+
+* **Metrics metadata dashboards**: If you have both Prometheus & Grafana, you can activate a dashboard as part of the remote write configuration that will show you the queue size and how many metrics you're sending. If your queue size increases, it might be necessary to open an additional channel. _(currently in development)_
+
+Learn more about Prometheus remote write tuning [here.](https://prometheus.io/docs/practices/remote_write/) 
+
+Once your metrics are flowing, export your existing Prometheus and Grafana dashboards to Logz.io Infrastructure Monitoring as JSON files.  
+
+#### Configuring Remote Write to Logz.io
+
+{:.no_toc}  
+
+<div class="tasklist">
+
+##### Get your Logz.io Infrastructure Monitoring account information
+Within Logz.io, look up the Listener host for your region (URL) and the Logz.io Metrics Account token.
+
++ You'll find the correct Region and Listener URL for your region in the <a href ="{{site.baseurl}}/user-guide/accounts/account-region.html#available-regions" target="_blank">_Regions and Listener Hosts_</a> table. 
+
++ Look up your Metrics account information in the <a href ="https://app.logz.io/#/dashboard/settings/manage-accounts" target="_blank">Manage Accounts **(<i class="li li-gear"></i> > Settings > Manage accounts)**</a> page of your Operations workspace. Click the relevant **Metrics account plan** to display its details, including your <a href ="/user-guide/accounts/finding-your-metrics-account-token/" target="_blank">Metrics account token. </a> 
+![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
+
+##### Add a remote_write url
+Add the following parameters to your Prometheus yaml file:
+
+| Environment variable | Description |
+|---|---|
+| external_labels | Parameter to tag the metrics from this specific Prometheus server. Do not change the label `p8s_logzio_name`: This variable is required to identify from which Prometheus environment the metrics are arriving to Logz.io  |
+| remote_write | The remote write section configuration sets Logz.io as the endpoint for your Prometheus metrics data. Place this section at the same indentation level as the `global` section. |
+|url| Logz.io Listener url for for your region, configured to use port **8052** for http traffic or port **8053** for https traffic. For more details, see the [Prometheus configuration file remote write reference](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)|
+|bearer_token| Logz.io Metrics account token|
+
+
+```yaml
+    global:
+      external_labels:
+        p8s_logzio_name: <labelvalue>
+    remote_write:
+      - url: https://<the Logz.io Listener URL for your region>:8053
+        bearer_token: <your Logz.io Metrics account token> 
+        remote_timeout: 30s
+        queue_config:
+          batch_send_deadline: 5s  #default = 5s
+          max_shards: 10  #default = 1000
+          min_shards: 1
+          max_samples_per_send: 500 #default = 100
+          capacity: 10000  #default = 500
+
+```
+
+   
+##### Verify the remote_write configuration
+To check that the remote_write configuration is working properly, run a query on your local Prometheus for the metric `prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
+

--- a/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
+++ b/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
@@ -14,8 +14,11 @@ shipping-tags:
 contributors:
   - yberlinger
 ---
+<!-- info-box-start:note -->
+This feature is in beta. Please contact the Support team or your account manager to request early access.
+{:.info-box.note}
+<!-- info-box-end -->
 
-{% include page-info/early-access.md type="beta" %}
 
 To send your Prometheus application metrics to a Logz.io Infrastructure Monitoring account, use remote write to connect to Logz.io as the endpoint. Your data is formatted as JSON documents by the Logz.io listener. 
 
@@ -52,14 +55,6 @@ Within Logz.io, look up the Listener host for your region (URL) and the Logz.io 
 ![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
 
 ##### Add a remote_write url
-Add the following parameters to your Prometheus yaml file:
-
-| Environment variable | Description |
-|---|---|
-| external_labels | Parameter to tag the metrics from this specific Prometheus server. Do not change the label `p8s_logzio_name`: This variable is required to identify from which Prometheus environment the metrics are arriving to Logz.io  |
-| remote_write | The remote write section configuration sets Logz.io as the endpoint for your Prometheus metrics data. Place this section at the same indentation level as the `global` section. |
-|url| Logz.io Listener url for for your region, configured to use port **8052** for http traffic or port **8053** for https traffic. For more details, see the [Prometheus configuration file remote write reference](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)|
-|bearer_token| Logz.io Metrics account token|
 
 
 ```yaml
@@ -78,14 +73,28 @@ Add the following parameters to your Prometheus yaml file:
           capacity: 10000  #default = 500
 
 ```
-   
+
+###### Parameters   
+Add the following parameters to your Prometheus yaml file:
+
+| Environment variable | Description |
+|---|---|
+| external_labels | Parameter to tag the metrics from this specific Prometheus server. Do not change the label `p8s_logzio_name`: This variable is required to identify from which Prometheus environment the metrics are arriving to Logz.io  |
+| remote_write | The remote write section configuration sets Logz.io as the endpoint for your Prometheus metrics data. Place this section at the same indentation level as the `global` section. |
+|url (Required)| Logz.io Listener url and port for your region, configured to use port **8052** for http traffic or port **8053** for https traffic. For more details, see the [Prometheus configuration file remote write reference](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)|
+|bearer-token (Required)| Your Logz.io Metrics account token|
+
+
+
+| bearer-token (Required) | Your Logz.io Metrics account token. {% include metric-shipping/replace-metrics-token.html %}   |
+| url (Required) | Listener URL and port. {% include log-shipping/listener-var.html %}  |   
 ##### Verify the remote_write configuration
 
 
-+ To check that the remote_write configuration is working properly, run a query on your local Prometheus for the metric `prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
++ **Run a query**: To check that the remote_write configuration is working properly, run a query on your local Prometheus for the metric `prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
 
 + **Check via Grafana Explore**: To verify that metrics are arriving to Logz,io: 
 1. Click the **Explore icon <i class="far fa-compass"></i>** in the left menu to open Grafana’s Explore. 
 
-1. Examine the Metrics drop down next to the **Explore** heading in the upper left of the pane. 
+1. Examine the **Metrics** drop down next to the **Explore** heading in the upper left of the pane. 
   An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 

--- a/_source/user-guide/infrastructure-monitoring/p8s-importing-dashbds.md
+++ b/_source/user-guide/infrastructure-monitoring/p8s-importing-dashbds.md
@@ -14,47 +14,16 @@ contributors:
 
 {% include page-info/early-access.md type="beta" %}
 
-You can import your existing dashboards to Logz.io via a manual process or via a bulk process, using a Python script.
+You can import your existing dashboards to Logz.io via a bulk process (using a Python script) or via a manual process.
 
 <!-- tabContainer:start -->
 <div class="branching-container">
 
-* [Manual upload](#manual)
 * [Bulk upload](#bulk)
+* [Manual upload](#manual)
 {:.branching-tabs}
 
-<!-- tab:start -->
-<div id="manual">
-  
-For the dashboard import to work smoothly, you'll need to change the name of the data source in your JSON file to the name of your Logz.io Metrics account. 
-Your Metrics account information is located in the <a href ="https://app.logz.io/#/dashboard/settings/manage-accounts" target="_blank">Manage Accounts **(<i class="li li-gear"></i> > Settings > Manage accounts)**</a> page of your Operations workspace. ![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
-
-For the record, notification endpoints and dashboard annotations are not imported: You'll need to recreate them in Logz.io.  See [Notification endpoints](/user-guide/integrations/endpoints.html) and [Annotations ](/user-guide/infrastructure-monitoring/annotations/)for more information. 
-
-#### Importing individual dashboards
-
-<div class="tasklist">
-
-To import individual dashboards: 
-
-##### Navigate to the Metrics tab.
-
-Log into Logz.io and navigate to the **Metrics** tab.
-
-##### Select the Import option.
-In the left navigation pane, click <i class="fas fa-plus"></i> and select **Import**.
-![Import dashboards to Logz.io](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8simport-dashboards.png)
-
-  - To import your existing Prometheus dashboards, first export the relevant dashboards as JSON files, then click **Upload json file** and select the files to upload. 
-    
-    For related information see [Upload JSON logs]({{site.baseurl}}/shipping/log-sources/json-uploads). 
-  - To import dashboards from Grafana.com, enter the relevant dashboard URL or ID in **Import via grafana.com** and **Load** them. 
-</div>
-
-</div>
-<!-- tab:end -->
-
-<!-- tab:start -->
+<!--tab start bulk-->
 <div id="bulk">
   
 ### Importing multiple dashboards via script 
@@ -121,5 +90,38 @@ python3 main.py # If python 2 is your default version
 </div>
 
 </div>
+<!--tab end bulk -->
+
+<!-- tab:start -->
+<div id="manual">
+  
+For the dashboard import to work smoothly, you'll need to change the name of the data source in your JSON file to the name of your Logz.io Metrics account. 
+Your Metrics account information is located in the <a href ="https://app.logz.io/#/dashboard/settings/manage-accounts" target="_blank">Manage Accounts **(<i class="li li-gear"></i> > Settings > Manage accounts)**</a> page of your Operations workspace. ![Account settings navigation](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8s-account-token00.png)
+
+For the record, notification endpoints and dashboard annotations are not imported: You'll need to recreate them in Logz.io.  See [Notification endpoints](/user-guide/integrations/endpoints.html) and [Annotations ](/user-guide/infrastructure-monitoring/annotations/)for more information. 
+
+#### Importing individual dashboards
+
+<div class="tasklist">
+
+To import individual dashboards: 
+
+##### Navigate to the Metrics tab.
+
+Log into Logz.io and navigate to the **Metrics** tab.
+
+##### Select the Import option.
+In the left navigation pane, click <i class="fas fa-plus"></i> and select **Import**.
+![Import dashboards to Logz.io](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8simport-dashboards.png)
+
+  - To import your existing Prometheus dashboards, first export the relevant dashboards as JSON files, then click **Upload json file** and select the files to upload. 
+    
+    For related information see [Upload JSON logs]({{site.baseurl}}/shipping/log-sources/json-uploads). 
+  - To import dashboards from Grafana.com, enter the relevant dashboard URL or ID in **Import via grafana.com** and **Load** them. 
+</div>
+
+</div>
 <!-- tab:end -->
+
+
 </div>

--- a/_source/user-guide/infrastructure-monitoring/p8s-importing-dashbds.md
+++ b/_source/user-guide/infrastructure-monitoring/p8s-importing-dashbds.md
@@ -30,19 +30,14 @@ You can import your existing dashboards to Logz.io via a bulk process (using a P
  
 To enable easy migration, we created a Python [script](https://github.com/logzio/grafana-dashboard-migration-tool) to bulk upload your Grafana dashboards to our platform.
 
-{:.info-box.note.notes}
+###### Notes
 
-+ Bulk import is supported for Grafana version 6 and above.
-
-  + Dashboards that include annotations, notification endpoints, and other  external resources are imported without these resources during bulk  import. 
-
-  + Custom selection of dashboards is not possible with bulk import. All  your dashboard folders are imported to a single folder within Logz.io.
-
-  * Grafana dashboards with schema version 14 or lower that include "row"  objects are not uploaded: You will receive a warning in the logs. We  recommend that you update your dashboard schema to the latest version.
-
-  * The`p8s_logzio_name` variable is not added to panel queries that don't  include filtering: You will receive a warning in the logs.
-
-  * Some panel types are not supported by the Logz.io platform. If your  dashboard includes an unsupported panel type, you will receive a warning  in the logs. You may experience some issues while the panel renders in  Logz.io.
+- Bulk import is supported for Grafana version 6 and above.
+- Dashboards that include annotations, notification endpoints, and other  external resources imported without these resources during bulk  import. 
+- Custom selection of dashboards is not possible with bulk import. All  your dashboard folders imported to a single folder within Logz.io.
+- Grafana dashboards with schema version 14 or lower that include "row"  objects are not aded: You will receive a warning in the logs. We  recommend that you update your dashboard ma to the latest version.
+- The`p8s_logzio_name` variable is not added to panel queries that don't  include filtering: will receive a warning in the logs.
+- Some panel types are not supported by the Logz.io platform. If your  dashboard includes an pported panel type, you will receive a warning  in the logs. You may experience some issues le the panel renders in  Logz.io.   
 
 
 ####  Bulk dashboard import procedure

--- a/_source/user-guide/infrastructure-monitoring/p8s-importing-dashbds.md
+++ b/_source/user-guide/infrastructure-monitoring/p8s-importing-dashbds.md
@@ -30,8 +30,8 @@ You can import your existing dashboards to Logz.io via a bulk process (using a P
  
 To enable easy migration, we created a Python [script](https://github.com/logzio/grafana-dashboard-migration-tool) to bulk upload your Grafana dashboards to our platform.
 
-###### Notes
 
+###### Notes
 - Bulk import is supported for Grafana version 6 and above.
 - Dashboards that include annotations, notification endpoints, and other  external resources imported without these resources during bulk  import. 
 - Custom selection of dashboards is not possible with bulk import. All  your dashboard folders imported to a single folder within Logz.io.

--- a/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
+++ b/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
@@ -84,5 +84,5 @@ Add the following parameters to your Prometheus yaml file:
 + **Check via Grafana Explore**: To verify that metrics are arriving to Logz,io: 
 1. Click the **Explore icon <i class="far fa-compass"></i>** in the left menu to open Grafana’s Explore. 
 
-1. Examine the Metrics drop down next to the **Explore** heading in the upper left of the pane. 
+1. Examine the **Metrics** drop down next to the **Explore** heading in the upper left of the pane. 
   An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 

--- a/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
+++ b/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
@@ -21,7 +21,6 @@ To send your Prometheus application metrics to a Logz.io Infrastructure Monitori
 
 * **Reduce tagging**: By default, all the metrics from your Prometheus server(s) are sent to Logz.io. To drop or send specific metrics, add Prometheus labeling _before_ enabling the remote write, or as part of the remote write configuration.  Learn more about Prometheus <a href ="https://medium.com/quiq-blog/prometheus-relabeling-tricks-6ae62c56cbda" target="_blank">relabeling tricks here <i class="fas fa-external-link-alt"></i>. </a>
 
-
 * **Paralleism levels**: Set the parallelism level for sending data in the configuration file. 
     This parameter determines the number of connections to open to the remote write listener.  The default parallelism level is 1000. We recommend configuring much fewer connections. Of course, if you're sending more data you'll need to open more channels. _(currently in development)_
     
@@ -78,5 +77,12 @@ Add the following parameters to your Prometheus yaml file:
 
    
 ##### Verify the remote_write configuration
-To check that the remote_write configuration is working properly, run a query on your local Prometheus for the metric `prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
 
+
++ **Run a query**: To check that the remote_write configuration is working properly, run a query on your local Prometheus for the metric `prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
+
++ **Check via Grafana Explore**: To verify that metrics are arriving to Logz,io: 
+1. Click the **Explore icon <i class="far fa-compass"></i>** in the left menu to open Grafana’s Explore. 
+
+1. Examine the Metrics drop down next to the **Explore** heading in the upper left of the pane. 
+  An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 


### PR DESCRIPTION
# What changed
Prometheus/metrics content
- Added the P8s remote write topic to Send your data tab under Prometheus as a service: 
       https://deploy-preview-910--logz-docs.netlify.app/shipping/p8s-sources/p8s-remote-write-shipping.html

- Changed order of tabs in importing grafana dashboards:
      https://deploy-preview-910--logz-docs.netlify.app/user-guide/infrastructure-monitoring/p8s-importing-dashbds.html


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
