### PR TITLE
broken links to docs w/in SYD

### DIFF
--- a/_source/_includes/tracing-shipping/tracing-parameters.md
+++ b/_source/_includes/tracing-shipping/tracing-parameters.md
@@ -2,5 +2,5 @@
 
 | Parameter | Description | Required/Default|
 |---|---|---|
-| ACCOUNT_TOKEN | The Logz.io token for the Distributed Tracing account you want to send your data to: `<<TRACING-SHIPPING-TOKEN>>` . Required when you use the collector to ship traces to Logz.io.  [How do I look up my Distributed Tracing account token?]({{site.baseurl}}/user-guide/accounts/finding-your-tracing-account-token)  | Required|
-| REGION |  Your two-letter Logz.io account region code. Defaults to **US**, required only if your Logz.io region is different than US. You can find your region code in the [Available regions]({{site.baseurl}}/user-guide/accounts/account-region.html#available-regions) table. | DEFAULT: _Blank (US East)_|
+| ACCOUNT_TOKEN | The Logz.io token for the Distributed Tracing account you want to send your data to: `<<TRACING-SHIPPING-TOKEN>>` . Required when you use the collector to ship traces to Logz.io.  [How do I look up my Distributed Tracing account token?](https://docs.logz.io/user-guide/accounts/finding-your-tracing-account-token)  | Required|
+| REGION |  Your two-letter Logz.io account region code. Defaults to **US**, required only if your Logz.io region is different than US. You can find your region code in the [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions) table. | DEFAULT: _Blank (US East)_|

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -21,10 +21,10 @@ Logz.io's trace exporter for Jaeger allows you to ship distributed traces to Log
 
 This topic explains how to install the Logz.io Jaeger Collector. 
 
-For an overview of the process to send traces to Logz.io, see [Getting started with Logz.io Distributed Tracing](/user-guide/distributed-tracing/getting-started-tracing). 
+For an overview of the process to send traces to Logz.io, see [Getting started with Logz.io Distributed Tracing]({{site.baseurl}}/user-guide/distributed-tracing/getting-started-tracing/). 
 
 We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. 
-See [_Ship traces with OpenTelemetry_](/shipping/tracing-sources/opentelemetry) for the procedure to configure and deploy the OpenTelemetry collector. You may consider using the Jaeger Collector as a secondary option, if you experience issues with the OpenTelemetry Collector. 
+See [_Ship traces with OpenTelemetry_]({{site.baseurl}}/shipping/tracing-sources/opentelemetry) for the procedure to configure and deploy the OpenTelemetry collector. You may consider using the Jaeger Collector as a secondary option, if you experience issues with the OpenTelemetry Collector. 
 
 #### Deploy Jaeger Collector with Logz.io Exporter
 

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -21,10 +21,10 @@ Logz.io's trace exporter for Jaeger allows you to ship distributed traces to Log
 
 This topic explains how to install the Logz.io Jaeger Collector. 
 
-For an overview of the process to send traces to Logz.io, see [Getting started with Logz.io Distributed Tracing]({{site.baseurl}}/user-guide/distributed-tracing/getting-started-tracing/). 
+For an overview of the process to send traces to Logz.io, see [Getting started with Logz.io Distributed Tracing](https://docs.logz.io/user-guide/distributed-tracing/getting-started-tracing/). 
 
 We recommend that you use the OpenTelemetry collector to gather trace transaction data from your system. 
-See [_Ship traces with OpenTelemetry_]({{site.baseurl}}/shipping/tracing-sources/opentelemetry) for the procedure to configure and deploy the OpenTelemetry collector. You may consider using the Jaeger Collector as a secondary option, if you experience issues with the OpenTelemetry Collector. 
+See [_Ship traces with OpenTelemetry_](https://docs.logz.io/shipping/tracing-sources/opentelemetry) for the procedure to configure and deploy the OpenTelemetry collector. You may consider using the Jaeger Collector as a secondary option, if you experience issues with the OpenTelemetry Collector. 
 
 #### Deploy Jaeger Collector with Logz.io Exporter
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -7,7 +7,7 @@ data-source: OpenTelemetry
 description: How to deploy an OpenTelemetry Collector for traces to Logz.io
 open-source:
   - title: Logz.io-OpenTelemetry trace exporter
-    github-repo: https://github.com/open-telemetry/opentelemetry-collector-contrib
+    github-repo: opentelemetry-collector-contrib
 contributors:
   - yyyogev
   - yberlinger
@@ -19,7 +19,7 @@ shipping-tags:
 
 Logz.io's trace exporter for OpenTelemetry allows you to ship distributed traces to Logz.io from different APM (Application Performance Management/Monitoring) agents, such as Jaeger, Zipkin, and so on.
 
-This topic explains how to install the OpenTelemetry Collector.  For an overview of the process to send traces to Logz.io, see [Getting started with Logz.io Distributed Tracing](/user-guide/distributed-tracing/getting-started-tracing). 
+This topic explains how to install the OpenTelemetry Collector.  For an overview of the process to send traces to Logz.io, see [Getting started with Logz.io Distributed Tracing](https://docs.logz.io/user-guide/distributed-tracing/getting-started-tracing). 
 
 ### OpenTelemetry components
 
@@ -57,7 +57,7 @@ You can use [this config file](https://github.com/open-telemetry/opentelemetry-c
 
 
 {% include tracing-shipping/tracing-parameters.md %}
-| CUSTOM_LISTENER_ADDRESS | Custom traces endpoint, for dev. This optional parameter overrides the region parameter.  You can find your Listener Address in the [Available regions]({{site.baseurl}}/user-guide/accounts/account-region.html#available-regions) table.| |
+| CUSTOM_LISTENER_ADDRESS | Custom traces endpoint, for dev. This optional parameter overrides the region parameter.  You can find your Listener Address in the [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions) table.| |
 
 
 
@@ -73,7 +73,7 @@ docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 
 ```
 
 ##### Run a working example.
-For a complete working example, you can run [this docker compose file](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/docker-compose.yaml) for the [Logz.io Hotrod demo application]({{site.baseurl}}/user-guide/distributed-tracing/trace-hotrod-demo).
+For a complete working example, you can run [this docker compose file](https://raw.githubusercontent.com/logzio/logz-docs/master/shipping-config-samples/docker-compose.yaml) for the [Logz.io Hotrod demo application](https://docs.logz.io/user-guide/distributed-tracing/trace-hotrod-demo).
 
   1. Download the docker compose file.
 
@@ -85,5 +85,5 @@ For a complete working example, you can run [this docker compose file](https://r
 
 Give your traces some time to get from your system to ours, then check the Distributed Tracing tab in Logz.io to see the traces in the Jaeger UI.
 
-To learn more about tracing instrumentation, see [Instrumentation recommendations and resources.]({{site.baseurl}}/user-guide/distributed-tracing/tracing-instrumentation#instrumentation-recommendations-and-resources)
+To learn more about tracing instrumentation, see [Instrumentation recommendations and resources.](https://docs.logz.io/user-guide/distributed-tracing/tracing-instrumentation#instrumentation-recommendations-and-resources)
 

--- a/_source/user-guide/tokens/index.md
+++ b/_source/user-guide/tokens/index.md
@@ -13,6 +13,7 @@ tags:
 contributors:
   - imnotashrimp
   - shalper
+  - yberlinger
 ---
 
 Logz.io uses tokens to manage log shipping, permissions for dashboard sharing links, and API authorization.


### PR DESCRIPTION
# What changed
https://deploy-preview-952--logz-docs.netlify.app/shipping/tracing-sources/opentelemetry.html

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
