### PR TITLE
Log shipping: filebeat version & port5015

### DIFF
--- a/_source/_includes/log-shipping/filebeat-installed-port5015-begin.md
+++ b/_source/_includes/log-shipping/filebeat-installed-port5015-begin.md
@@ -1,0 +1,1 @@
+* [Filebeat 7](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html#installation) installed

--- a/_source/_includes/log-shipping/filebeat-installed-port5015-end.md
+++ b/_source/_includes/log-shipping/filebeat-installed-port5015-end.md
@@ -1,0 +1,2 @@
+: While support for [Filebeat 6.3 and later versions](https://www.elastic.co/guide/en/beats/filebeat/6.7/filebeat-installation.html) is available, Logz.io recommends that you use the latest stable version
+* Destination port 5015 open to outgoing traffic

--- a/_source/logzio_collections/_log-sources/filebeat.md
+++ b/_source/logzio_collections/_log-sources/filebeat.md
@@ -33,8 +33,9 @@ Filebeat is often the easiest way to get logs from your system to Logz.io. Logz.
 #### Configure Filebeat on macOS or Linux
 
 **Before you begin, you'll need**:
-[Filebeat 7](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html) or
-[Filebeat 6](https://www.elastic.co/guide/en/beats/filebeat/6.7/filebeat-installation.html)
+
+
+{% include /log-shipping/filebeat-installed-port5015-begin.md %}{% include /log-shipping/filebeat-installed-port5015-end.md %}
 
 
 <div class="tasklist">
@@ -77,12 +78,17 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <!-- tab:start -->
 <div id="windows">
 
-Filebeat is often the easiest way to get logs from your system to Logz.io. Logz.io has a dedicated configuration wizard to make it simple to configure Filebeat. If you already have Filebeat and you want to add new sources, check out our other shipping instructions to copy&paste just the relevant changes from our code examples.
+Filebeat is often the easiest way to get logs from your system to Logz.io. Logz.io has a dedicated configuration wizard to make it simple to configure Filebeat. If you already have Filebeat and you want to add new sources, check out our other shipping instructions to copy & paste just the relevant changes from our code examples.
 
 
 #### Configure Filebeat on Windows
 
-**Before you begin, you'll need**: [Filebeat 7](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html) or [Filebeat 6](https://www.elastic.co/guide/en/beats/filebeat/6.7/filebeat-installation.html) installed as a Windows service
+**Before you begin, you'll need**: 
+
+
+{% include /log-shipping/filebeat-installed-port5015-begin.md %} installed as a Windows service{% include /log-shipping/filebeat-installed-port5015-end.md %}
+
+
 
 
 <div class="tasklist">


### PR DESCRIPTION
# What changed

For https://logzio.atlassian.net/browse/DOC-151: 
- https://deploy-preview-1025--logz-docs.netlify.app/shipping/log-sources/filebeat.html
- updated filebeat version & destination port information in both tabs

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
