### PR TITLE
Syd tables tracing

### DIFF
--- a/_source/_includes/general-shipping/region-parameter.md
+++ b/_source/_includes/general-shipping/region-parameter.md
@@ -1,0 +1,1 @@
+| LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL.    You can find your region code in the [Regions and URLs]({{site.baseurl}}/user-guide/accounts/account-region.html#regions-and-urls) table. |DEFAULT: _Blank (US East)_|

--- a/_source/_includes/metric-shipping/certificate.md
+++ b/_source/_includes/metric-shipping/certificate.md
@@ -6,3 +6,5 @@ For HTTPS shipping, download the Logz.io public certificate to your certificate 
 ```shell
 sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/AAACertificateServices.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
+
+You'll need to run this command on the server that hosts Metricbeat.

--- a/_source/_includes/metric-shipping/k8s-over-helm-overview.md
+++ b/_source/_includes/metric-shipping/k8s-over-helm-overview.md
@@ -1,0 +1,21 @@
+## Overview
+
+Helm is a tool for managing packages of pre-configured Kubernetes resources, known as Charts.
+
+You can ship metrics from your Kubernetes cluster using Logzio-k8s-metrics.
+
+This Daemonset can be deployed using a standard configuration or [Metricbeat autodiscover](https://www.elastic.co/guide/en/beats/metricbeat/7.9/configuration-autodiscover.html), for even more powerful automation.
+
+
+**Before you begin, you'll need**:
+
+* [Helm CLI](https://helm.sh/docs/intro/install/) installed
+* [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) installed
+* [Metricbeat 7.6](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-installation.html) or higher for Autodiscover support. This integration defaults to Metricbeat 7.9.1.
+* To allow outgoing traffic to destination port 5015
+* Kubelet read-only-port 10255 enabled. Kubelet read-only-port 10255 is enabled by default on some cluster versions. If it isn’t enabled, follow Kubernetes’s instructions for enabling 10255 as a read-only-port in Kubelet’s config file
+
+<!-- info-box-start:info -->
+Helm 2 will reach [EOL on November 2020](https://helm.sh/blog/2019-10-22-helm-2150-released/#:~:text=6%20months%20after%20Helm%203's,Helm%202%20will%20formally%20end). This document follows the command syntax recommended for Helm 3, but the Chart will work with both Helm 2 and Helm 3.
+{:.info-box.note}
+<!-- info-box-end -->

--- a/_source/_includes/metric-shipping/replace-metrics-token.md
+++ b/_source/_includes/metric-shipping/replace-metrics-token.md
@@ -1,0 +1,1 @@
+Replace `<<METRICS-SHIPPING-TOKEN>>` with a [token](https://app.logz.io/#/dashboard/settings/manage-accounts) for the Metrics account you want to ship to. Here's how to [look up your Metrics token.]({{site.baseurl}}/user-guide/accounts/finding-your-metrics-account-token/)

--- a/_source/_includes/tracing-shipping/tracing-parameters.md
+++ b/_source/_includes/tracing-shipping/tracing-parameters.md
@@ -1,0 +1,6 @@
+###### Parameters
+
+| Parameter | Description | Required/Default|
+|---|---|---|
+| ACCOUNT_TOKEN | The Logz.io token for the Distributed Tracing account you want to send your data to: `<<TRACING-SHIPPING-TOKEN>>` . Required when you use the collector to ship traces to Logz.io.  [How do I look up my Distributed Tracing account token?]({{site.baseurl}}/user-guide/accounts/finding-your-tracing-account-token)  | Required|
+| REGION |  Your two-letter Logz.io account region code. Defaults to **US**, required only if your Logz.io region is different than US. You can find your region code in the [Available regions]({{site.baseurl}}/user-guide/accounts/account-region.html#available-regions) table. | DEFAULT: _Blank (US East)_|

--- a/_source/data/shipping-manifest.json
+++ b/_source/data/shipping-manifest.json
@@ -9,7 +9,7 @@ permalink: /data/shipping-manifest.json
   {%- when "production" -%}
     {%- assign branch = "/master" -%}
   {%- else -%}
-    {%- assign branch = "/test-staging-links" -%}
+    {%- assign branch = "/syd_tables_tracing" -%}
 {%- endcase -%}
 {%- assign githubUrl = "https://raw.githubusercontent.com/logzio/logz-docs" | append: branch -%}
 

--- a/_source/logzio_collections/_metrics-sources/azure-monitor.md
+++ b/_source/logzio_collections/_metrics-sources/azure-monitor.md
@@ -80,7 +80,7 @@ You'll need this information later on, so paste it in your text editor.
 "password": "e6ab6d24-4907-5d11-a132-a171ef55355d",
 ```
 
-{% include log-shipping/certificate.md server="to your Metricbeat server" clarification="You'll need to run this command on the server that hosts Metricbeat:" %}
+{% include metric-shipping/certificate.md %}
 
 ##### _(Optional)_ Disable the system module
 

--- a/_source/logzio_collections/_metrics-sources/azure-mysql.md
+++ b/_source/logzio_collections/_metrics-sources/azure-mysql.md
@@ -80,7 +80,7 @@ You'll need this information later on, so paste it in your text editor.
 "password": "e6ab6d24-4907-5d11-a132-a171ef55355d",
 ```
 
-{% include log-shipping/certificate.md server="to your Metricbeat server" clarification="You'll need to run this command on the server that hosts Metricbeat:" %}
+{% include metric-shipping/certificate.md %}
 
 ##### (_Optional_) Disable the system module
 

--- a/_source/logzio_collections/_metrics-sources/azure-postgres-metrics.md
+++ b/_source/logzio_collections/_metrics-sources/azure-postgres-metrics.md
@@ -80,7 +80,7 @@ You'll need this information later on, so paste it in your text editor.
 "password": "e6ab6d24-4907-5d11-a132-a171ef55355d",
 ```
 
-{% include log-shipping/certificate.md server="to your Metricbeat server" clarification="You'll need to run this command on the server that hosts Metricbeat:" %}
+{% include metric-shipping/certificate.md %}
 
 ##### (_Optional_) Disable the system module
 

--- a/_source/logzio_collections/_metrics-sources/azure-redis.md
+++ b/_source/logzio_collections/_metrics-sources/azure-redis.md
@@ -81,7 +81,7 @@ You'll need this information later on, so paste it in your text editor.
 "password": "85a75902-e75a-5b55-9142-bbb317e0eb5a",
 ```
 
-{% include log-shipping/certificate.md server="to your Metricbeat server" clarification="You'll need to run this command on the server that hosts Metricbeat:" %}
+{% include metric-shipping/certificate.md %}
 
 ##### (_Optional_) Disable the system module
 

--- a/_source/logzio_collections/_metrics-sources/azure-service-bus.md
+++ b/_source/logzio_collections/_metrics-sources/azure-service-bus.md
@@ -80,7 +80,7 @@ You'll need this information later on, so paste it in your text editor.
 "password": "e6ab6d24-4907-5d11-a132-a171ef55355d",
 ```
 
-{% include log-shipping/certificate.md server="to your Metricbeat server" clarification="You'll need to run this command on the server that hosts Metricbeat:" %}
+{% include metric-shipping/certificate.md %}
 
 ##### (_Optional_) Disable the system module
 

--- a/_source/logzio_collections/_metrics-sources/azure-sql-metrics.md
+++ b/_source/logzio_collections/_metrics-sources/azure-sql-metrics.md
@@ -80,7 +80,7 @@ You'll need this information later on, so paste it in your text editor.
 "password": "e6ab6d24-4907-5d11-a132-a171ef55355d",
 ```
 
-{% include log-shipping/certificate.md server="to your Metricbeat server" clarification="You'll need to run this command on the server that hosts Metricbeat:" %}
+{% include metric-shipping/certificate.md %}
 
 ##### (_Optional_) Disable the system module
 

--- a/_source/logzio_collections/_metrics-sources/azure-vm-scaleset.md
+++ b/_source/logzio_collections/_metrics-sources/azure-vm-scaleset.md
@@ -80,7 +80,7 @@ You'll need this information later on, so paste it in your text editor.
 "password": "e6ab6d24-4907-5d11-a132-a171ef55355d",
 ```
 
-{% include log-shipping/certificate.md server="to your Metricbeat server" clarification="You'll need to run this command on the server that hosts Metricbeat:" %}
+{% include metric-shipping/certificate.md %}
 
 ##### (_Optional_) Disable the system module
 

--- a/_source/logzio_collections/_metrics-sources/azure-vm.md
+++ b/_source/logzio_collections/_metrics-sources/azure-vm.md
@@ -81,7 +81,7 @@ You'll need this information later on, so paste it in your text editor.
 "password": "e6ab6d24-4907-5d11-a132-a171ef55355d",
 ```
 
-{% include log-shipping/certificate.md server="to your Metricbeat server" clarification="You'll need to run this command on the server that hosts Metricbeat:" %}
+{% include metric-shipping/certificate.md %}
 
 ##### (_Optional_) Disable the system module
 

--- a/_source/logzio_collections/_metrics-sources/consul.md
+++ b/_source/logzio_collections/_metrics-sources/consul.md
@@ -49,7 +49,7 @@ Now the metrics for this Consul server will be exposed locally in Prometheus for
 http://127.0.0.1:8500/v1/agent/metrics?format=prometheus
 ```
 
-{% include log-shipping/certificate.md server="to your Metricbeat server" clarification="You'll need to run this command on the server that hosts Metricbeat:" %}
+{% include metric-shipping/certificate.md %}
 
 ##### Set metricbeat modules on Consul servers
 

--- a/_source/logzio_collections/_metrics-sources/docker.md
+++ b/_source/logzio_collections/_metrics-sources/docker.md
@@ -75,18 +75,18 @@ logzio/docker-collector-metrics
 
 ###### Parameters for all modules
 
-| Parameter | Description |
-|---|---|
-| LOGZIO_TOKEN (Required) | {% include metric-shipping/replace-metrics-token.html %} |
-| LOGZIO_MODULES (Required) | Comma-separated list of Metricbeat modules to be enabled on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/modules`. |
-| LOGZIO_REGION <span class="default-param">_Blank (US East)_</span> | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL.    You can find your region code in the [Regions and URLs]({{site.baseurl}}/user-guide/accounts/account-region.html#regions-and-urls) table. |
-| LOGZIO_TYPE <span class="default-param">`docker-collector-metrics`</span> | This field is needed only if you're shipping metrics to Kibana and you want to override the default value.    In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. |
-| LOGZIO_LOG_LEVEL <span class="default-param">`"INFO"`</span> | The log level the module startup scripts will generate. |
-| LOGZIO_EXTRA_DIMENSIONS | Semicolon-separated list of dimensions to be included with your metrics (formatted as `dimensionName1=value1;dimensionName2=value2`).    To use an environment variable as a value, format as `dimensionName=$ENV_VAR_NAME`. Environment variables must be the only value in the field. If an environment variable can't be resolved, the field is omitted. |
-| DEBUG <span class="default-param">`"false"`</span> | Set to `true` if you want Metricbeat to run in debug mode.<br/> **Note:** Debug mode tends to generate a lot of debugging output, so you should probably enable it temporarily only when an error occurs while running the docker-collector in production.  |
-| HOSTNAME <span class="default-param">``</span> | Insert your host name if you want it to appear in the metrics' `host.name`. If null, host.name will show the container's ID. |
-| CLOUD_METADATA <span class="default-param">`"false"`</span> | Set to `true` to enrich events with instance metadata from the machine’s hosting provider. |
-{:.paramlist}
+| Parameter | Description | Required/Default|
+|---|---|---|
+| LOGZIO_TOKEN | {% include metric-shipping/replace-metrics-token.md %} |Required|
+| LOGZIO_MODULES  | Comma-separated list of Metricbeat modules to be enabled on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/modules`. | 
+{%include general-shipping/region-parameter.md %}
+| LOGZIO_TYPE | This field is needed only if you're shipping metrics to Kibana and you want to override the default value.    In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. |DEFAULT: `docker-collector-metrics`|
+| LOGZIO_LOG_LEVEL | The log level the module startup scripts will generate. |DEFAULT: `"INFO"`|
+| LOGZIO_EXTRA_DIMENSIONS | Semicolon-separated list of dimensions to be included with your metrics (formatted as `dimensionName1=value1;dimensionName2=value2`).    To use an environment variable as a value, format as `dimensionName=$ENV_VAR_NAME`. Environment variables must be the only value in the field. If an environment variable can't be resolved, the field is omitted. |  |
+| DEBUG  | Set to `true` if you want Metricbeat to run in debug mode.<br/> **Note:** Debug mode tends to generate a lot of debugging output, so you should probably enable it temporarily only when an error occurs while running the docker-collector in production.  |DEFAULT: `"false"`|
+| HOSTNAME  | Insert your host name if you want it to appear in the metrics' `host.name`. If null, host.name will show the container's ID. |DEFAULT: `` |
+| CLOUD_METADATA | Set to `true` to enrich events with instance metadata from the machine’s hosting provider. |DEFAULT: `"false"`| 
+
 
 
 {% include metric-shipping/open-dashboard.md title="Docker overview" %}

--- a/_source/logzio_collections/_metrics-sources/kubernetes-over-helm.md
+++ b/_source/logzio_collections/_metrics-sources/kubernetes-over-helm.md
@@ -19,7 +19,7 @@ shipping-tags:
 <!-- tabContainer:start -->
 <div class="branching-container">
 
-* [Automated deployment _recommended_](#automated-config)
+* [Automated deployment (recommended)](#automated-config)
 * [Manual deployment](#manual-config)
 * [Parameters](#configurations)
 * [Uninstall](#uninstall)

--- a/_source/logzio_collections/_metrics-sources/kubernetes-over-helm.md
+++ b/_source/logzio_collections/_metrics-sources/kubernetes-over-helm.md
@@ -15,33 +15,21 @@ contributors:
 shipping-tags:
   - container
 ---
-Helm is a tool for managing packages of pre-configured Kubernetes resources, known as Charts.
 
-You can ship metrics from your Kubernetes cluster using Logzio-k8s-metrics.
-
-This Daemonset can be deployed using a standard configuration or [Metricbeat autodiscover](https://www.elastic.co/guide/en/beats/metricbeat/7.9/configuration-autodiscover.html), for even more powerful automation.
-
-
-**Before you begin, you'll need**:
-
-* [Helm CLI](https://helm.sh/docs/intro/install/) installed
-* [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) installed
-* [Metricbeat 7.6](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-installation.html) or higher for Autodiscover support. This integration defaults to Metricbeat 7.9.1.
-* To allow outgoing traffic to destination port 5015
-* Kubelet read-only-port 10255 enabled. Kubelet read-only-port 10255 is enabled by default on some cluster versions. If it isn’t enabled, follow Kubernetes’s instructions for enabling 10255 as a read-only-port in Kubelet’s config file
-
-Helm 2 will reach [EOL on November 2020](https://helm.sh/blog/2019-10-22-helm-2150-released/#:~:text=6%20months%20after%20Helm%203's,Helm%202%20will%20formally%20end). This document follows the command syntax recommended for Helm 3, but the Chart will work with both Helm 2 and Helm 3.
-{:.info-box.note}
-
-
+<!-- tabContainer:start -->
 <div class="branching-container">
+
 * [Automated deployment _recommended_](#automated-config)
 * [Manual deployment](#manual-config)
 * [Parameters](#configurations)
 * [Uninstall](#uninstall)
 {:.branching-tabs}
 
+<!-- tab:start -->
+
 <div id="automated-config">
+
+{% include metric-shipping/k8s-over-helm-overview.md %}
 
 #### Automated deployment
 
@@ -60,21 +48,26 @@ bash <(curl -s https://raw.githubusercontent.com/logzio/logzio-helm/master/quick
 
 Follow through the system's prompts and provide the requested parameters.
 
-| Prompt | Answer |
-|---|---|
-| Logz.io metrics shipping token (Required) | {% include metric-shipping/replace-metrics-token.html %} |
-| Logz.io region (Default: `Blank (US East)`) | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you’re shipping the logs to) and API URL. You can find your region code in the [Regions and URLs](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. |
-| Cluster name (Default: `detected by the script`) | Name of the Kubernetes cluster in which you are deploying. |
-| Standard or autodiscover deployment (Default: `standard`) | To deploy with [configuration templates](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-autodiscover.html) answer 'autodiscover'. |
+| Prompt | Answer |Required/Default|
+|---|---|---|
+| Logz.io metrics shipping token | {% include metric-shipping/replace-metrics-token.html %} | Required |
+| Logz.io region | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you’re shipping the logs to) and API URL. You can find your region code in the [Regions and URLs](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. |DEFAULT: `Blank (US East)` |
+| Cluster name | Name of the Kubernetes cluster in which you are deploying. |DEFAULT: `detected by the script` |
+| Standard or autodiscover deployment  | To deploy with [configuration templates](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-autodiscover.html) answer 'autodiscover'. |DEFAULT: `standard`|
 
 {% include metric-shipping/open-dashboard.md title="Kubernetes" %}
 
-
 </div>
+</div>
+
 <!-- tab:end -->
-</div>
 
+
+<!-- tab:start -->
 <div id="manual-config">
+
+{% include metric-shipping/k8s-over-helm-overview.md %}
+
 
 #### Manual deployment
 
@@ -90,18 +83,18 @@ helm repo add logzio-helm https://logzio.github.io/logzio-helm/metricbeat
 
 ##### Deploy
 
-You have three options for deployment:
+You have three options for deployment: <!--there's a mini toc here that links to tagged content below -->
 
 * [Standard configuration](#standard-config)
 * [Autodiscover configuration](#autodiscover-config)
 * [Custom configuration](#custom-config)
 
-
 ###### Deploy with standard configuration {#standard-config}
+
 
 Run the command below after replacing the following placeholders:
 
-* Replace `<<METRICS-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/general) of the account you want to ship to.
+* Replace `<<METRICS-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/general) of the metrics account you want to ship to.
 * Replace `<<LISTENER-HOST>>` with your region’s listener host (for example, `listener.logz.io`). For more information on finding your account’s region, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html).
 * Replace `<<KUBE-STATE-METRICS-NAMESPACE>>`, `<<KUBE-STATE-METRICS-PORT>>`, and `<<CLUSTER-NAME>>` in this command to save your cluster details as a Kubernetes secret.
 
@@ -190,8 +183,15 @@ metricbeat.yml: |-
 {% include metric-shipping/open-dashboard.md title="Kubernetes" %}
 
 </div>
+
 </div>
+<!-- tab:end -->
+
+
+<!-- tab:start -->
 <div id="configurations">
+
+
 
 ### To override values in a chart
 
@@ -210,6 +210,7 @@ To override configurations such as `metricbeatConfig.autoCustomConfig`, `deploym
 helm install --namespace=kube-system logzio-k8s-metrics logzio-helm/logzio-k8s-metrics \
   --set-file deployment.metricbeatConfig.custom=/path/to/your/config.yaml
 ```
+
 
 #### Configuration options
 
@@ -267,7 +268,14 @@ helm install --namespace=kube-system logzio-k8s-metrics logzio-helm/logzio-k8s-m
 
 </div>
 
+
+<!-- tab:end -->
+
+
+<!-- tab:start -->
+
 <div id="uninstall">
+
 
 #### To uninstall the chart
 
@@ -278,6 +286,9 @@ For example, to uninstall the `logzio-k8s-metrics` deployment, run:
 helm uninstall --namespace=kube-system logzio-k8s-metrics
 ```
 
+</div>
+
+<!-- tab:end -->
 
 </div>
-</div>
+<!-- tabContainer:end -->

--- a/_source/logzio_collections/_metrics-sources/kubernetes.md
+++ b/_source/logzio_collections/_metrics-sources/kubernetes.md
@@ -155,9 +155,12 @@ kubectl --namespace=kube-system create secret generic cluster-details \
 
 Deploy one of these configurations.
 
+<!-- info-box-start:info -->
 If your Kubernetes setup is EKS or AKS,
 you'll need to use the HTTPS deployment.
 {:.info-box.note}
+<!-- info-box-end -->
+
 
 ###### For HTTP communication with kubelet
 

--- a/_source/logzio_collections/_metrics-sources/kubernetes.md
+++ b/_source/logzio_collections/_metrics-sources/kubernetes.md
@@ -16,7 +16,7 @@ shipping-tags:
 <!-- tabContainer:start -->
 <div class="branching-container">
 
-* [Automated deployment <span class="sm ital">(recommended)</span>](#automated-config)
+* [Automated deployment (*recommended*)](#automated-config)
 * [Manual deployment](#manual-config)
 {:.branching-tabs}
 
@@ -44,13 +44,14 @@ bash <(curl -s https://raw.githubusercontent.com/logzio/logzio-helm/master/quick
 
 ###### Prompts and answers
 
-| Prompt | Description |
-|---|---|
-| logzio-metrics-shipping-token (Required) | {% include metric-shipping/replace-metrics-token.html %} |
-| Logz.io region <span class="default-param">_Blank (US East)_</span> | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL.    You can find your region code in the [Regions and URLs](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. |
-| Kubelet communication protocol <span class="default-param">`http`</span> | `http` or `https`. If your Kubernetes setup is EKS or AKS, you'll need to use `https`. |
-| Target namespace <span class="default-param">`kube-system`</span> | Select a namespace to serve as the origin for Logz.io’s Metricbeat Deamonset deployment. The deployment monitors the **entire** cluster, regardless of which namespace is selected as the origin. It’s a good idea to avoid a namespace that already has Metricbeat installed. |
-| Cluster name <span class="default-param">Detected by the script</span> | The name of the Kubernetes cluster you're deploying in. |
+| Prompt | Description | Required/Default|
+|---|---|---|
+| logzio-metrics-shipping-token  | {% include metric-shipping/replace-metrics-token.html %} |Required|
+| Logz.io region | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL.    You can find your region code in the [Regions and URLs](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. |DEFAULT: _Blank (US East)_ |
+| Kubelet communication protocol | `http` or `https`. If your Kubernetes setup is EKS or AKS, you'll need to use `https`. |DEFAULT: `http`|
+| Target namespace  | Select a namespace to serve as the origin for Logz.io’s Metricbeat Deamonset deployment. The deployment monitors the **entire** cluster, regardless of which namespace is selected as the origin. It’s a good idea to avoid a namespace that already has Metricbeat installed. |DEFAULT: `kube-system` |
+| Cluster name | The name of the Kubernetes cluster you're deploying in. |DEFAULT: Detected by the script |
+
 {:.paramlist}
 
 ##### Check Logz.io for your metrics

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -66,9 +66,9 @@ The complete list of Logz.io collector parameters is presented below.
 In addition to these parameters, you can also use [Jaeger's collector parameters](https://www.jaegertracing.io/docs/latest/cli/#jaeger-collector-grpc-plugin). 
 You'll need to change to the version page for your deployment. 
 
- Collector Parameter | Description|Required/Default|
- ------------ | -------------
-  ACCOUNT_TOKEN | The account token is required when you use the collector to send traces to Logz.io. Replace `<<TRACING-SHIPPING-TOKEN>>` with the token of the Distributed Tracing account you want to send data to. [_How do I look up my Distributed Tracing account token?_](/user-guide/accounts/finding-your-tracing-account-token)| Required |
-REGION | Two-letter region code that determines the suggested listener URL (where you will be sending trace data to).   Find your region code in the Regions and URLs table. This parameter is left blank for US East (Northern Virginia).  [_How do I look up the Listener host URL for my region?_](/user-guide/accounts/account-region.html#available-regions)|   |
-GRPC_STORAGE_PLUGIN_LOG_LEVEL| The lowest log level to send.  Default: **warn**.  From lowest to highest, log levels are: **trace, debug, info, warn, error**.  Controls logging only for the Jaeger Logz.io Collector.  Does not affect Jaeger components.| |
-COLLECTOR_ZIPKIN_HTTP_PORT | If you’re using a Zipkin implementation to create traces, set this optional environment variable to the HTTP port for the Zipkin collector service.| |
+ |Collector Parameter | Description|Required/Default|
+ |--- | ---|---|
+  |ACCOUNT_TOKEN | The account token is required when you use the collector to send traces to Logz.io. Replace `<<TRACING-SHIPPING-TOKEN>>` with the token of the Distributed Tracing account you want to send data to. [_How do I look up my Distributed Tracing account token?_](/user-guide/accounts/finding-your-tracing-account-token)| Required |
+|REGION | Two-letter region code that determines the suggested listener URL (where you will be sending trace data to).   Find your region code in the Regions and URLs table. This parameter is left blank for US East (Northern Virginia).  [_How do I look up the Listener host URL for my region?_](/user-guide/accounts/account-region.html#available-regions)|   |
+|GRPC_STORAGE_PLUGIN_LOG_LEVEL| The lowest log level to send.  Default: **warn**.  From lowest to highest, log levels are: **trace, debug, info, warn, error**.  Controls logging only for the Jaeger Logz.io Collector.  Does not affect Jaeger components.| |
+|COLLECTOR_ZIPKIN_HTTP_PORT | If you’re using a Zipkin implementation to create traces, set this optional environment variable to the HTTP port for the Zipkin collector service.| |

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -59,16 +59,12 @@ docker run -e ACCOUNT_TOKEN=<<TRACING-SHIPPING-TOKEN>>  # see parameter list bel
 logzio/logzio-collector:latest
 ```
 
-###### Parameters
 
 The complete list of Logz.io collector parameters is presented below. 
-
 In addition to these parameters, you can also use [Jaeger's collector parameters](https://www.jaegertracing.io/docs/latest/cli/#jaeger-collector-grpc-plugin). 
 You'll need to change to the version page for your deployment. 
 
- |Collector Parameter | Description|Required/Default|
- |--- | ---|---|
-  |ACCOUNT_TOKEN | The account token is required when you use the collector to send traces to Logz.io. Replace `<<TRACING-SHIPPING-TOKEN>>` with the token of the Distributed Tracing account you want to send data to. [_How do I look up my Distributed Tracing account token?_](/user-guide/accounts/finding-your-tracing-account-token)| Required |
-|REGION | Two-letter region code that determines the suggested listener URL (where you will be sending trace data to).   Find your region code in the Regions and URLs table. This parameter is left blank for US East (Northern Virginia).  [_How do I look up the Listener host URL for my region?_](/user-guide/accounts/account-region.html#available-regions)|   |
-|GRPC_STORAGE_PLUGIN_LOG_LEVEL| The lowest log level to send.  Default: **warn**.  From lowest to highest, log levels are: **trace, debug, info, warn, error**.  Controls logging only for the Jaeger Logz.io Collector.  Does not affect Jaeger components.| |
+
+{% include tracing-shipping/tracing-parameters.md %}
+|GRPC_STORAGE_PLUGIN_LOG_LEVEL| The lowest log level to send.  From lowest to highest, log levels are: **trace, debug, info, warn, error**.  Controls logging only for the Jaeger Logz.io Collector.  Does not affect Jaeger components.|DEFAULT: **warn** |
 |COLLECTOR_ZIPKIN_HTTP_PORT | If you’re using a Zipkin implementation to create traces, set this optional environment variable to the HTTP port for the Zipkin collector service.| |

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -56,12 +56,7 @@ The config file must include the required components for the OpenTelemetry Colle
 You can use [this config file](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/logzioexporter/example/config.yaml) as a starting point, with the Logz.io exporter parameters, below.
 
 
-###### Parameters
-
-| Parameter | Description | Required/Default|
-|---|---|---|
-| ACCOUNT_TOKEN | The Logz.io token for the Distributed Tracing account you want to send your data to: `<<TRACING-SHIPPING-TOKEN>>` . Required when you use the collector to ship traces to Logz.io.  [How do I look up my Distributed Tracing account token?]({{site.baseurl}}/user-guide/accounts/finding-your-tracing-account-token)  | Required|
-| REGION |  Your two-letter Logz.io account region code. Defaults to **US**, required only if your Logz.io region is different than US. You can find your region code in the [Available regions]({{site.baseurl}}/user-guide/accounts/account-region.html#available-regions) table. | DEFAULT: _Blank (US East)_|
+{% include tracing-shipping/tracing-parameters.md %}
 | CUSTOM_LISTENER_ADDRESS | Custom traces endpoint, for dev. This optional parameter overrides the region parameter.  You can find your Listener Address in the [Available regions]({{site.baseurl}}/user-guide/accounts/account-region.html#available-regions) table.| |
 
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -59,12 +59,11 @@ You can use [this config file](https://github.com/open-telemetry/opentelemetry-c
 ###### Parameters
 
 | Parameter | Description | Required/Default|
-|---|---|
+|---|---|---|
 | ACCOUNT_TOKEN | The Logz.io token for the Distributed Tracing account you want to send your data to: `<<TRACING-SHIPPING-TOKEN>>` . Required when you use the collector to ship traces to Logz.io.  [How do I look up my Distributed Tracing account token?]({{site.baseurl}}/user-guide/accounts/finding-your-tracing-account-token)  | Required|
 | REGION |  Your two-letter Logz.io account region code. Defaults to **US**, required only if your Logz.io region is different than US. You can find your region code in the [Available regions]({{site.baseurl}}/user-guide/accounts/account-region.html#available-regions) table. | DEFAULT: _Blank (US East)_|
 | CUSTOM_LISTENER_ADDRESS | Custom traces endpoint, for dev. This optional parameter overrides the region parameter.  You can find your Listener Address in the [Available regions]({{site.baseurl}}/user-guide/accounts/account-region.html#available-regions) table.| |
 
-{:.paramlist}
 
 
 ##### Save the file as `config.yaml`.


### PR DESCRIPTION
# What changed
https://deploy-preview-940--logz-docs.netlify.app/shipping/tracing-sources/jaeger-collector.html
https://deploy-preview-940--logz-docs.netlify.app/shipping/tracing-sources/opentelemetry.html
https://deploy-preview-940--logz-docs.netlify.app/shipping/metrics-sources/azure-postgres-metrics.html#download-the-logzio-public-certificate-to-your-metricbeat-server
container and pod 
https://deploy-preview-940--logz-docs.netlify.app/shipping/metrics-sources/docker.html
https://deploy-preview-940--logz-docs.netlify.app/shipping/metrics-sources/kubernetes-over-helm.html



- fixed syntax for Metrics azure SYD objects. The wrong include was being used in step 4
- added tracing-parameter include, used it in Tracing syd topics
- fixed tab syntax in Kubernetes over Helm
- changed param table to 3 columns in Docker: logzio-metrics token include created as .md file


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
