### PR TITLE
DOC-8:  which regions support Prometheus metrics

### DIFF
--- a/_source/user-guide/regions/account-region.md
+++ b/_source/user-guide/regions/account-region.md
@@ -48,6 +48,15 @@ Your listener host and API host will always be in the same region as your accoun
 |Europe (London)|AWS|app-uk.logz.io|listener-uk.logz.io|api-uk.logz.io|uk|eu-west-2|
 |West US 2 (Washington)|Azure|app-wa.logz.io|listener-wa.logz.io|api-wa.logz.io|wa|westus2|
 
+## Supported regions for Prometheus metrics
+
+Prometheus Metrics are currently in roll-out. Supported regions include US East, EU Central, and EU West. Your listener host and API host will always be in the same region as your Prometheus metrics account.
+
+| Region | Cloud | Logz.io account host | Listener host | API host | Region code | Region slug |
+|---|---|---|
+|US East (Northern Virginia)|AWS|app.logz.io|listener.logz.io|api.logz.io| | us-east-1|	 
+|Europe (Frankfurt)|AWS|app-eu.logz.io|listener-eu.logz.io|api-eu.logz.io|eu|eu-central-1|
+|Europe (London)|AWS|app-uk.logz.io|listener-uk.logz.io|api-uk.logz.io|uk|eu-west-2|
 
 
 


### PR DESCRIPTION
# What changed

https://deploy-preview-1043--logz-docs.netlify.app/user-guide/accounts/account-region.html#supported-regions-for-prometheus-metrics

https://logzio.atlassian.net/browse/DOC-8

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
