### PR TITLE
Prometheus tidbits

### DIFF
--- a/_source/_data/shipper-tabs.yml
+++ b/_source/_data/shipper-tabs.yml
@@ -20,14 +20,17 @@ tabs:
     templated: true
     top-content: >-
       <p class="info-box important no-title">
-        <span class="bold">Prometheus Metrics are currently in roll-out. Supported regions include US East and EU Central.
-        Please contact your Logz.io Customer Success Manager to request early-access.
+        <span class="bold">Prometheus Metrics are currently in roll-out. Supported regions include US East and EU Central, and shortly, EU West.
+         <br> </br>
+        Contact your Logz.io Customer Success Manager to request early-access.
       </p>
   - collection: metrics-sources
     templated: true
     top-content: >-
       <p class="info-box important no-title">
-        <span class="bold">Please contact your Logz.io Customer Success Manager for assistance selecting the best Metrics options for your environments.
+        <span class="bold"> If you started using Logz.io metrics in March 2021 or later, select the relevant data shipping option from the <a href="https://app.logz.io/#/dashboard/send-your-data?tag=all&collection=prometheus-sources"> Metrics (Prometheus) </a> tab.
+        <br> </br>
+        Contact your Logz.io Customer Success Manager for assistance with selecting the best Metrics data shipping options for your environments. 
       </p>
   - collection: tracing-sources
     templated: true

--- a/_source/_includes/p8s-shipping/prometheus-rollout.md
+++ b/_source/_includes/p8s-shipping/prometheus-rollout.md
@@ -1,0 +1,5 @@
+<p class="info-box important no-title">
+  <span class="bold">Prometheus Metrics are currently in roll-out. Supported regions include US East and EU Central, and shortly, EU West. <br> <br>
+  Contact your Logz.io Customer Success Manager to request early-access.
+</p>
+   

--- a/_source/_includes/p8s-shipping/remotewrite-syd-userguide.md
+++ b/_source/_includes/p8s-shipping/remotewrite-syd-userguide.md
@@ -75,7 +75,7 @@ Edit your chart `values.yaml` file in the following sections:
 ```yaml
 remoteWrite:
     - url: https://<<LISTENER-HOST>>:8053  # The Logz.io Listener URL for your region, configured to use port **8052** for http traffic, or port **8053** for https traffic. 
-      bearerToken:<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> # The Logz.io Prometheus metrics account token
+      bearerToken: <<PROMETHEUS-METRICS-SHIPPING-TOKEN>> # The Logz.io Prometheus metrics account token
       remoteTimeout: 30s
       queueConfig:
         batchSendDeadline: 5s  #default = 5s

--- a/_source/_includes/p8s-shipping/remotewrite-syd-userguide.md
+++ b/_source/_includes/p8s-shipping/remotewrite-syd-userguide.md
@@ -1,4 +1,3 @@
-{% include page-info/early-access.md type="beta" %}
 
 To send your Prometheus application metrics to a Logz.io Infrastructure Monitoring account, use remote write to connect to Logz.io as the endpoint. Your data is formatted as JSON documents by the Logz.io listener. 
 

--- a/_source/logzio_collections/_prometheus-sources/prometheus-cloudwatch-exporter.md
+++ b/_source/logzio_collections/_prometheus-sources/prometheus-cloudwatch-exporter.md
@@ -15,7 +15,6 @@ shipping-tags:
   - aws
 ---
 
-{% include page-info/early-access.md type="beta" %}
 
 This project allows you to collect Prometheus-format metrics from Amazon CloudWatch with the CloudWatch exporter, and ship them to Logz.io using the OpenTelemetry collector.
 

--- a/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
+++ b/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
@@ -4,6 +4,9 @@ logo:
   logofile: mascot-telegraf.png #telegraf-tiger.png  #telegraf-logo-preview.svg
   orientation: vertical
 data-source: Telegraf for Prometheus metrics
+open-source:
+  - title: Telegraf Collector for Prometheus metrics
+    github-repo: logz-telegraf-metrics
 templates: ["docker"]
 contributors:
   - fadi-khatib
@@ -13,8 +16,6 @@ shipping-tags:
 
 ---
 
-
-{% include page-info/early-access.md type="beta" %}
 
 
 This project lets you configure a Telegraf agent to send your collected Prometheus-format metrics to Logz.io.
@@ -54,14 +55,12 @@ For the list of options, see the parameters below the code block.👇
      Authorization = "Bearer <<PROMETHEUS-METRICS-SHIPPING-TOKEN>>"
 ``` 
 
