### PR TITLE
cannot query metrics fields - Metricbeat solution

### DIFF
--- a/_source/_includes/metric-shipping/no-query-elastic-based.md
+++ b/_source/_includes/metric-shipping/no-query-elastic-based.md
@@ -1,0 +1,4 @@
+<!-- info-box-start:info -->
+You cannot query Logz.io metrics fields for the Elasticsearch-based (Metricbeat) solution. 
+{:.info-box.note}
+<!-- info-box-end -->

--- a/_source/user-guide/infrastructure-monitoring/getting-started.md
+++ b/_source/user-guide/infrastructure-monitoring/getting-started.md
@@ -13,6 +13,8 @@ contributors:
 
 This quick tour will help you get started with your new infrastructure monitoring workspace.
 
+{% include /metric-shipping/no-query-elastic-based.md %}
+
 ###### Overview
 {:.no_toc}
 

--- a/_source/user-guide/infrastructure-monitoring/metrics-explore.md
+++ b/_source/user-guide/infrastructure-monitoring/metrics-explore.md
@@ -20,7 +20,7 @@ It's also great if you're a long-time user and want to examine the structure of 
 
 To go to Explore, click the **Explore icon <i class="far fa-compass"></i>** in the left menu.
 
-{% include /metric-shipping/no-query-elastic-based.md %}
+
 
 ## Metrics view vs. Logs view
 
@@ -38,6 +38,8 @@ Which view is better, depends on your goal:
 ### Metrics View
 
 The Metrics view options offer a playground you can use to explore your data. They show a graph panel where you can experiment with queries. If you've edited a dashboard before, the interface will be familiar.
+
+{% include /metric-shipping/no-query-elastic-based.md %}
 
 The Metrics view options are great for learning what Metrics data is in your system. Here are a few examples of what it offers:
 

--- a/_source/user-guide/infrastructure-monitoring/metrics-explore.md
+++ b/_source/user-guide/infrastructure-monitoring/metrics-explore.md
@@ -20,6 +20,8 @@ It's also great if you're a long-time user and want to examine the structure of 
 
 To go to Explore, click the **Explore icon <i class="far fa-compass"></i>** in the left menu.
 
+{% include /metric-shipping/no-query-elastic-based.md %}
+
 ## Metrics view vs. Logs view
 
 Explore mode has a number of views, including various Metrics options and a Logs view.


### PR DESCRIPTION
# What changed
First and last links in https://deploy-preview-1024--logz-docs.netlify.app/user-guide/infrastructure-monitoring/elastic-metrics

For https://logzio.atlassian.net/browse/DOC-149, Added the following note to

- https://docs.logz.io/user-guide/infrastructure-monitoring/getting-started
- https://docs.logz.io/user-guide/infrastructure-monitoring/metrics-explore/

> You cannot query Logz.io metrics fields for the Elasticsearch-based (Metricbeat) solution. 

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
