### PR TITLE
Paas/improve visibility

### DIFF
--- a/_source/logzio_collections/_p8s-sources/aws-amazonmq-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-amazonmq-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon MQ
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-apigateway-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-apigateway-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon API Gateway
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-app-elb-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-app-elb-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon App ELB
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-athena-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-athena-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon Athena
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-classic-elb-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-classic-elb-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon Classic ELB
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-cloudfront-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-cloudfront-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon CloudFront
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-dynamodb-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-dynamodb-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon DynamoDB
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-ebs-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-ebs-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon EBS
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-ec2-auto-scaling-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-ec2-auto-scaling-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon EC2 Auto Scaling
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-ec2-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-ec2-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon EC2
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-ecs-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-ecs-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon ECS
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-efs-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-efs-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon EFS
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-elasticache-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-elasticache-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon ElastiCache
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-kinesis-firehose-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-kinesis-firehose-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon Kinesis Data Firehose
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-kinesis-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-kinesis-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon Kinesis
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-lambda-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-lambda-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon Lambda
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-network-elb-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-network-elb-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon Network ELB
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-rds-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-rds-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon RDS
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-redshift-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-redshift-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon Redshift
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-route53-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-route53-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon Route 53
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-s3-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-s3-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon S3
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-sns-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-sns-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon SNS
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/aws-sqs-p8s.md
+++ b/_source/logzio_collections/_p8s-sources/aws-sqs-p8s.md
@@ -7,7 +7,7 @@ data-source: Amazon SQS
 templates: ["docker-metricbeat"]
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 contributors:
   - yotamloe
   - imnotashrimp

--- a/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
+++ b/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
@@ -13,6 +13,8 @@ contributors:
 shipping-tags:
 contributors:
   - yberlinger
+shipping-tags:  
+  - p8s
 ---
 <!-- info-box-start:note -->
 This feature is in beta. Please contact the Support team or your account manager to request early access.

--- a/_source/logzio_collections/_p8s-sources/prometheus-cloudwatch-exporter.md
+++ b/_source/logzio_collections/_p8s-sources/prometheus-cloudwatch-exporter.md
@@ -6,7 +6,7 @@ logo:
 data-source: Amazon CloudWatch for Prometheus metrics
 open-source:
   - title: CloudWatch metrics for Prometheus
-    github-repo: logz-aws-metrics
+    github-repo: logzio-aws-metrics
 templates: ["docker"]
 contributors:
   - yotamloe

--- a/_source/logzio_collections/_p8s-sources/prometheus-telegraf-output.md
+++ b/_source/logzio_collections/_p8s-sources/prometheus-telegraf-output.md
@@ -11,7 +11,7 @@ templates: ["docker"]
 contributors:
   - fadi-khatib
   - yberlinger
-shipping-tags:  # add tag attribute definition to .yaml for shipping
+shipping-tags:  
   - p8s
 
 ---


### PR DESCRIPTION
# What changed
https://deploy-preview-920--logz-docs.netlify.app/shipping/

added filters for PAAS to make non-AWS metrics "shippers" easier to locate.
updated OS project: 
from  https://github.com/logzio/logz-aws-metrics. ---> to https://github.com/logzio/logzio-aws-metrics

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
