### PR TITLE
YotamB's (support) request to add a link to elastic, for restart filebeat. Would need to be an include for all docs. 

### DIFF
--- a/_source/logzio_collections/_log-sources/apache.md
+++ b/_source/logzio_collections/_log-sources/apache.md
@@ -120,7 +120,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_log-sources/filebeat.md
+++ b/_source/logzio_collections/_log-sources/filebeat.md
@@ -60,7 +60,7 @@ Move your configuration file to `/etc/filebeat/filebeat.yml`.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_log-sources/gitlab.md
+++ b/_source/logzio_collections/_log-sources/gitlab.md
@@ -152,7 +152,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_log-sources/jenkins.md
+++ b/_source/logzio_collections/_log-sources/jenkins.md
@@ -102,7 +102,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_log-sources/mysql.md
+++ b/_source/logzio_collections/_log-sources/mysql.md
@@ -172,7 +172,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_log-sources/network-device.md
+++ b/_source/logzio_collections/_log-sources/network-device.md
@@ -95,7 +95,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_log-sources/puppet.md
+++ b/_source/logzio_collections/_log-sources/puppet.md
@@ -140,7 +140,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/check-point.md
+++ b/_source/logzio_collections/_security-sources/check-point.md
@@ -130,7 +130,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/cisco-asa.md
+++ b/_source/logzio_collections/_security-sources/cisco-asa.md
@@ -104,7 +104,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/cisco-meraki.md
+++ b/_source/logzio_collections/_security-sources/cisco-meraki.md
@@ -95,7 +95,7 @@ If the file has other outputs, remove them.
 ##### Start Filebeat
 
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 
 ##### Check Logz.io for your logs

--- a/_source/logzio_collections/_security-sources/eset.md
+++ b/_source/logzio_collections/_security-sources/eset.md
@@ -95,7 +95,7 @@ If the file has other outputs, remove them.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Configure ESET to send logs to Logzio
 

--- a/_source/logzio_collections/_security-sources/fail2ban.md
+++ b/_source/logzio_collections/_security-sources/fail2ban.md
@@ -92,7 +92,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/falco.md
+++ b/_source/logzio_collections/_security-sources/falco.md
@@ -246,7 +246,7 @@ If the file has other outputs, remove them.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/fortigate.md
+++ b/_source/logzio_collections/_security-sources/fortigate.md
@@ -114,7 +114,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/gsuite.md
+++ b/_source/logzio_collections/_security-sources/gsuite.md
@@ -138,7 +138,7 @@ Still in the same configuration file, replace the placeholders to match your spe
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/hashicorp-vault.md
+++ b/_source/logzio_collections/_security-sources/hashicorp-vault.md
@@ -101,7 +101,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/juniper-srx.md
+++ b/_source/logzio_collections/_security-sources/juniper-srx.md
@@ -106,7 +106,7 @@ If the file has other outputs, remove them.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/mcafee-epolicy-orchestrator.md
+++ b/_source/logzio_collections/_security-sources/mcafee-epolicy-orchestrator.md
@@ -115,7 +115,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/modsecurity.md
+++ b/_source/logzio_collections/_security-sources/modsecurity.md
@@ -85,7 +85,7 @@ If the file has other outputs, remove them.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/nginx.md
+++ b/_source/logzio_collections/_security-sources/nginx.md
@@ -117,7 +117,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/openvas.md
+++ b/_source/logzio_collections/_security-sources/openvas.md
@@ -104,7 +104,7 @@ If the file has other outputs, remove them.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
   
 Filebeat is now configured to send OpenVAS CSV reports directly to Logz.io.
 

--- a/_source/logzio_collections/_security-sources/ossec.md
+++ b/_source/logzio_collections/_security-sources/ossec.md
@@ -115,7 +115,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/palo-alto-networks.md
+++ b/_source/logzio_collections/_security-sources/palo-alto-networks.md
@@ -158,7 +158,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/sentinelone.md
+++ b/_source/logzio_collections/_security-sources/sentinelone.md
@@ -95,7 +95,7 @@ If the file has other outputs, remove them.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Configure SentinelOne to send logs to Logzio
 

--- a/_source/logzio_collections/_security-sources/sonicwall.md
+++ b/_source/logzio_collections/_security-sources/sonicwall.md
@@ -101,7 +101,7 @@ If the file has other outputs, remove them.
 
 
 ##### Start Filebeat
-
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 Start or restart Filebeat for the changes to take effect.
 
 ##### Check Logz.io for your logs

--- a/_source/logzio_collections/_security-sources/sophos.md
+++ b/_source/logzio_collections/_security-sources/sophos.md
@@ -90,7 +90,7 @@ If the file has other outputs, remove them.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 
 ##### Check Logz.io for your logs

--- a/_source/logzio_collections/_security-sources/stormshield.md
+++ b/_source/logzio_collections/_security-sources/stormshield.md
@@ -79,7 +79,7 @@ If the file has other outputs, remove them.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 
 ##### Check Logz.io for your logs

--- a/_source/logzio_collections/_security-sources/trendmicro.md
+++ b/_source/logzio_collections/_security-sources/trendmicro.md
@@ -94,7 +94,7 @@ If the file has other outputs, remove them.
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Configure Trend Micro agents to forward logs to Filebeat
 

--- a/_source/logzio_collections/_security-sources/wazuh.md
+++ b/_source/logzio_collections/_security-sources/wazuh.md
@@ -108,7 +108,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_security-sources/zeek.md
+++ b/_source/logzio_collections/_security-sources/zeek.md
@@ -133,7 +133,7 @@ output.logstash:
 
 ##### Start Filebeat
 
-Start or restart Filebeat for the changes to take effect.
+[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.
 
 ##### Check Logz.io for your logs
 


### PR DESCRIPTION
Linked linux "start filebeat" to instructions on how to do so



# What changed
**@boofinka  - would you please do a sanity check before I merge?**
 
Did a global replace for all instances of "Start or restart Filebeat" to change to a link with the instructions:
- from:   **Start or restart Filebeat for the changes to take effect.**
- to **[Start or restart Filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-starting.html) for the changes to take effect.**

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
