### PR TITLE
highlight beta status:  Telegraf & PromRemoteWrite

### DIFF
--- a/_source/logzio_collections/_prometheus-sources/prometheus-remote-write_shipping.md
+++ b/_source/logzio_collections/_prometheus-sources/prometheus-remote-write_shipping.md
@@ -16,8 +16,10 @@ contributors:
 shipping-tags:  
   - prometheus
 ---
-
+<!-- info-box-start:info -->
 This feature is in beta. Please [email our support](mailto:help@logz.io?subject=Requesting%20early%20access%20for%20p8s.%20Thanks) or your Logz.io account manager to request early access. 
+{:.info-box.note}
+<!-- info-box-end -->
 
 To send your Prometheus application metrics to a Logz.io Infrastructure Monitoring account, use remote write to connect to Logz.io as the endpoint. Your data is formatted as JSON documents by the Logz.io listener. 
 

--- a/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
+++ b/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
@@ -15,8 +15,10 @@ shipping-tags:
   - prometheus
 
 ---
-
+<!-- info-box-start:info -->
 This feature is in beta. Please [email our support](mailto:help@logz.io?subject=Requesting%20early%20access%20for%20p8s.%20Thanks) or your Logz.io account manager to request early access. 
+{:.info-box.note}
+<!-- info-box-end -->
 
 This project lets you to configure a Telegraf agent to send your collected Prometheus-format metrics to Logz.io.
 


### PR DESCRIPTION
# What changed
Cosmetic change: Added note formatting to highlight beta status for 2 Prom objects
https://deploy-preview-954--logz-docs.netlify.app/shipping/prometheus-sources/prometheus-telegraf-output.html
https://deploy-preview-954--logz-docs.netlify.app/shipping/prometheus-sources/prometheus-remote-write-shipping.html

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
