### PR TITLE
DOC-160: replace dashboard/data-sources

### DIFF
--- a/_source/_includes/log-shipping/filebeat-wizard.html
+++ b/_source/_includes/log-shipping/filebeat-wizard.html
@@ -1,1 +1,1 @@
-Log into your Logz.io account, and go to the [Filebeat log shipping page](https://app.logz.io/#/dashboard/data-sources/Filebeat) to use the dedicated Logz.io Filebeat configuration wizard. It's the simplest way to configure Filebeat for your use case.
+Log into your Logz.io account, and go to the [Filebeat log shipping page](https://app.logz.io/#/dashboard/send-your-data/log-sources/Filebeat) to use the dedicated Logz.io Filebeat configuration wizard. It's the simplest way to configure Filebeat for your use case.

--- a/_source/_includes/log-shipping/filebeat-wizard.html
+++ b/_source/_includes/log-shipping/filebeat-wizard.html
@@ -1,1 +1,1 @@
-Log into your Logz.io account, and go to the [Filebeat log shipping page](https://app.logz.io/#/dashboard/send-your-data/log-sources/Filebeat) to use the dedicated Logz.io Filebeat configuration wizard. It's the simplest way to configure Filebeat for your use case.
+Log into your Logz.io account, and go to the [Filebeat log shipping page](https://app.logz.io/#/dashboard/send-your-data/log-sources/filebeat) to use the dedicated Logz.io Filebeat configuration wizard. It's the simplest way to configure Filebeat for your use case.

--- a/_source/_includes/log-shipping/s3-bucket.md
+++ b/_source/_includes/log-shipping/s3-bucket.md
@@ -3,4 +3,4 @@ destination bucket to which {{include.service}} writes its logs.
 
 It is based on {{include.service}}'s naming convention and path structure.
 
-If you're looking to ship {{include.service}} logs from a different bucket, please use the [S3 Bucket shipping](https://app.logz.io/#/dashboard/send-your-data/log-sources/S3-Bucket) method instead.
+If you're looking to ship {{include.service}} logs from a different bucket, please use the [S3 Bucket shipping](https://app.logz.io/#/dashboard/send-your-data/log-sources/s3-bucket) method instead.

--- a/_source/_includes/log-shipping/s3-bucket.md
+++ b/_source/_includes/log-shipping/s3-bucket.md
@@ -3,4 +3,4 @@ destination bucket to which {{include.service}} writes its logs.
 
 It is based on {{include.service}}'s naming convention and path structure.
 
-If you're looking to ship {{include.service}} logs from a different bucket, please use the [S3 Bucket shipping](https://app.logz.io/#/dashboard/data-sources/S3-Bucket) method instead.
+If you're looking to ship {{include.service}} logs from a different bucket, please use the [S3 Bucket shipping](https://app.logz.io/#/dashboard/send-your-data/log-sources/S3-Bucket) method instead.

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -4,7 +4,7 @@ logo:
   logofile: aws.svg
   orientation: vertical
 data-source: AWS cost and usage report
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/AWS-costandusagereport
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/aws-cost-and-usage-report
 templates: ["lambda-cloudwatch"]
 open-source:
   - title: AWS Cost and Usage Lambda

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -4,7 +4,7 @@ logo:
   logofile: aws.svg
   orientation: vertical
 data-source: AWS cost and usage report
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/AWS-costandusagereport
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/AWS-costandusagereport
 templates: ["lambda-cloudwatch"]
 open-source:
   - title: AWS Cost and Usage Lambda

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -5,7 +5,7 @@ logo:
   orientation: vertical
 data-source: CloudWatch
 templates: ["lambda-cloudwatch", "cloudformation"]
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/CloudWatch
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/cloudWatch
 open-source:
   - title: CloudWatch Lambda Log Shipper
     github-repo: logzio_aws_serverless/tree/master/python3/cloudwatch

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -5,7 +5,7 @@ logo:
   orientation: vertical
 data-source: CloudWatch
 templates: ["lambda-cloudwatch", "cloudformation"]
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/cloudWatch
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/cloudwatch
 open-source:
   - title: CloudWatch Lambda Log Shipper
     github-repo: logzio_aws_serverless/tree/master/python3/cloudwatch

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -5,7 +5,7 @@ logo:
   orientation: vertical
 data-source: CloudWatch
 templates: ["lambda-cloudwatch", "cloudformation"]
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/CloudWatch
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/CloudWatch
 open-source:
   - title: CloudWatch Lambda Log Shipper
     github-repo: logzio_aws_serverless/tree/master/python3/cloudwatch

--- a/_source/logzio_collections/_log-sources/curl.md
+++ b/_source/logzio_collections/_log-sources/curl.md
@@ -6,7 +6,7 @@ logo:
 data-source: cURL file upload
 shipping-tags:
   - log-shipper
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/File-UploadcURL
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/curl
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/curl.md
+++ b/_source/logzio_collections/_log-sources/curl.md
@@ -6,7 +6,7 @@ logo:
 data-source: cURL file upload
 shipping-tags:
   - log-shipper
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/File-UploadcURL
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/File-UploadcURL
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/_source/logzio_collections/_log-sources/docker.md
+++ b/_source/logzio_collections/_log-sources/docker.md
@@ -9,7 +9,7 @@ open-source:
     github-repo: docker-collector-logs
   - title: Logz.io Docker Logging Plugin
     github-repo: docker-logging-plugin
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/Docker-Logging
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/docker
 contributors:
   - mirii1994
   - shalper

--- a/_source/logzio_collections/_log-sources/docker.md
+++ b/_source/logzio_collections/_log-sources/docker.md
@@ -9,7 +9,7 @@ open-source:
     github-repo: docker-collector-logs
   - title: Logz.io Docker Logging Plugin
     github-repo: docker-logging-plugin
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Docker-Logging
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/Docker-Logging
 contributors:
   - mirii1994
   - shalper

--- a/_source/logzio_collections/_log-sources/elastic-load-balancing.md
+++ b/_source/logzio_collections/_log-sources/elastic-load-balancing.md
@@ -5,7 +5,7 @@ logo:
   orientation: vertical
 data-source: Elastic Load Balancing
 templates: ["s3-fetcher"]
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/ELB
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/elastic-load-balancing
 contributors:
   - idohalevi
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/elastic-load-balancing.md
+++ b/_source/logzio_collections/_log-sources/elastic-load-balancing.md
@@ -5,7 +5,7 @@ logo:
   orientation: vertical
 data-source: Elastic Load Balancing
 templates: ["s3-fetcher"]
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/ELB
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/ELB
 contributors:
   - idohalevi
   - imnotashrimp
@@ -41,7 +41,7 @@ For help with setting this up, see these docs from AWS:
 
 ##### Add a new S3 bucket using the dedicated Logz.io configuration wizard
 
-Log into the app to use the dedicated Logz.io [configuration wizard](https://app.logz.io/#/dashboard/data-sources/ELB) and add a new S3 bucket.
+Log into the app to use the dedicated Logz.io [configuration wizard](https://app.logz.io/#/dashboard/send-your-data/log-sources/ELB) and add a new S3 bucket.
 
 
 <!-- logzio-inject:aws:elb -->

--- a/_source/logzio_collections/_log-sources/filebeat.md
+++ b/_source/logzio_collections/_log-sources/filebeat.md
@@ -9,7 +9,7 @@ shipping-tags:
   - filebeat
   - intro to filebeat
 description: Filebeat is often the easiest way to get logs from your system to Logz.io. Logz.io has a dedicated configuration wizard to make it simple to configure Filebeat. If you already have Filebeat and you want to add new sources, check out our other shipping instructions to copy&paste just the relevant changes from our code examples.
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Filebeat
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/Filebeat
 contributors:
   - imnotashrimp
   - amosd92

--- a/_source/logzio_collections/_log-sources/filebeat.md
+++ b/_source/logzio_collections/_log-sources/filebeat.md
@@ -9,7 +9,7 @@ shipping-tags:
   - filebeat
   - intro to filebeat
 description: Filebeat is often the easiest way to get logs from your system to Logz.io. Logz.io has a dedicated configuration wizard to make it simple to configure Filebeat. If you already have Filebeat and you want to add new sources, check out our other shipping instructions to copy&paste just the relevant changes from our code examples.
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/Filebeat
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/filebeat
 contributors:
   - imnotashrimp
   - amosd92

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -8,7 +8,7 @@ open-source:
     github-repo: logzio_aws_serverless/tree/master/python3/kinesis
 data-source: Kinesis
 templates: ["lambda-kinesis", "cloudformation"]
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Kinesis
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/Kinesis
 contributors:
   - idohalevi
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -8,7 +8,7 @@ open-source:
     github-repo: logzio_aws_serverless/tree/master/python3/kinesis
 data-source: Kinesis
 templates: ["lambda-kinesis", "cloudformation"]
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/Kinesis
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/kinesis
 contributors:
   - idohalevi
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/s3-access.md
+++ b/_source/logzio_collections/_log-sources/s3-access.md
@@ -5,7 +5,7 @@ logo:
   orientation: vertical
 data-source: S3 access logs
 templates: ["s3-fetcher"]
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/S3Access
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/S3Access
 contributors:
   - idohalevi
   - imnotashrimp
@@ -34,7 +34,7 @@ For help with this, see [Amazon S3 Server Access Logging](https://docs.aws.amazo
 
 ##### Add a new S3 bucket using the dedicated Logz.io configuration wizard
 
-Log into the app to use the dedicated Logz.io [configuration wizard](https://app.logz.io/#/dashboard/data-sources/S3-Access) and add a new S3 bucket.
+Log into the app to use the dedicated Logz.io [configuration wizard](https://app.logz.io/#/dashboard/send-your-data/log-sources/S3-Access) and add a new S3 bucket.
 
 
 <!-- logzio-inject:aws:s3-access -->

--- a/_source/logzio_collections/_log-sources/s3-access.md
+++ b/_source/logzio_collections/_log-sources/s3-access.md
@@ -5,7 +5,7 @@ logo:
   orientation: vertical
 data-source: S3 access logs
 templates: ["s3-fetcher"]
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/S3Access
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/s3-access
 contributors:
   - idohalevi
   - imnotashrimp

--- a/_source/logzio_collections/_log-sources/vpc.md
+++ b/_source/logzio_collections/_log-sources/vpc.md
@@ -5,7 +5,7 @@ logo:
   orientation: vertical
 data-source: VPC
 templates: ["s3-fetcher"]
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/VPC
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/VPC
 contributors:
   - idohalevi
   - imnotashrimp
@@ -32,7 +32,7 @@ For help with this, see [Publishing Flow Logs to Amazon S3](https://docs.aws.ama
 
 ##### Add a new S3 bucket using the dedicated Logz.io configuration wizard
 
-Log into the app to use the dedicated Logz.io [configuration wizard](https://app.logz.io/#/dashboard/data-sources/vpc) and add a new S3 bucket.
+Log into the app to use the dedicated Logz.io [configuration wizard](https://app.logz.io/#/dashboard/send-your-data/log-sources/vpc) and add a new S3 bucket.
 
 
 <!-- logzio-inject:aws:vpc-flow -->

--- a/_source/logzio_collections/_log-sources/vpc.md
+++ b/_source/logzio_collections/_log-sources/vpc.md
@@ -5,7 +5,7 @@ logo:
   orientation: vertical
 data-source: VPC
 templates: ["s3-fetcher"]
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/VPC
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/vpc
 contributors:
   - idohalevi
   - imnotashrimp

--- a/_source/logzio_collections/_security-sources/cloudtrail.md
+++ b/_source/logzio_collections/_security-sources/cloudtrail.md
@@ -39,7 +39,7 @@ For help with setting up a new trail, see [Overview for Creating a Trail](https:
 
 <!-- logzio-inject:aws:cloudtrail -->
 
-To use the S3 fetcher, log into your Logz.io account, and go to the [CloudTrail log shipping page](https://app.logz.io/#/dashboard/send-your-data/log-sources/cloudtrail).
+To use the S3 fetcher, log into your Logz.io account, and go to the [CloudTrail log shipping page](https://app.logz.io/#/dashboard/send-your-data/security-sources/cloudtrail).
 
 1. Click **+ Add a bucket**
 2. Select your preferred method of authentication - an IAM role or access keys.

--- a/_source/logzio_collections/_security-sources/cloudtrail.md
+++ b/_source/logzio_collections/_security-sources/cloudtrail.md
@@ -4,7 +4,7 @@ logo:
   logofile: aws-cloudtrail.svg
   orientation: vertical
 data-source: CloudTrail
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/CloudTrail
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/security-sources/CloudTrail
 templates: ["s3-fetcher"]
 contributors:
   - idohalevi
@@ -39,7 +39,7 @@ For help with setting up a new trail, see [Overview for Creating a Trail](https:
 
 <!-- logzio-inject:aws:cloudtrail -->
 
-To use the S3 fetcher, log into your Logz.io account, and go to the [CloudTrail log shipping page](https://app.logz.io/#/dashboard/data-sources/cloudtrail).
+To use the S3 fetcher, log into your Logz.io account, and go to the [CloudTrail log shipping page](https://app.logz.io/#/dashboard/send-your-data/log-sources/cloudtrail).
 
 1. Click **+ Add a bucket**
 2. Select your preferred method of authentication - an IAM role or access keys.

--- a/_source/logzio_collections/_security-sources/cloudtrail.md
+++ b/_source/logzio_collections/_security-sources/cloudtrail.md
@@ -4,7 +4,7 @@ logo:
   logofile: aws-cloudtrail.svg
   orientation: vertical
 data-source: CloudTrail
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/security-sources/CloudTrail
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/security-sources/cloudtrail
 templates: ["s3-fetcher"]
 contributors:
   - idohalevi

--- a/_source/user-guide/give-aws-access-with-iam-roles.md
+++ b/_source/user-guide/give-aws-access-with-iam-roles.md
@@ -123,7 +123,7 @@ your company might have.
 Before you migrate,
 you'll need to know where the existing IAM role is used in Logz.io.
 This is because you'll need to replace any
-[S3 fetcher](https://app.logz.io/#/dashboard/data-sources/S3-Bucket)
+[S3 fetcher](https://app.logz.io/#/dashboard/send-your-data/log-sources/S3-Bucket)
 and
 [Archive & restore](https://app.logz.io/#/dashboard/tools/archive-and-restore)
 configurations that use the existing role.
@@ -162,7 +162,7 @@ make sure you know everywhere your existing IAM role is used in Logz.io.
 ##### Delete an S3 configuration from Logz.io
 
 Choose an
-[S3 fetcher](https://app.logz.io/#/dashboard/data-sources/S3-Bucket)
+[S3 fetcher](https://app.logz.io/#/dashboard/send-your-data/log-sources/S3-Bucket)
 or
 [Archive & restore](https://app.logz.io/#/dashboard/tools/archive-and-restore)
 configuration to replace.
@@ -252,7 +252,7 @@ where you need to fetch or archive logs in an S3 bucket.
 ##### Delete an S3 configuration from Logz.io
 
 Choose an
-[S3 fetcher](https://app.logz.io/#/dashboard/data-sources/S3-Bucket)
+[S3 fetcher](https://app.logz.io/#/dashboard/send-your-data/log-sources/S3-Bucket)
 or
 [Archive & restore](https://app.logz.io/#/dashboard/tools/archive-and-restore)
 configuration to replace.

--- a/_source/user-guide/give-aws-access-with-iam-roles.md
+++ b/_source/user-guide/give-aws-access-with-iam-roles.md
@@ -123,7 +123,7 @@ your company might have.
 Before you migrate,
 you'll need to know where the existing IAM role is used in Logz.io.
 This is because you'll need to replace any
-[S3 fetcher](https://app.logz.io/#/dashboard/send-your-data/log-sources/S3-Bucket)
+[S3 fetcher](https://app.logz.io/#/dashboard/send-your-data/log-sources/s3-bucket)
 and
 [Archive & restore](https://app.logz.io/#/dashboard/tools/archive-and-restore)
 configurations that use the existing role.
@@ -162,7 +162,7 @@ make sure you know everywhere your existing IAM role is used in Logz.io.
 ##### Delete an S3 configuration from Logz.io
 
 Choose an
-[S3 fetcher](https://app.logz.io/#/dashboard/send-your-data/log-sources/S3-Bucket)
+[S3 fetcher](https://app.logz.io/#/dashboard/send-your-data/log-sources/s3-bucket)
 or
 [Archive & restore](https://app.logz.io/#/dashboard/tools/archive-and-restore)
 configuration to replace.
@@ -252,7 +252,7 @@ where you need to fetch or archive logs in an S3 bucket.
 ##### Delete an S3 configuration from Logz.io
 
 Choose an
-[S3 fetcher](https://app.logz.io/#/dashboard/send-your-data/log-sources/S3-Bucket)
+[S3 fetcher](https://app.logz.io/#/dashboard/send-your-data/log-sources/s3-bucket)
 or
 [Archive & restore](https://app.logz.io/#/dashboard/tools/archive-and-restore)
 configuration to replace.

--- a/_source/user-guide/log-shipping/log-shipping-troubleshooting.md
+++ b/_source/user-guide/log-shipping/log-shipping-troubleshooting.md
@@ -107,7 +107,7 @@ in the [account settings](https://app.logz.io/#/dashboard/settings/general) page
 Compare your account token
 with the token you're sending to Logz.io with your logs.
 Review the instructions for your
-[log shipping method](https://app.logz.io/#/dashboard/data-sources/)
+[log shipping method](https://app.logz.io/#/dashboard/send-your-data/log-sources/)
 if you're not sure where to find the token you're sending with your logs.
 
 In most cases, the token is stored in a configuration file

--- a/_source/user-guide/tokens/log-shipping-tokens.md
+++ b/_source/user-guide/tokens/log-shipping-tokens.md
@@ -45,7 +45,7 @@ Log shipping tokens are used in the shipping configuration to send data to the r
 
 To view your default token, go to [**<i class="li li-gear"></i> > Settings > General**](https://app.logz.io/#/dashboard/settings/general). You can click the token to copy it.
 
-The default token is auto-populated in the [configuration instructions](https://app.logz.io/#/dashboard/data-sources/) in the app. You can replace the token with another enabled token.
+The default token is auto-populated in the [configuration instructions](https://app.logz.io/#/dashboard/send-your-data/log-sources/) in the app. You can replace the token with another enabled token.
 
 If you prefer to view the configuration instructions outside the app, note that you will need to replace the the `<<SHIPPING-TOKEN>>` parameter with one of your enabled log shipping tokens. See more in the [log shipping guide]({{site.baseurl}}/shipping/).
 

--- a/no-publish/archive/azure-diagnostic-metrics.md
+++ b/no-publish/archive/azure-diagnostic-metrics.md
@@ -7,7 +7,7 @@ logo:
   logofile: azure-monitor.svg
   orientation: vertical
 data-source: Azure diagnostic metrics
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/Diagnostics-settings
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/diagnostics-settings
 tags:
   - azure
   - event-hubs

--- a/no-publish/archive/azure-diagnostic-metrics.md
+++ b/no-publish/archive/azure-diagnostic-metrics.md
@@ -7,7 +7,7 @@ logo:
   logofile: azure-monitor.svg
   orientation: vertical
 data-source: Azure diagnostic metrics
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/Diagnostics-settings
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/Diagnostics-settings
 tags:
   - azure
   - event-hubs

--- a/no-publish/cloud-foundry.md
+++ b/no-publish/cloud-foundry.md
@@ -6,7 +6,7 @@ logo:
   orientation: vertical
 shipping-summary:
   data-source: Amazon RDS (MySQL)
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/RDS
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/RDS
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/no-publish/rds-mysql.md
+++ b/no-publish/rds-mysql.md
@@ -6,7 +6,7 @@ logo:
   orientation: vertical
 shipping-summary:
   data-source: Amazon RDS (MySQL)
-logzio-app-url: https://app.logz.io/#/dashboard/data-sources/RDS
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/RDS
 contributors:
   - imnotashrimp
 shipping-tags:

--- a/no-publish/rds-mysql.md
+++ b/no-publish/rds-mysql.md
@@ -6,7 +6,7 @@ logo:
   orientation: vertical
 shipping-summary:
   data-source: Amazon RDS (MySQL)
-logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/RDS
+logzio-app-url: https://app.logz.io/#/dashboard/send-your-data/log-sources/rds
 contributors:
   - imnotashrimp
 shipping-tags:


### PR DESCRIPTION
# What changed
https://logzio.atlassian.net/browse/DOC-160
Across 18 documents: 

- The solution is replacing "dashboard/data-sources" with "dashboard/send-your-data/log-sources" in the following documents: https://github.com/logzio/logz-docs/search?q=dashboard%2Fdata-sources

- SIEM docs which contain the old links should be replaced to: “dashboard/send-your-data/security-sources”

- Raul corrected case-sensitive issues for these links, as well. 

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
