### PR TITLE
fix metrics token placeholder-p8s remote write SYD

### DIFF
--- a/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
+++ b/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
@@ -60,8 +60,8 @@ Within Logz.io, look up the Listener host for your region (URL) and the Logz.io 
       external_labels:
         p8s_logzio_name: <labelvalue>
     remote_write:
-      - url: https://<the Logz.io Listener URL for your region>:8053
-        bearer_token: <your Logz.io Metrics account token> 
+      - url: https://<<LISTENER-HOST>>:8053
+        bearer_token: <<METRICS-SHIPPING-TOKEN>> 
         remote_timeout: 30s
         queue_config:
           batch_send_deadline: 5s  #default = 5s


### PR DESCRIPTION
# What changed
https://deploy-preview-939--logz-docs.netlify.app/shipping/p8s-sources/p8s-remote-write-shipping.html
- fixed token placeholder for p8s remote write topic in SYD (send your data)
<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
