### PR TITLE
explained p8s_logzio_name parameter

### DIFF
--- a/_source/_includes/p8s-shipping/p8s_logzio_name.md
+++ b/_source/_includes/p8s-shipping/p8s_logzio_name.md
@@ -1,0 +1,2 @@
+| external_labels | Parameters to tag the metrics from this specific Prometheus server. |
+| p8s_logzio_name |Use the value of the parameter `p8s_logzio_name` to identify from which Prometheus environment the metrics are arriving to Logz.io. Replace the `<labelvalue>` placeholder with a label that will be added to all the metrics that are sent from this specific Prometheus server. | 

--- a/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
+++ b/_source/logzio_collections/_p8s-sources/p8s-remote-write_shipping.md
@@ -78,11 +78,12 @@ Add the following parameters to your Prometheus yaml file:
 
 | Environment variable | Description |
 |---|---|
-| external_labels | Parameter to tag the metrics from this specific Prometheus server. Do not change the label `p8s_logzio_name`: This variable is required to identify from which Prometheus environment the metrics are arriving to Logz.io  |
+{% include p8s-shipping/p8s_logzio_name.md %}
 | remote_write | The remote write section configuration sets Logz.io as the endpoint for your Prometheus metrics data. Place this section at the same indentation level as the `global` section. |
 |url (Required)| Logz.io Listener URL and port for your region, configured to use port **8052** for http traffic or port **8053** for https traffic. For more details, see the [Prometheus configuration file remote write reference](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write). {% include log-shipping/listener-var.html %}  |
 | bearer-token (Required) | Your Logz.io Metrics account token. {% include metric-shipping/replace-metrics-token.html %}   |
    
+
 
 ##### Verify the remote_write configuration
 

--- a/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
+++ b/_source/user-guide/infrastructure-monitoring/p8s-remote-write.md
@@ -51,7 +51,7 @@ Add the following parameters to your Prometheus yaml file:
 
 | Environment variable | Description |
 |---|---|
-| external_labels | Parameter to tag the metrics from this specific Prometheus server. Do not change the label `p8s_logzio_name`: This variable is required to identify from which Prometheus environment the metrics are arriving to Logz.io  |
+{% include p8s-shipping/p8s_logzio_name.md %}
 | remote_write | The remote write section configuration sets Logz.io as the endpoint for your Prometheus metrics data. Place this section at the same indentation level as the `global` section. |
 |url| Logz.io Listener url for for your region, configured to use port **8052** for http traffic or port **8053** for https traffic. For more details, see the [Prometheus configuration file remote write reference](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)|
 


### PR DESCRIPTION
# What changed
SYD: https://deploy-preview-944--logz-docs.netlify.app/shipping/p8s-sources/p8s-remote-write-shipping.html

UG: https://deploy-preview-944--logz-docs.netlify.app/user-guide/infrastructure-monitoring/p8s-remote-write.html

Clarified how to use parameter to tag metrics ingested from specific Prometheus environment.

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] **AI: Create the content as a single include and replicate it in the 2 pages** 
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
