### PR TITLE
removed typo in configuration sample

### DIFF
--- a/_source/logzio_collections/_security-sources/sonicwall.md
+++ b/_source/logzio_collections/_security-sources/sonicwall.md
@@ -74,7 +74,6 @@ processors:
     - from: "log.file.path"
       to: "source"
     ignore_missing: true
-  ignore_older: 3h
 ```
 
 Copy and paste the following code block directly below.


### PR DESCRIPTION
This 'ignore_older' parameter doesn't belong there and makes the configuration invalid.

confirmed with @boofinka (teh YotamB) & @ralongit (teh RaulG)

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
