### PR TITLE
fixed image version in the config

### DIFF
--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -68,7 +68,7 @@ You can use [this config file](https://github.com/open-telemetry/opentelemetry-c
 ```yaml
 docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 -p 9411:9411 \
     -v config.yaml:/etc/otel-collector-config.yaml:ro \
-    --name logzio-collector otel/opentelemetry-collector-contrib:0.5.0 \  ## In the collector configuration, the --name attribute specifies the <<collector name>> used to run the collector. In this example, the <<collector-name>> is "logzio-collector"
+    --name logzio-collector otel/opentelemetry-collector-contrib:0.17.0 \  ## In the collector configuration, the --name attribute specifies the <<collector name>> used to run the collector. In this example, the <<collector-name>> is "logzio-collector"
         --config /etc/otel-collector-config.yaml
 ```
 


### PR DESCRIPTION
I updated image version in config to match the one we are pulling in step 2

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
