### PR TITLE
redirect, still

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -277,7 +277,7 @@
   force = true
 
 [[redirects]]
-  from = "/shipping/p8s-sources/aws-redshift-p8s.html"
+  from = "/shipping/prometheus-sources/aws-redshift-p8s.html"
   to = "/shipping/prometheus-sources/aws-redshift-prometheus.html"
   status = 301
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -275,24 +275,19 @@
   to = "/shipping/prometheus-sources/:splat"
   status = 301
   force = true
- 
-[[redirects]]
-  from = "/user-guide/infrastructure-monitoring/p8s-*"
-  to = "/user-guide/infrastructure-monitoring/prometheus-:splat"
-  status = 301
-  force = true  
-
-[[redirects]]
-  from = "/shipping/p8s-sources/*"
-  to = "/shipping/prometheus-sources/:splat"
-  status = 301
-  force = true
 
 [[redirects]]
   from = "/shipping/p8s-sources/aws-redshift-p8s.html"
   to = "/shipping/prometheus-sources/aws-redshift-prometheus.html"
   status = 301
   force = true
+
+[[redirects]]
+  from = "/user-guide/infrastructure-monitoring/p8s-*"
+  to = "/user-guide/infrastructure-monitoring/prometheus-:splat"
+  status = 301
+  force = true  
+
 
 [[redirects]]
   from = "/user-guide/infrastructure-monitoring/grafana*"   


### PR DESCRIPTION
# What changed
Redirect issue. 
created explicit redirect for https://docs.logz.io/shipping/p8s-sources/aws-redshift-p8s.html


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
