### PR TITLE
Limit audience-log mgmnt>insights> exceptions Pro+

### DIFF
--- a/_source/user-guide/kibana/exceptions-in-discover.md
+++ b/_source/user-guide/kibana/exceptions-in-discover.md
@@ -3,7 +3,7 @@ layout: article
 title: Exceptions
 permalink: /user-guide/insights/exceptions/
 flags:
-  logzio-plan: community
+  logzio-plan: pro
 tags:
   - insights
 contributors:


### PR DESCRIPTION
# What changed
https://deploy-preview-1047--logz-docs.netlify.app//user-guide/insights/exceptions/

per this slack thread: https://logzio.slack.com/archives/C099PQYLC/p1618238627157600

> Is the Exceptions tab in Kibana available to community customers? A community customer has reached out with a screenshot of the tab saying "Upgrade plan" but our documentation says this is available to Enterprise, Pro, and Community.


/user-guide/insights/exceptions/

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
