### PR TITLE
Fix docker-compose error

### DIFF
--- a/shipping-config-samples/docker-compose.yaml
+++ b/shipping-config-samples/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     container_name: otel-logzio
     command: ["--config=/etc/otel-collector-config.yml"]
     volumes:
-      - config.yaml:/etc/otel-collector-config.yml
+      - ./config.yaml:/etc/otel-collector-config.yml
     ports:
       - "1888:1888"   # pprof extension
       - "8888:8888"   # Prometheus metrics exposed by the collector


### PR DESCRIPTION
Without the `./` prefix to the config.yaml file, the following error is thrown by docker-compose:
`Named volume "config.yaml:/etc/otel-collector-config.yml:rw" is used in service "otel-collector" but no declaration was found in the volumes section.`

This change fixes it

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
