### PR TITLE
fix token dox - correct Manage tokens links

### DIFF
--- a/_source/_includes/general-shipping/data-shipping-tokens_vars.md
+++ b/_source/_includes/general-shipping/data-shipping-tokens_vars.md
@@ -1,0 +1,5 @@
+From your account, go to the <a href="https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping" target ="_blank"> **Manage Tokens** > **Data shipping tokens** tab.</a> of your Operations workspace. <br> It can be reached by selecting **<i class="li li-gear"></i> > Settings > Tools > Manage Tokens**. 
+
++ Click the **{{include.product}}** option.
++ The Listener URL for your account is displayed above the token table.
++ The token for each account is listed in the table along with the date it was created.  

--- a/_source/_includes/general-shipping/manage-tokens-nav.md
+++ b/_source/_includes/general-shipping/manage-tokens-nav.md
@@ -1,3 +1,2 @@
 You must have admin permissions for the Logz.io account to view the **Manage Tokens** page. If you're not an admin user for the account, consult with an account admin to get the token information. 
 
-From your account, go to the <a href="https://app.logz.io/#/dashboard/settings/manage-tokens" target ="_blank"> **Manage Tokens** page</a> of your Operations workspace. <br> It can be reached by selecting **<i class="li li-gear"></i> > Settings > Tools > Manage Tokens**. 

--- a/_source/user-guide/tokens/api-tokens.md
+++ b/_source/user-guide/tokens/api-tokens.md
@@ -20,7 +20,7 @@ API tokens are unique to each account. The only exception is a subset of account
 
 {% include general-shipping/manage-tokens-nav.md %}
 
-Click the **API tokens** tab. 
+From your account, go to the <a href="https://app.logz.io/#/dashboard/settings/manage-tokens/api" target ="_blank"> **Manage Tokens** > **API tokens** tab.</a> of your Operations workspace <br> It can be reached by selecting **<i class="li li-gear"></i> > Settings > Tools > Manage Tokens**. 
 
 The token for each account is listed in the table along with the date it was created.
 

--- a/_source/user-guide/tokens/log-shipping-tokens.md
+++ b/_source/user-guide/tokens/log-shipping-tokens.md
@@ -17,49 +17,17 @@ Log shipping tokens are used in shipper configurations to direct data to the rel
 
 Every account has its own set of tokens. Only account admins have permissions to access the account tokens, view them and manage them.
 
-To manage your log shipping tokens, select an account. You can manage your tokens either on the Manage Tokens page or on the Manage accounts page. 
+To manage your log shipping tokens, select an account. You can manage your tokens via the Manage Tokens page. 
 
-<!-- tabContainer:start -->
-<div class="branching-container">
-
-* [Via the Manage Tokens page](#manage-token)
-* [Via the Manage accounts page](#manage-accounts)
-{:.branching-tabs}
-
-<!-- tab:start -->
-<div id="manage-token">
-
-### Via the Manage Tokens page:
+### Manage Tokens page
 
 {% include general-shipping/manage-tokens-nav.md %}
-
-+ Navigate to **Data shipping tokens** and click the **Logs** option.
-+ The Listener URL for your account is displayed above the token table.
-+ The token for each account is listed in the table along with the date it was created. 
-
-</div>
-<!-- tab:end -->
-
-
-<!-- tab:start -->
-<div id="manage-accounts">
-
-### Via the Manage accounts page:
-
-Select [**<i class="li li-gear"></i> > Tools > Manage tokens**](https://app.logz.io/#/dashboard/settings/manage-tokens/log-shipping) in the top menu and select the **Log shipping tokens** tab.
-
-
-</div>
-<!-- tab:end -->
-
-
-</div>
-<!-- tabContainer:end -->
+{% include general-shipping/data-shipping-tokens_vars.md product="Logs" %}
 
 Community plans have a limit on the number of tokens that may be enabled. See the official [pricing page](https://logz.io/pricing/) for details.
 {:.info-box.note}
 
-#### Managing log shipping tokens
+### Managing log shipping tokens
 
 You can have several tokens enabled simultaneously. The limit is indicated directly on the page and depends on your account level.
 
@@ -71,7 +39,7 @@ You can have several tokens enabled simultaneously. The limit is indicated direc
 If there is only one token, it can't be disabled or deleted.
 
 
-#### Using log shipping tokens
+### Using log shipping tokens
 
 Log shipping tokens are used in the shipping configuration to send data to the relevant Logz.io account.
 

--- a/_source/user-guide/tokens/metrics-shipping-token.md
+++ b/_source/user-guide/tokens/metrics-shipping-token.md
@@ -30,12 +30,9 @@ Here's how to get the metrics token:
 ### Via the Manage Tokens page
 
 {% include general-shipping/manage-tokens-nav.md %}
+{% include general-shipping/data-shipping-tokens_vars.md product="Metrics" %}
 
-Navigate to **Data shipping tokens** and click the **Metrics** option.
 
-The Listener URL and Region code for your account are displayed above the token table.
-
-The token for each account is listed in the table along with the date it was created. 
 
 </div>
 <!-- tab:end -->

--- a/_source/user-guide/tokens/shared-tokens.md
+++ b/_source/user-guide/tokens/shared-tokens.md
@@ -52,8 +52,7 @@ These best-practice recommendations will help you keep your data secure when usi
 
 To manage your shared tokens: 
 {% include general-shipping/manage-tokens-nav.md %}
-
-Click the **Shared tokens** tab. 
+From your account, go to the <a href="https://app.logz.io/#/dashboard/settings/manage-tokens/shared" target ="_blank"> **Manage Tokens** > **Shared tokens** tab.</a> of your Operations workspace <br> It can be reached by selecting **<i class="li li-gear"></i> > Settings > Tools > Manage Tokens**.
 
 The token for each account is listed in the table along with the date it was created.
 

--- a/_source/user-guide/tokens/tracing-shipping-token.md
+++ b/_source/user-guide/tokens/tracing-shipping-token.md
@@ -27,12 +27,7 @@ Here's how to get the tracing token:
 ### Via the Manage Tokens page
 
 {% include general-shipping/manage-tokens-nav.md %}
-
-Navigate to **Data shipping tokens** and click the **Tracing** option.
-
-The Listener URL and Region code for your account are displayed above the token table.
-
-The token for each account is listed in the table along with the date it was created. 
+{% include general-shipping/data-shipping-tokens_vars.md product="Tracing" %}
 
 </div>
 <!-- tab:end -->


### PR DESCRIPTION
# What changed
Updated links to Manage tokens tabs, streamlined the Logs token topic, created 'include' topics for better content reuse. 

- https://deploy-preview-988--logz-docs.netlify.app/user-guide/tokens/log-shipping-tokens/
- https://deploy-preview-988--logz-docs.netlify.app/user-guide/accounts/finding-your-metrics-account-token/
- https://deploy-preview-988--logz-docs.netlify.app/user-guide/accounts/finding-your-tracing-account-token/
- https://deploy-preview-988--logz-docs.netlify.app/user-guide/tokens/shared-tokens.html
- https://deploy-preview-988--logz-docs.netlify.app/user-guide/tokens/api-tokens.html

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] **Images for Manage tokens - Data shipping topics** 
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