-###### Parameters
+###### Parameters 
 
-{% include general-shipping/replace-placeholders-prometheus.md %}
-{% include log-shipping/listener-var-bullet.html %}
+{% include general-shipping/replace-placeholders-prometheus.html %}
 
 
 ##### Check Logz.io for your metrics
-
 Give your data some time to get from your system to ours, then log in to your Logz.io Metrics account, and open [the Logz.io Metrics tab](https://app.logz.io/#/dashboard/grafana/).
 
 

--- a/_source/logzio_collections/_prometheus-sources/python-custom-prometheus.md
+++ b/_source/logzio_collections/_prometheus-sources/python-custom-prometheus.md
@@ -17,9 +17,6 @@ shipping-tags:
 
 
 
-{% include page-info/early-access.md type="beta" %}
-
-
 This page contains instructions on how to send custom metrics to Logz.io from your Python application. This example uses the [OpenTelemetry Python SDK](https://github.com/open-telemetry/opentelemetry-python-contrib) and the [OpenTelemetry remote write exporter](https://pypi.org/project/opentelemetry-exporter-prometheus-remote-write/), which are both in alpha/preview.
 
 #### Quick start

--- a/_source/user-guide/distributed-tracing/index.md
+++ b/_source/user-guide/distributed-tracing/index.md
@@ -24,7 +24,9 @@ Logz.io gives you the ability to look under the hood at how your microservices a
 
 Gain a system-wide view of your distributed architecture, detect failed or high latency requests, and quickly drill into end-to-end call sequences of selected requests of intercommunicating microservices. Logz.io Distributed Tracing provides Jaeger as a fully managed service - so DevOps teams can use the best cloud-native open source tracing tool - without managing or having to scale it themselves. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/yYM_qLr__Ow" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<iframe width="560" height="315" src="https://play.vidyard.com/NA62kgFX2mLFsvkdMaJ9Kn" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 
 ### Yes, you _can_ have it all!
 

--- a/_source/user-guide/distributed-tracing/tracing-instrumentation.md
+++ b/_source/user-guide/distributed-tracing/tracing-instrumentation.md
@@ -67,7 +67,6 @@ The following open infrastructure projects include built-in auto instrumentation
 
 * <a href ="https://istio.io/latest/docs/tasks/observability/distributed-tracing/jaeger/" target="_blank">Istio <i class="fas fa-external-link-alt"></i></a> 
 * <a href ="https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/jaeger_tracing" target="_blank">Envoy <i class="fas fa-external-link-alt"></i></a> 
-* <a href ="https://grafana.com/docs/grafana/latest/administration/configuration/" target="_blank">Grafana <i class="fas fa-external-link-alt"></i></a> 
 * <a href ="https://docs.traefik.io/observability/tracing/jaeger/" target="_blank">Traefik <i class="fas fa-external-link-alt"></i></a> 
 * <a href ="https://vertx-ci.github.io/vertx-4-preview/docs/vertx-opentracing/java/" target="_blank">VertX <i class="fas fa-external-link-alt"></i></a>
 * <a href ="https://docs.konghq.com/hub/kong-inc/zipkin/" target="_blank">Kong <i class="fas fa-external-link-alt"></i></a>

--- a/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
+++ b/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
@@ -8,12 +8,15 @@ tags:
   - metrics
 contributors:
   - shalper
+  - yberlinger
 ---
 
 Logz.io Metrics will help you monitor the health of your systems and catch issues BEFORE your customers notice.
 Here's how Logz.io Metrics will get you there.
 
 Logz.io Metrics is a Prometheus-based infrastructure monitoring platform that integrates seamlessly with the Kibana-based logging platform. Prometheus is the leading open-source tool for visualizing numerical data at scale, with powerful graphing capabilities of trends, changes over time, derivatives, and inflection curves.
+
+The Logz.io’s Metrics UI, the front-end for Infrastructure Monitoring, is a forked version of the Grafana open-source software created by Logz.io. Read more about the Logz.io fork [here.](https://logz.io/about-us/forked-statement/)
 
 
 ### Easily correlate metrics with logs

--- a/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
+++ b/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
@@ -16,7 +16,7 @@ Here's how Logz.io Metrics will get you there.
 
 Logz.io Metrics is a Prometheus-based infrastructure monitoring platform that integrates seamlessly with the Kibana-based logging platform. Prometheus is the leading open-source tool for visualizing numerical data at scale, with powerful graphing capabilities of trends, changes over time, derivatives, and inflection curves.
 
-The Logz.io’s Metrics UI, the front-end for Infrastructure Monitoring, is a forked version of the Grafana open-source software created by Logz.io. Read more [here.](https://logz.io/about-us/forked-statement/)
+The Logz.io’s Metrics UI, the front-end for Infrastructure Monitoring, is a forked version of the Grafana open-source software, created by Logz.io. Read more [here.](https://logz.io/about-us/forked-statement/)
 
 
 ### Easily correlate metrics with logs

--- a/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
+++ b/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
@@ -16,7 +16,7 @@ Here's how Logz.io Metrics will get you there.
 
 Logz.io Metrics is a Prometheus-based infrastructure monitoring platform that integrates seamlessly with the Kibana-based logging platform. Prometheus is the leading open-source tool for visualizing numerical data at scale, with powerful graphing capabilities of trends, changes over time, derivatives, and inflection curves.
 
-The Logz.io’s Metrics UI, the front-end for Infrastructure Monitoring, is a forked version of the Grafana open-source software created by Logz.io. Read more about the Logz.io fork [here.](https://logz.io/about-us/forked-statement/)
+The Logz.io’s Metrics UI, the front-end for Infrastructure Monitoring, is a forked version of the Grafana open-source software created by Logz.io. Read more [here.](https://logz.io/about-us/forked-statement/)
 
 
 ### Easily correlate metrics with logs

--- a/_source/user-guide/infrastructure-monitoring/metrics-explore-prometheus.md
+++ b/_source/user-guide/infrastructure-monitoring/metrics-explore-prometheus.md
@@ -5,7 +5,7 @@ permalink: /user-guide/infrastructure-monitoring/metrics-explore-prometheus/
 flags:
   #admin: true
   logzio-plan: pro
-  beta: true
+  beta: 
 tags:
   - Metrics
 contributors:
@@ -13,6 +13,9 @@ contributors:
   - shalper
   - yberlinger
 ---
+
+{% include /p8s-shipping/prometheus-rollout.md %}
+
 
 Metrics Explore is where you can research the data available in your Prometheus metrics account and discover the metadata (tags, dimensions, or fields) associated with each metric from the services in your environment.
 

--- a/_source/user-guide/infrastructure-monitoring/prometheus-getting-started.md
+++ b/_source/user-guide/infrastructure-monitoring/prometheus-getting-started.md
@@ -26,14 +26,17 @@ You can continue using Prometheus Alert Manager: You'll simply store the metrics
 ## One small step
 All it takes to ship your metrics data to Logz.io is to use Remote Write on each Prometheus server, with Logz.io configured as the endpoint: By adding a few lines of code, Remote Write ensures that your metrics are written to Logz.io. 
 
+
+<iframe width="560" height="315" src="https://play.vidyard.com/eyLtidmJn1Ad1e2UA1Pjxi" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
 Your data is formatted as JSON documents by the Logz.io listener. 
-For the beta program, your incoming raw data has a 30-day retention period. 
+For the trial program, your incoming raw data has a 30-day retention period. 
 
 Once your metrics are flowing, import your existing Prometheus and Grafana dashboards to Logz.io Infrastructure Monitoring as JSON files.  
 
 For the record, notification endpoints and dashboard annotations are not imported: You'll need to recreate them in Logz.io.  See [Notification endpoints](/user-guide/integrations/endpoints.html) and [Annotations](/user-guide/infrastructure-monitoring/annotations/) for more information.
 
- 
 
 ### Steps to get started
 1. <a href ="/user-guide/infrastructure-monitoring/prometheus-remote-write#configuring-remote-write-to-logzio)"  target="_blank">Configure Remote Write. 
@@ -41,6 +44,9 @@ For the record, notification endpoints and dashboard annotations are not importe
 1. [Configure notification endpoints.](/user-guide/integrations/endpoints.html)
 1. [Recreate your dashboard annotations.](/user-guide/infrastructure-monitoring/annotations/)
 1. [Explore your Prometheus metrics](/user-guide/infrastructure-monitoring/grafana-explore-prometheus/)
+
+
+
 
 <!-- 
 1. Highlight the value: 

--- a/_source/user-guide/infrastructure-monitoring/prometheus-getting-started.md
+++ b/_source/user-guide/infrastructure-monitoring/prometheus-getting-started.md
@@ -3,15 +3,13 @@ layout: article
 title: Getting started with Prometheus 
 permalink: /user-guide/infrastructure-monitoring/prometheus-getting-started.html
 flags:
-  logzio-plan: 
-  beta: true
+  logzio-plan: pro
 tags:
   - metrics integrations
 contributors:
   - yberlinger
 ---
-
-{% include page-info/early-access.md type="beta" %} 
+{% include /p8s-shipping/prometheus-rollout.md %}
 
 ## Why go it alone? 
 Manage your metrics with Logz.io Infrastructure Monitoring, powered by Prometheus.  

--- a/_source/user-guide/infrastructure-monitoring/prometheus-importing-dashbds.md
+++ b/_source/user-guide/infrastructure-monitoring/prometheus-importing-dashbds.md
@@ -3,8 +3,7 @@ layout: article
 title: Importing metrics dashboards   
 permalink: /user-guide/infrastructure-monitoring/prometheus-importing-dashbds.html
 flags:
-  logzio-plan:  
-  beta: true
+  logzio-plan: pro 
 tags:
   - metrics integrations
 contributors:
@@ -12,7 +11,8 @@ contributors:
   - yotamloe
 ---
 
-{% include page-info/early-access.md type="beta" %}
+{% include /p8s-shipping/prometheus-rollout.md %}
+
 
 You can import your existing Grafana dashboards to Logz.io via a manual process.
  

--- a/_source/user-guide/infrastructure-monitoring/prometheus-remote-write.md
+++ b/_source/user-guide/infrastructure-monitoring/prometheus-remote-write.md
@@ -3,8 +3,8 @@ layout: article
 title: Configuring remote write for Prometheus 
 permalink: /user-guide/infrastructure-monitoring/prometheus-remote-write.html
 flags:
-  logzio-plan:  
-  beta: true
+  logzio-plan: pro
+  beta: 
 tags:
   - metrics integrations
 contributors:
@@ -12,6 +12,7 @@ contributors:
   - yotamloe
 ---
 
+{% include /p8s-shipping/prometheus-rollout.md %}
 
 
 {% include p8s-shipping/remotewrite-syd-userguide.md %}


### PR DESCRIPTION
# What changed

- https://deploy-preview-1005--logz-docs.netlify.app/user-guide/infrastructure-monitoring/metrics-logzio
- link to [Forked Grafana statement](https://logz.io/about-us/forked-statement/)
- https://deploy-preview-1005--logz-docs.netlify.app/user-guide/infrastructure-monitoring/prometheus-getting-started.html
- Replaced beta message with rollout message for Prometheus user guide topics
- Updated notes at the top of the Prometheus (rollout in progress) and Metricbeat data shipper tabs (if you started in March 2021 or later, see the Prometheus tab
- removed Grafana link on Tracing instrumentation topic page: https://deploy-preview-1005--logz-docs.netlify.app/user-guide/distributed-tracing/tracing-instrumentation#auto-instrumentation-resources
- replaced video link to YouTube on tracing page to vidyard hosting
- fixed code snippet- missing space after ` bearer token:` 


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
