### PR TITLE
Fix indentation of 'external_labels'

### DIFF
--- a/_source/_includes/p8s-shipping/remotewrite-syd-userguide.md
+++ b/_source/_includes/p8s-shipping/remotewrite-syd-userguide.md
@@ -88,7 +88,7 @@ remoteWrite:
 
 ```yaml
 externalLabels:
-    - p8s_logzio_name: <labelvalue>
+  p8s_logzio_name: <labelvalue>
 ```
 
    


### PR DESCRIPTION
Quick fix to `external_labels` on kube-prometheus-stack 