### PR TITLE
added region slug to table, deprecated coded table

### DIFF
--- a/_source/user-guide/accounts/account-region.md
+++ b/_source/user-guide/accounts/account-region.md
@@ -38,13 +38,16 @@ For example, if you see `app-eu.logz.io`, then your account is in the Europe (Fr
 
 Your listener host and API host will always be in the same region as your account.
 
-| Region | Cloud | Logz.io account host | Listener host | API host | Region code |
+| Region | Cloud | Logz.io account host | Listener host | API host | Region code | Region slug |
 |---|---|---|
-{% for r in regions -%}
-  {%- if r.suffix -%}
-      {%- assign suffix = r.suffix | prepend: "-" -%}
-    {%- else -%}
-      {%- assign suffix = "" -%}
-  {%- endif -%}
-| {{r.title}} | {{r.cloud}} | app{{suffix}}.logz.io | listener{{suffix}}.logz.io | api{{suffix}}.logz.io | {{suffix | replace: "-", ""}} |
-{% endfor -%}
+|US East (Northern Virginia)|AWS|app.logz.io|listener.logz.io|api.logz.io| | us-east-1|	 
+|Asia Pacific (Sydney)|AWS|app-au.logz.io|listener-au.logz.io|api-au.logz.io|au|ap-southeast-2|
+|Canada (Central)	|AWS|app-ca.logz.io|listener-ca.logz.io	|api-ca.logz.io|ca|ca-central-1|
+|Europe (Frankfurt)|AWS|app-eu.logz.io|listener-eu.logz.io|api-eu.logz.io|eu|eu-central-1|
+|West Europe (Netherlands)|	Azure	|app-nl.logz.io|listener-nl.logz.io|api-nl.logz.io| nl |westeurope|
+|Europe (London)|AWS|app-uk.logz.io|listener-uk.logz.io|api-uk.logz.io|uk|eu-west-2|
+|West US 2 (Washington)|Azure|app-wa.logz.io|listener-wa.logz.io|api-wa.logz.io|wa|westus2|
+
+
+
+

--- a/_source/user-guide/accounts/account-regions-table-deprecated-snippet.md
+++ b/_source/user-guide/accounts/account-regions-table-deprecated-snippet.md
@@ -1,0 +1,30 @@
+Available regions
+Your listener host and API host will always be in the same region as your account.
+
+introduce table text 
+
+| Region | Cloud | Logz.io account host | Listener host | API host | Region code | Region slug |
+|---|---|---|
+| US East (Northern Virginia)|	AWS	|app.logz.io	|listener.logz.io	|api.logz.io| | us-east-1|	 
+|Asia Pacific (Sydney)|	AWS	|app-au.logz.io|	listener-au.logz.io	|api-au.logz.io|	au |ap-southeast-2 |
+|Canada (Central)	|AWS	|app-ca.logz.io	|listener-ca.logz.io	|api-ca.logz.io	|ca|ca-central-1 |
+|Europe (Frankfurt)|	AWS	|app-eu.logz.io	| listener-eu.logz.io|	api-eu.logz.io	|eu |eu-central-1 |
+|West Europe (Netherlands)|	Azure	|app-nl.logz.io|	listener-nl.logz.io	|api-nl.logz.io| nl | westeurope|
+|Europe (London)	|AWS	|app-uk.logz.io	| listener-uk.logz.io|	api-uk.logz.io | uk| eu-west-2 |
+|West US 2 (Washington)|	Azure	|app-wa.logz.io	|listener-wa.logz.io	|api-wa.logz.io|	wa | westus2|
+
+
+
+
+Your listener host and API host will always be in the same region as your account.
+
+| Region | Cloud | Logz.io account host | Listener host | API host | Region code |
+|---|---|---|
+{% for r in regions -%}
+  {%- if r.suffix -%}
+      {%- assign suffix = r.suffix | prepend: "-" -%}
+    {%- else -%}
+      {%- assign suffix = "" -%}
+  {%- endif -%}
+| {{r.title}} | {{r.cloud}} | app{{suffix}}.logz.io | listener{{suffix}}.logz.io | api{{suffix}}.logz.io | {{suffix | replace: "-", ""}} |
+{% endfor -%}


### PR DESCRIPTION
# What changed

https://deploy-preview-953--logz-docs.netlify.app/user-guide/accounts/account-region.html#available-regions

For ticket: https://trello.com/c/8t0FBT2P/121-need-to-update-the-regions-doc-to-contain-the-region-slug-so-it-can-match-the-region-we-show-in-the-app

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
