### PR TITLE
fix syntax for p8s remote write in SYD

### DIFF
--- a/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
+++ b/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
@@ -41,7 +41,6 @@ Once your metrics are flowing, export your existing Prometheus and Grafana dashb
 
 #### Configuring Remote Write to Logz.io
 
-{:.no_toc}  
 
 <div class="tasklist">
 
@@ -92,7 +91,7 @@ Add the following parameters to your Prometheus yaml file:
 
 + **Check via Grafana Explore**: To verify that metrics are arriving to Logz,io: 
 
-  1. To open Grafana's Explore, click **Explore** (compass icon) in the left menu bar. 
+  1. Click **Explore** (compass icon) in the left menu bar to open Grafana's Explore. 
 
   1. Examine the **Metrics** drop down below the **Explore** heading in the upper left of the pane. 
   An empty list or the text _no metrics_ indicates that the remote write configuration is not working properly. 


### PR DESCRIPTION
# What changed
https://deploy-preview-938--logz-docs.netlify.app/shipping/p8s-sources/p8s-remote-write-shipping.html 
- clean up syntax: removed `{:.no_toc}` 

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
