### PR TITLE
redirect aws-redshift-p8s

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -289,6 +289,13 @@
   force = true
 
 [[redirects]]
+  from = "/shipping/p8s-sources/aws-redshift-p8s*"
+  to = "/shipping/prometheus-sources/aws-redshift-prometheus:splat"
+  status = 301
+  force = true
+
+
+[[redirects]]
   from = "/user-guide/infrastructure-monitoring/grafana*"   
   to = "/user-guide/infrastructure-monitoring/metrics:splat"
   status = 301


### PR DESCRIPTION
# What changed
Google search console notification for https://docs.logz.io/shipping/p8s-sources/aws-redshift-p8s.html
created explicit redirect to  https://deploy-preview-1000--logz-docs.netlify.app/shipping/prometheus-sources/aws-redshift-prometheus.html

>  Search Console
> We're validating your Coverage issue fixes for site https://docs.logz.io/
> > To owner of https://docs.logz.io/,
> > Google has started validating your fix of Coverage issues on your site. Specifically, we are checking for ‘Server error (5xx)’, which currently affects 1 pages.
> > Validation can take a few days; we will send you a message when the process is complete. You can monitor the progress of the test by following the link below.


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->
      [[redirects]]
  from = "/shipping/p8s-sources/aws-redshift-p8s*"
  to = "/shipping/prometheus-sources/aws-redshift-prometheus:splat"
  status = 301
  force = true


## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
