### PR TITLE
fix p8s remote write icon

### DIFF
--- a/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
+++ b/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
@@ -92,7 +92,8 @@ Add the following parameters to your Prometheus yaml file:
 
 + **Check via Grafana Explore**: To verify that metrics are arriving to Logz,io: 
 
-  1. Click the **Explore icon <i class="far fa-compass"></i>** in the left menu to open Grafana’s Explore. 
+  1. To open Grafana's Explore, click **Explore** (compass icon) in the left menu bar. 
 
   1. Examine the **Metrics** drop down next to the **Explore** heading in the upper left of the pane. 
   An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 
+  ![Verify Prometheus metrics](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8smetrics_arriving.png)

--- a/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
+++ b/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
@@ -94,6 +94,6 @@ Add the following parameters to your Prometheus yaml file:
 
   1. To open Grafana's Explore, click **Explore** (compass icon) in the left menu bar. 
 
-  1. Examine the **Metrics** drop down next to the **Explore** heading in the upper left of the pane. 
+  1. Examine the **Metrics** drop down below the **Explore** heading in the upper left of the pane. 
   An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 
   ![Verify Prometheus metrics](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8smetrics_arriving.png)

--- a/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
+++ b/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
@@ -82,7 +82,8 @@ Add the following parameters to your Prometheus yaml file:
 + **Run a query**: To check that the remote_write configuration is working properly, run a query on your local Prometheus for the metric `prometheus_remote_storage_succeeded_sample_total` and verify that the result is greater than zero (n > 0) for the url. 
 
 + **Check via Grafana Explore**: To verify that metrics are arriving to Logz,io: 
-1. Click the **Explore icon <i class="far fa-compass"></i>** in the left menu to open Grafana’s Explore. 
+  1. Open **Explore <i class="far fa-compass"></i>** in the left menu bar. 
 
-1. Examine the **Metrics** drop down next to the **Explore** heading in the upper left of the pane. 
-  An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 
+  1. Examine the **Metrics** dropdown list next to the **Explore** heading in the upper left of the pane. <br>
+    An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 
+    ![Verify Prometheus metrics](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8smetrics_arriving.png)

--- a/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
+++ b/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
@@ -84,6 +84,6 @@ Add the following parameters to your Prometheus yaml file:
 + **Check via Grafana Explore**: To verify that metrics are arriving to Logz,io: 
   1. Open **Explore <i class="far fa-compass"></i>** in the left menu bar. 
 
-  1. Examine the **Metrics** dropdown list next to the **Explore** heading in the upper left of the pane. <br>
+  1. Examine the **Metrics** dropdown list below the **Explore** heading in the upper left of the pane. <br>
     An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 
     ![Verify Prometheus metrics](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/p8smetrics_arriving.png)


### PR DESCRIPTION
# What changed
https://deploy-preview-937--logz-docs.netlify.app/shipping/p8s-sources/p8s-remote-write-shipping.html
https://deploy-preview-937--logz-docs.netlify.app/user-guide/infrastructure-monitoring/p8s-remote-write.html

- added screen image for verifying that p8s metrics are arriving for bothe SYD and Getting started with Prometheus child topic
- removed Grafana compass icon from SYD page Prometheus as a service > Configuring remote write for Prometheus


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
