### PR TITLE
Update footers with copyright and trademarks legal notice

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: Logz.io Docs
-copyright: 2020 Logz.io
+copyright: 2015-2021, Logshero Ltd. # 2020 Logz.io 
 # description:
 url: "https://docs.logz.io" # the base hostname & protocol for your site, e.g. http://example.com
 baseurl: "" # the subpath of your site, e.g. /blog

--- a/_source/_includes/p8s-shipping/prometheus-rollout.md
+++ b/_source/_includes/p8s-shipping/prometheus-rollout.md
@@ -1,5 +1,5 @@
 <p class="info-box important no-title">
-  <span class="bold">Prometheus Metrics are currently in roll-out. Supported regions include US East and EU Central, and shortly, EU West. <br> <br>
+  <span class="bold">Prometheus Metrics are currently in roll-out. Supported regions include US East, EU Central, and EU West. <br> <br>
   Contact your Logz.io Customer Success Manager to request early-access.
 </p>
    

--- a/_source/_includes/templates/footer.html
+++ b/_source/_includes/templates/footer.html
@@ -2,7 +2,7 @@
   <div class="copyright">
     <a href="{{site.baseurl}}/docs-admin/" class="no-link">All</a>
     Rights Reserved
-    &copy; {{ site.copyright }},
+    &copy; {{ site.copyright }}
   </div>
 
   <div class="footer-links">

--- a/_source/_includes/templates/footer.html
+++ b/_source/_includes/templates/footer.html
@@ -1,14 +1,15 @@
 <footer>
   <div class="copyright">
+    <a href="{{site.baseurl}}/docs-admin/" class="no-link">All</a>
+    Rights Reserved
     &copy; {{ site.copyright }},
-    <a href="{{site.baseurl}}/docs-admin/" class="no-link">all</a>
-    rights reserved.
   </div>
 
   <div class="footer-links">
     <ul class="horizontal-list">
       <li><a href="https://logz.io/about-us/privacy-policy/" target="_top">Privacy policy</a></li>
       <li><a href="https://logz.io/about-us/terms-of-use/" target="_top">Terms of use</a></li>
+      <li><a href="https://logz.io/about-us/trademarks-legal-notice/" target="_top">Trademark Legal Notice</a></li>
       <li><a href="{{ site.baseurl }}/credits.html" target="_top">Contributors</a></li>
     </ul>
   </div>

--- a/_source/user-guide/infrastructure-monitoring/metrics-alerts.md
+++ b/_source/user-guide/infrastructure-monitoring/metrics-alerts.md
@@ -95,10 +95,10 @@ Next, set your alert conditions.
 
 ![Add Grafana alert to graph panel](https://dytvr9ot2sszz.cloudfront.net/logz-docs/grafana/alert-condition.png)
 
-**Grafana tags for alert Severity levels**
+**Metrics UI tags for alert Severity levels**
 
-Use Grafana tags as a Severity field for your alerts when integrating Grafana with PagerDuty as an alert notification endpoint.
-Follow the link for more information on <a href="https://grafana.com/docs/grafana/latest/alerting/notifications/#pagerduty" target="_blank"> the syntax for setting up Grafana tags for PagerDuty.  <i class="fas fa-external-link-alt"></i> </a>
+Use Metrics tags as a Severity field for your alerts when integrating the Metrics UI with PagerDuty as an alert notification endpoint.
+Follow the link for more information on <a href="https://grafana.com/docs/grafana/latest/alerting/notifications/#pagerduty" target="_blank"> the syntax for setting up Metrics UI tags for PagerDuty.  <i class="fas fa-external-link-alt"></i> </a>
 
 <!-- OpsGenie integration is coming too: Use tags as Priority fields for alerts when integrating Grafana withOpsGenie aas an alert notification endpoint.     Follow the link for more information on <a href="https:/grafana.com/docs/grafana/latest/alerting/notifications/" target="_blank"> the syntax for setting up Grafanatags for OpsGenie <i class="fas fa-external-link-alt"></i> </a> -->   
 


### PR DESCRIPTION
# What changed
- update Prometheus rollout regions: EU West is implemented https://deploy-preview-1012--logz-docs.netlify.app/user-guide/infrastructure-monitoring/prometheus-getting-started.html
- redact Grafana tags in Alert severity: They are now Metrics UI tags.  
  - https://deploy-preview-1012--logz-docs.netlify.app/user-guide/infrastructure-monitoring/alerts.html#add-an-alert
  - 
Footer
- add the Trademark Legal Notice: https://logz.io/about-us/trademarks-legal-notice/
- change from : "© 2020 Logz.io, all rights reserved" to "All Rights Reserved © 2015-2021,

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
