### PR TITLE
DOC-70 SetUrl param & DOC-141 NXLog sample outdated

### DIFF
--- a/_source/logzio_collections/_log-sources/go.md
+++ b/_source/logzio_collections/_log-sources/go.md
@@ -75,7 +75,7 @@ func main() {
 | Parameter | Description | Required/Default |
 |---|---|---|
 | token | {% include log-shipping/log-shipping-token.md %}  {% include log-shipping/log-shipping-token.html %} | Required |
-| SetUrl | Listener URL and port.    {% include log-shipping/listener-var.html %}  | `https://listener.logz.io:8071` |
+| SetUrl | Listener URL and port.    {% include log-shipping/listener-var.html %}  |Required (default:  `https://listener.logz.io:8071`) |
 | SetDebug | Debug flag. | `false` |
 | SetDrainDuration  | Time to wait between log draining attempts. | `5 * time.Second` |
 | SetTempDirectory | Filepath where the logs are buffered. | -- |

--- a/_source/logzio_collections/_log-sources/json-uploads.md
+++ b/_source/logzio_collections/_log-sources/json-uploads.md
@@ -166,6 +166,9 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 
 </div>
 
+<!-- 21 April 2021 Removing NXLog scode sample: needs rewrite -->
+
+<!--  temporary deprecation starts here --.
 
 ### Code sample: NXLog
 
@@ -197,7 +200,7 @@ LogLevel INFO
 </Route>
 ```
 
-
+.-- temporary deprecation of NXLog sample ends here 21 April 2021 -->
 
 <!-- info-box-start:info -->
 To configure NXLog for log shipping, see [Ship Windows logs (NXLog)]({{site.baseurl}}/shipping/log-sources/windows.html).


### PR DESCRIPTION
# What changed
DOC-70: setURL is required. 
https://deploy-preview-1056--logz-docs.netlify.app/shipping/log-sources/go.html#parameters

DOC-141: deprecate NXLog code sample.  It is outdated and needs rewrite. 
https://deploy-preview-1056--logz-docs.netlify.app/shipping/log-sources/json-uploads.html

_source/logzio_collections/_log-sources/go.md

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
