### PR TITLE
remove beta flag for Distributed Tracing topics

### DIFF
--- a/_source/user-guide/distributed-tracing/compare-traces.md
+++ b/_source/user-guide/distributed-tracing/compare-traces.md
@@ -4,7 +4,6 @@ title: Compare traces
 permalink: /user-guide/distributed-tracing/compare-traces
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -4,7 +4,6 @@ title: Deploying components in your system
 permalink: /user-guide/distributed-tracing/deploying-components
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/getting-started-tracing.md
+++ b/_source/user-guide/distributed-tracing/getting-started-tracing.md
@@ -4,7 +4,6 @@ title: Getting started with Logz.io Distributed Tracing
 permalink: /user-guide/distributed-tracing/getting-started-tracing
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/index.md
+++ b/_source/user-guide/distributed-tracing/index.md
@@ -4,7 +4,6 @@ title: Distributed Tracing
 permalink: /user-guide/distributed-tracing/
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/k8s-deployment.md
+++ b/_source/user-guide/distributed-tracing/k8s-deployment.md
@@ -4,7 +4,6 @@ title: Kubernetes deployment reference
 permalink: /user-guide/distributed-tracing/k8s-deployment
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/topology-system_architecture.md
+++ b/_source/user-guide/distributed-tracing/topology-system_architecture.md
@@ -4,7 +4,6 @@ title: Topology diagrams
 permalink: /user-guide/distributed-tracing/topology-system_architecture
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/trace-graph.md
+++ b/_source/user-guide/distributed-tracing/trace-graph.md
@@ -4,7 +4,6 @@ title: What can I do in the Trace Graph?
 permalink: /user-guide/distributed-tracing/trace-graph
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/trace-json.md
+++ b/_source/user-guide/distributed-tracing/trace-json.md
@@ -4,7 +4,6 @@ title: What can I do in the Trace JSON?
 permalink: /user-guide/distributed-tracing/trace-json
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/trace-statistics.md
+++ b/_source/user-guide/distributed-tracing/trace-statistics.md
@@ -4,7 +4,6 @@ title: What can I do in the Trace Statistics?
 permalink: /user-guide/distributed-tracing/trace-statistics
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/trace-timeline.md
+++ b/_source/user-guide/distributed-tracing/trace-timeline.md
@@ -4,7 +4,6 @@ title: What can I do in the Trace Timeline?
 permalink: /user-guide/distributed-tracing/trace-timeline
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/tracing-tour.md
+++ b/_source/user-guide/distributed-tracing/tracing-tour.md
@@ -4,7 +4,6 @@ title: The Grand Distributed Tracing Tour
 permalink: /user-guide/distributed-tracing/tracing-tour
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:

--- a/_source/user-guide/distributed-tracing/what-is-tracing.md
+++ b/_source/user-guide/distributed-tracing/what-is-tracing.md
@@ -4,7 +4,6 @@ title: What is Distributed Tracing?
 permalink: /user-guide/distributed-tracing/what-is-tracing
 flags:
   logzio-plan: pro enterprise
-  beta: true
 tags:
   - distributed tracing
 contributors:


### PR DESCRIPTION
# What changed
Beta flag removed from this and all child topics: https://deploy-preview-960--logz-docs.netlify.app/user-guide/distributed-tracing/

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
