### PR TITLE
update manifest, corrects githubRepo links

### DIFF
--- a/_source/data/shipping-manifest.json
+++ b/_source/data/shipping-manifest.json
@@ -35,7 +35,7 @@ permalink: /data/shipping-manifest.json
                         "githubRepo": "{{
                           | split: "." | last
                           | append: "https://github.com/logzio/"
-                          | append: project.github-repo }}",
+                          | append: project.github-repo }}"
                       }
                       {%- unless forloop.last -%} , {% endunless -%}
                     {%- endfor -%}

--- a/_source/data/shipping-manifest.json
+++ b/_source/data/shipping-manifest.json
@@ -9,7 +9,7 @@ permalink: /data/shipping-manifest.json
   {%- when "production" -%}
     {%- assign branch = "/master" -%}
   {%- else -%}
-    {%- assign branch = "/develop" -%}
+    {%- assign branch = "/test-staging-links" -%}
 {%- endcase -%}
 {%- assign githubUrl = "https://raw.githubusercontent.com/logzio/logz-docs" | append: branch -%}
 
@@ -32,7 +32,10 @@ permalink: /data/shipping-manifest.json
                     {%- for project in d.open-source -%}
                       {
                         "title": "{{project.title}}",
-                        "githubRepo": "{{project.github-repo}}"
+                        "githubRepo": "{{
+                          | split: "." | last
+                          | append: "https://github.com/logzio/"
+                          | append: project.github-repo }}",
                       }
                       {%- unless forloop.last -%} , {% endunless -%}
                     {%- endfor -%}


### PR DESCRIPTION
# What changed

1. I've updated the manifest to point to the correct staging links:   {%- assign branch = "/test-staging-links" -%} 
2. I've fixed the links to point to the github repo. @AlonMiz The links are currently broken in V2. This should fix them.