### PR TITLE
grafana purge

### DIFF
--- a/_source/_includes/metric-shipping/open-dashboard.md
+++ b/_source/_includes/metric-shipping/open-dashboard.md
@@ -1,7 +1,7 @@
 ##### Open your {{include.title}} dashboard in Logz.io
 
 Give your metrics a few minutes to get from your system to ours,
-and then open [Logz.io](https://app.logz.io/#/dashboard/grafana/).
+and then open [Logz.io](https://app.logz.io/#/dashboard/metrics/).
 
 Your metrics should appear in the preconfigured dashboard in your Metrics account.
 To open it, search your Logz.io Metrics dashboards for

--- a/_source/_includes/metric-shipping/open-dashboard_p8s.md
+++ b/_source/_includes/metric-shipping/open-dashboard_p8s.md
@@ -1,7 +1,7 @@
 ##### Open your {{include.title}} dashboard in Logz.io
 
 Give your metrics a few minutes to get from your system to ours,
-and then open [Logz.io](https://app.logz.io/#/dashboard/grafana/).
+and then open [Logz.io](https://app.logz.io/#/dashboard/metrics/).
 
 Your metrics should appear in the preconfigured dashboard in your Metrics account.
 To open it, search your Logz.io Metrics dashboards for

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -78,8 +78,8 @@ security:
   - X-API-TOKEN: []
 
 tags:
-  - name: Grafana gateway
-    description: Grafana API Gateway to supported endpoints. In the context of this API, "*Grafana*" refers to the Logz.io fork of Grafana, thus this gateway provides support for the APIs of the Logz.io fork of Grafana and for some of the open source Grafana APIs. Read more about the fork created by Logz.io [here.](https://logz.io/about-us/forked-statement/)
+  - name: Metrics gateway
+    description: Metrics API Gateway to supported endpoints. In the context of this API, "*Grafana*" refers to the Logz.io fork of Grafana, thus this gateway provides support for the APIs of the Logz.io fork of Grafana and for some of the open source Grafana APIs. Read more about the fork created by Logz.io [here.](https://logz.io/about-us/forked-statement/)
 
   - name: Who am I
   - name: Manage time-based log accounts
@@ -265,18 +265,18 @@ x-tagGroups:
     tags:
       - Connect to CloudTrail
       - Connect to S3 Buckets
-  - name: Grafana API Gateway
+  - name: Metrics API Gateway
     tags:
-      - Grafana gateway
-    description: Grafana API Gateway to supported endpoints.
+      - Metrics gateway
+    description: Metrics API Gateway to supported endpoints.
 
 paths:
   # ::::: GRAFANA
   /v1/grafana/api/{GRAFANA_API_URL}:
     get:
-      summary: Grafana API Capabilities
+      summary: Metrics API Capabilities
       description: >-
-        Prepend your Logz.io API Gateway to the relevant Grafana API endpoint.
+        Prepend your Logz.io API Gateway to the relevant Metrics API endpoint.
 
 
         Supported endpoints:
@@ -289,8 +289,8 @@ paths:
 
         **Note:** Run these endpoints with an API token belonging to the main Log Management account associated with your Metrics account.
       tags:
-        - Grafana gateway
-      operationId: grafanaGateway
+        - Metrics gateway
+      operationId: metricsGateway
       produces:
         - application/json
       parameters:

--- a/_source/integrations/metrics-lights.md
+++ b/_source/integrations/metrics-lights.md
@@ -79,7 +79,7 @@ Check the box to acknowledge this option and click **Create stack**.
 
 ##### Open your Synthetic Monitoring dashboard in Logz.io
 
-Give your metrics some time to get from your system to ours, and then open [Logz.io Metrics](https://app.logz.io/#/dashboard/grafana/).
+Give your metrics some time to get from your system to ours, and then open [Logz.io Metrics](https://app.logz.io/#/dashboard/metrics/).
 
 Your metrics should appear in the preconfigured dashboard in your Metrics account. Use the Synthetic Monitoring Dashboard to monitor your website performance and availability via Logz.io.
 

--- a/_source/logzio_collections/_metrics-sources/azure-diagnostic-metrics.md
+++ b/_source/logzio_collections/_metrics-sources/azure-diagnostic-metrics.md
@@ -137,7 +137,7 @@ Include the following details in your message:
 
 ##### Check Logz.io for your metrics
 
-Give your data some time to get from your system to ours, and then open your [Logz.io Metrics account](https://app.logz.io/#/dashboard/grafana?).
+Give your data some time to get from your system to ours, and then open your [Logz.io Metrics account](https://app.logz.io/#/dashboard/metrics?).
 
 
 

--- a/_source/logzio_collections/_metrics-sources/jmx.md
+++ b/_source/logzio_collections/_metrics-sources/jmx.md
@@ -226,7 +226,7 @@ docker run -v $(pwd)/config.conf:/application.conf logzio/jmx2logzio
 
 ##### Check Logz.io for your metrics
 
-Give your metrics some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/#/dashboard/grafana/).
+Give your metrics some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/#/dashboard/metrics/).
 
 </div>
 

--- a/_source/logzio_collections/_metrics-sources/kubernetes.md
+++ b/_source/logzio_collections/_metrics-sources/kubernetes.md
@@ -57,7 +57,7 @@ bash <(curl -s https://raw.githubusercontent.com/logzio/logzio-helm/master/quick
 ##### Check Logz.io for your metrics
 
 Give your metrics some time to get from your system to ours,
-and then open [Logz.io](https://app.logz.io/#/dashboard/grafana/).
+and then open [Logz.io](https://app.logz.io/#/dashboard/metrics/).
 
 </div>
 
@@ -180,7 +180,7 @@ kubectl --namespace=kube-system create -f https://raw.githubusercontent.com/logz
 ##### Check Logz.io for your metrics
 
 Give your metrics some time to get from your system to ours,
-and then open [Logz.io](https://app.logz.io/#/dashboard/grafana/).
+and then open [Logz.io](https://app.logz.io/#/dashboard/metrics/).
 
 </div>
 

--- a/_source/logzio_collections/_metrics-sources/redis.md
+++ b/_source/logzio_collections/_metrics-sources/redis.md
@@ -103,6 +103,6 @@ Start or restart Metricbeat for the changes to take effect.
 
 ##### Check Logz.io for your metrics
 
-Give your metrics some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/#/dashboard/grafana/).
+Give your metrics some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/#/dashboard/metrics/).
 
 </div>

--- a/_source/logzio_collections/_prometheus-sources/go-custom-metrics.md
+++ b/_source/logzio_collections/_prometheus-sources/go-custom-metrics.md
@@ -211,6 +211,6 @@ _ = metric.Must(meter).NewInt64ValueObserver("valueobserver", observerCallback,
 <!-- See full [example](link2github) -->
 
 ##### Check Logz.io for your metrics
-Give your data some time to get from your system to ours, then log in to your Logz.io Metrics account, and open [the Logz.io Metrics tab](https://app.logz.io/#/dashboard/grafana/).
+Give your data some time to get from your system to ours, then log in to your Logz.io Metrics account, and open [the Logz.io Metrics tab](https://app.logz.io/#/dashboard/metrics/).
 
 </div>

--- a/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
+++ b/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
@@ -61,7 +61,7 @@ For the list of options, see the parameters below the code block.👇
 
 
 ##### Check Logz.io for your metrics
-Give your data some time to get from your system to ours, then log in to your Logz.io Metrics account, and open [the Logz.io Metrics tab](https://app.logz.io/#/dashboard/grafana/).
+Give your data some time to get from your system to ours, then log in to your Logz.io Metrics account, and open [the Logz.io Metrics tab](https://app.logz.io/#/dashboard/metrics/).
 
 
 </div>

--- a/_source/logzio_collections/_prometheus-sources/python-custom-prometheus.md
+++ b/_source/logzio_collections/_prometheus-sources/python-custom-prometheus.md
@@ -208,6 +208,6 @@ meter.register_valueobserver(
 ```
 
 ##### Check Logz.io for your metrics
-Give your data some time to get from your system to ours, then log in to your Logz.io Metrics account, and open [the Logz.io Metrics tab](https://app.logz.io/#/dashboard/grafana/).
+Give your data some time to get from your system to ours, then log in to your Logz.io Metrics account, and open [the Logz.io Metrics tab](https://app.logz.io/#/dashboard/metrics/).
 
 </div>

--- a/_source/user-guide/infrastructure-monitoring/configure-metrics-drilldowns.md
+++ b/_source/user-guide/infrastructure-monitoring/configure-metrics-drilldowns.md
@@ -20,7 +20,7 @@ The Metrics interface variables are indicated with a `$`.
 #### Add dashboard variables {#set-up-dashboard-variables}
 
 **Before you begin, you'll need**:
-[Metrics](https://app.logz.io/#/dashboard/grafana/) in your Logz.io metrics account.
+[Metrics](https://app.logz.io/#/dashboard/metrics/) in your Logz.io metrics account.
 
 <div class="tasklist">
 

--- a/_source/user-guide/infrastructure-monitoring/getting-started.md
+++ b/_source/user-guide/infrastructure-monitoring/getting-started.md
@@ -28,7 +28,7 @@ This quick tour will help you get started with your new infrastructure monitorin
 <div class="tasklist">
 
 ##### Log into your Metrics account
-Your Infrastucture Monitoring account complements your logging ELK stack. To reach it, log into your Logz.io Operations workspace and select the [Metrics tab](https://app.logz.io/#/dashboard/grafana/).
+Your Infrastucture Monitoring account complements your logging ELK stack. To reach it, log into your Logz.io Operations workspace and select the [Metrics tab](https://app.logz.io/#/dashboard/metrics/).
 
 Don't see it? By default, your Metrics account can only be accessed from your main account. If you don't see the Metrics tab, the account doesn't have permissions to it. [Learn how to grant sub accounts permissions to Metrics]({{site.baseurl}}/user-guide/accounts/manage-the-infrastructure-monitoring-account.html).
 

--- a/_source/user-guide/integrations/resolved-metrics-alerts.md
+++ b/_source/user-guide/integrations/resolved-metrics-alerts.md
@@ -72,5 +72,5 @@ The following fields are sent to Opsgenie when an Opsgenie alert is triggered:
 	"Account": "Account Name" ,
 	"alert_event_samples": "Sample 1 event out of 1"
 },  
-"alert_view_link": "https://app.logz.io/#/dashboard/grafana/d/..."
+"alert_view_link": "https://app.logz.io/#/dashboard/metrics/d/..."
 ```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "grafana",
     "cloud siem",
     "Jaeger",
-    "distributed tracing"
+    "distributed tracing",
+    "metrics",
+    "Prometheus"
   ],
   "author": [
     "Shalom Boroda",


### PR DESCRIPTION
# What changed
All links to Metrics/Infrastructure Monitoring tab in product are now: https://app.logz.io/#/dashboard/metrics
References to Grafana Gateway API

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
