### PR TITLE
WIP: Send Kubernetes metrics over Helm with the OpenTelemetry Collector

### DIFF
--- a/_source/_includes/p8s-shipping/otel-metrics-k8s-helm.md
+++ b/_source/_includes/p8s-shipping/otel-metrics-k8s-helm.md
@@ -1,0 +1,76 @@
+
+# Logzio-otel-k8s-metrics
+
+The Helm tool is used to manage packages of pre-configured Kubernetes resources that use Charts.
+logzio-otel-k8s-metrics allows you to ship metrics from your Kubernetes cluster with the OpenTelemetry collector.
+
+**Note:** This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) helm chart, it is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, that will be installed by default. To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
+
+### Prerequisites:
+* [Helm 3](https://helm.sh/docs/intro/install/) installed
+
+
+### Deployment:
+
+#### 1. Add the logzio-otel-k8s-metrics repo to your Helm repo list
+
+```shell
+helm repo add logzio-otel https://logzio.github.io/logzio-helm/opentelemtry/
+```
+
+#### 2. Deploy
+
+
+#### Deploy with standard configuration:  
+
+Replace the Logz-io `<<METRICS-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/general) of the metrics account you want to ship to.
+
+Replace `<<LISTENER-HOST>>` with your region’s listener host (for example, `https://listener.logz.io:8053`). For more information on finding your account’s region, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html).
+
+Replace `<<ENV-TAG>>` with the name for the environment's metrics, to easily identify the metrics for each environment.
+
+```
+helm install  \
+--set secrets.MetricsToken=<<METRICS-TOKEN>> \
+--set secrets.ListenerHost=<<LISTENER-HOST>> \
+--set secrets.p8s_logzio_name=<<ENV-TAG>> \
+logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics
+```
+
+#### 3. Check Logz.io for your metrics
+
+Give your metrics some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/).
+
+
+### Configuration
+
+You can use the following options to update your default parameter values: 
+
+* Specify parameters using the `--set key=value[,key=value]` argument to `helm install`
+
+* Edit the `values.yaml`
+
+* Overide default values with your own `my_values.yaml` and apply it in the `helm install` command. For exapmle:
+
+```
+helm install logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics -f my_values.yaml 
+```
+### Collected metrics
+
+The default set up uses the Prometheus receiver with the following scrape jobs:
+* Cadvisor: Scrapes container metrics
+* Kubernetes service endpoints: These job scrape metrics from the node exporters, Kube state metrics, from any other service for which the `prometheus.io/scrape: true` annotaion is set, and from services that expose Prometheus metrics at the `/metrics` endpoint.
+
+You can customize your configuration by editing the `config` section in the `values.yaml` file.
+
+### Uninstalling the Chart
+
+The uninstall command is used to remove all the Kubernetes components associated with the chart and deletes the release.  
+To uninstall the `logzio-otel-k8s-metrics` deployment:
+
+```shell
+helm uninstall logzio-otel-k8s-metrics
+```
+
+
+## Change log

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -6,7 +6,7 @@ logo:
 data-source: Kubernetes over Helm with OpenTelemetry
 open-source:
   - title: Logzio-otel-k8s-metrics
-    github-repo: https://github.com/logzio/logzio-helm/tree/master/charts/opentelemetry
+    github-repo: logzio-helm/tree/master/charts/opentelemetry
 templates: ["k8s-daemonset"]
 contributors:
   - yotamloe

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -58,7 +58,9 @@ helm install  \
 --set secrets.p8s_logzio_name=<<ENV-TAG>> \
 logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics
 ```
+
 ##### Check Logz.io for your metrics
+
 Give your data some time to get from your system to ours, then log in to your Logz.io Metrics account, and open [the Logz.io Metrics tab](https://app.logz.io/#/dashboard/metrics/).
 
 

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -5,8 +5,8 @@ logo:
   orientation: horizontal
 data-source: Kubernetes over Helm with OpenTelemetry
 open-source:
-  - title: logzio-helm-opentelemetry  #is this correct?
-    github-repo: logzio-otel-k8s-metrics  #is this correct? Should it be https://github.com/logzio/logzio-helm/tree/master/charts/opentelemetry
+  - title: Logzio-otel-k8s-metrics
+    github-repo: https://github.com/logzio/logzio-helm/tree/master/charts/opentelemetry
 templates: ["k8s-daemonset"]
 contributors:
   - yotamloe

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -12,7 +12,7 @@ contributors:
   - yotamloe
   - yberlinger
 shipping-tags:
-  - container  #is this tag correct? 
+  - container  
 ---
 
 

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -6,7 +6,7 @@ logo:
 data-source: Kubernetes over Helm with OpenTelemetry
 open-source:
   - title: Logzio-otel-k8s-metrics
-    github-repo: logzio-helm/charts/opentelemetry
+    github-repo: logzio-helm/tree/master/charts/opentelmetry
 templates: ["k8s-daemonset"]
 contributors:
   - yotamloe

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -1,3 +1,20 @@
+---
+title: Ship Kubernetes metrics over Helm with the OpenTelemetry Collector
+logo:
+  logofile: k8s-helm.svg
+  orientation: horizontal
+data-source: Kubernetes over Helm
+open-source:
+  - title: 
+    github-repo: 
+templates: ["docker"]
+contributors:
+  - yotamloe
+  - yberlinger
+shipping-tags:
+  - container
+---
+
 
 # Logzio-otel-k8s-metrics
 

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -23,8 +23,8 @@ shipping-tags:
 
 <!-- info-box-start:info -->
 This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) Helm chart. 
-It is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, which are installed by default. 
-To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
+It is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics), [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) and [prometheus-pushgateway](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-pushgateway)charts, which are installed by default. 
+To disable the dependency during installation, set `kubeStateMetrics.enabled`, `nodeExporter.enabled` or `pushGateway.enabled` to `false`.
 {:.info-box.note}
 <!-- info-box-end -->
 
@@ -32,10 +32,12 @@ To disable the dependency during installation, set `kubeStateMetrics.enabled` an
 
 <div class="tasklist">
   
-##### Add logzio-otel-k8s-metrics repo to your helm repo list
+##### Add logzio-helm repo to your helm repo list
 
-`helm repo add logzio-helm https://logzio.github.io/logzio-helm/opentelmetry`
-
+```shell
+helm repo add logzio-helm https://logzio.github.io/logzio-helm
+helm repo update
+```
 ##### Deploy the Helm chart
 
 To deploy the Helm chart, enter the relevant parameters for the placeholders and run the code. 
@@ -56,7 +58,7 @@ helm install  \
 --set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
 --set secrets.ListenerHost=<<LISTENER-HOST>> \
 --set secrets.p8s_logzio_name=<<ENV-TAG>> \
-logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics
+logzio-otel-k8s-metrics logzio-helm/logzio-otel-k8s-metrics
 ```
 
 ##### Check Logz.io for your metrics
@@ -83,7 +85,7 @@ You can use the following options to update the Helm chart parameters:
 ###### Example:
 
 ```
-helm install logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics -f my_values.yaml 
+helm install logzio-otel-k8s-metrics logzio-helm/logzio-otel-k8s-metrics -f my_values.yaml 
 ```
 
 ##### Customize the metrics collected by the Helm chart 

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -18,8 +18,6 @@ shipping-tags:
 
 ##  Overview
 
-You can use a Helm chart to ship Kubernetes logs to Logz.io via the OpenTelemetry collector.
-The Helm tool is used to manage packages of pre-configured Kubernetes resources that use charts.
 
 **logzio-otel-k8s-metrics** allows you to ship metrics from your Kubernetes cluster to Logz.io with the OpenTelemetry collector.
 
@@ -33,6 +31,10 @@ To disable the dependency during installation, set `kubeStateMetrics.enabled` an
 #### Standard configuration
 
 <div class="tasklist">
+  
+##### Add logzio-otel-k8s-metrics repo to your helm repo list
+
+`helm repo add logzio-helm https://logzio.github.io/logzio-helm/opentelmetry`
 
 ##### Deploy the Helm chart
 
@@ -56,10 +58,9 @@ helm install  \
 --set secrets.p8s_logzio_name=<<ENV-TAG>> \
 logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics
 ```
-
 ##### Check Logz.io for your metrics
+Give your data some time to get from your system to ours, then log in to your Logz.io Metrics account, and open [the Logz.io Metrics tab](https://app.logz.io/#/dashboard/metrics/).
 
-Give your metrics some time to get from your system to ours, then open [Logz.io](https://app.logz.io/).
 
 </div>
 

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -1,13 +1,13 @@
 ---
-title: Ship Kubernetes metrics over Helm with the OpenTelemetry Collector
+title: Send Kubernetes metrics with Helm and the OpenTelemetry Collector
 logo:
   logofile: k8s-helm.svg
   orientation: horizontal
-data-source: Kubernetes over Helm
+data-source: Kubernetes over Helm with OpenTelemetry
 open-source:
-  - title: 
-    github-repo: 
-templates: ["docker"]
+  - title: Kubernetes metrics with Helm and OpenTelemetry
+    github-repo: logzio-otel-k8s-metrics
+templates: ["k8s-daemonset"]
 contributors:
   - yotamloe
   - yberlinger
@@ -16,50 +16,52 @@ shipping-tags:
 ---
 
 
-# Logzio-otel-k8s-metrics
+##  Overview
+
+<!-- logzio-otel-k8s-metrics 
+This should be the repo url after we merge: https://github.com/logzio/logzio-helm/tree/master/charts/opentelmetry -->
+
+You can use a Helm chart to ship k8s logs to Logz.io via OpenTelemetry collector.
 
 The Helm tool is used to manage packages of pre-configured Kubernetes resources that use Charts.
-logzio-otel-k8s-metrics allows you to ship metrics from your Kubernetes cluster with the OpenTelemetry collector.
+logzio-otel-k8s-metrics allows you to ship metrics from your Kubernetes cluster to Logz.io with the OpenTelemetry collector.
 
-**Note:** This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) helm chart, it is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, that will be installed by default. To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
+<!-- info-box-start:info -->
+This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) helm chart, it is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, that will be installed by default. To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
+{:.info-box.note}
+<!-- info-box-end -->
 
-### Prerequisites:
-* [Helm 3](https://helm.sh/docs/intro/install/) installed
+#### Standard configuration
 
+<div class="tasklist">
 
-### Deployment:
+##### Deploy
 
-#### 1. Add the logzio-otel-k8s-metrics repo to your Helm repo list
+###### Parameter configuration
 
-```shell
-helm repo add logzio-otel https://logzio.github.io/logzio-helm/opentelemtry/
-```
+Replace the Logz-io `<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping) of the metrics account to which you want to send your data.
 
-#### 2. Deploy
-
-
-#### Deploy with standard configuration:  
-
-Replace the Logz-io `<<METRICS-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/general) of the metrics account you want to ship to.
 
 Replace `<<LISTENER-HOST>>` with your region’s listener host (for example, `https://listener.logz.io:8053`). For more information on finding your account’s region, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html).
 
 Replace `<<ENV-TAG>>` with the name for the environment's metrics, to easily identify the metrics for each environment.
 
+###### Deployment code
+
 ```
 helm install  \
---set secrets.MetricsToken=<<METRICS-TOKEN>> \
+--set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
 --set secrets.ListenerHost=<<LISTENER-HOST>> \
 --set secrets.p8s_logzio_name=<<ENV-TAG>> \
 logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics
 ```
 
-#### 3. Check Logz.io for your metrics
+##### Check Logz.io for your metrics
 
 Give your metrics some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/).
 
 
-### Configuration
+####  Customizing default parameters
 
 You can use the following options to update your default parameter values: 
 
@@ -67,27 +69,35 @@ You can use the following options to update your default parameter values:
 
 * Edit the `values.yaml`
 
-* Overide default values with your own `my_values.yaml` and apply it in the `helm install` command. For exapmle:
+* Overide default values with your own `my_values.yaml` and apply it in the `helm install` command. 
+
+###### Example:
 
 ```
 helm install logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics -f my_values.yaml 
 ```
-### Collected metrics
 
-The default set up uses the Prometheus receiver with the following scrape jobs:
+#### Customizing which metrics are collected  
+
+The default configuration uses the Prometheus receiver with the following scrape jobs:
+
 * Cadvisor: Scrapes container metrics
-* Kubernetes service endpoints: These job scrape metrics from the node exporters, Kube state metrics, from any other service for which the `prometheus.io/scrape: true` annotaion is set, and from services that expose Prometheus metrics at the `/metrics` endpoint.
+* Kubernetes service endpoints: These jobs scrape metrics from the node exporters, from Kube state metrics, from any other service for which the `prometheus.io/scrape: true` annotaion is set, and from services that expose Prometheus metrics at the `/metrics` endpoint.
+##### Customize the metrics collection
 
-You can customize your configuration by editing the `config` section in the `values.yaml` file.
+To customize your configuration, edit the `config` section in the `values.yaml` file.
 
-### Uninstalling the Chart
+#### Uninstalling the Chart
 
-The uninstall command is used to remove all the Kubernetes components associated with the chart and deletes the release.  
-To uninstall the `logzio-otel-k8s-metrics` deployment:
+The uninstall command is used to remove all the Kubernetes components associated with the chart and to delete the release.  
+
+##### To uninstall the `logzio-otel-k8s-metrics` deployment
+
+Use the following command:
 
 ```shell
 helm uninstall logzio-otel-k8s-metrics
 ```
+</div>
 
-
-## Change log
+### Change log

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -6,7 +6,7 @@ logo:
 data-source: Kubernetes over Helm with OpenTelemetry
 open-source:
   - title: Logzio-otel-k8s-metrics
-    github-repo: logzio-helm/tree/master/charts/opentelmetry
+    github-repo: logzio-helm/tree/master/charts/opentelemetry
 templates: ["k8s-daemonset"]
 contributors:
   - yotamloe

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -21,7 +21,7 @@ shipping-tags:
 <!-- logzio-otel-k8s-metrics 
 This should be the repo url after we merge: https://github.com/logzio/logzio-helm/tree/master/charts/opentelmetry -->
 
-You can use a Helm chart to ship Kubernetes logs to Logz.io via OpenTelemetry collector.
+You can use a Helm chart to ship Kubernetes logs to Logz.io via the OpenTelemetry collector.
 
 The Helm tool is used to manage packages of pre-configured Kubernetes resources that use Charts.
 

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -21,10 +21,11 @@ shipping-tags:
 <!-- logzio-otel-k8s-metrics 
 This should be the repo url after we merge: https://github.com/logzio/logzio-helm/tree/master/charts/opentelmetry -->
 
-You can use a Helm chart to ship k8s logs to Logz.io via OpenTelemetry collector.
+You can use a Helm chart to ship Kubernetes logs to Logz.io via OpenTelemetry collector.
 
 The Helm tool is used to manage packages of pre-configured Kubernetes resources that use Charts.
-logzio-otel-k8s-metrics allows you to ship metrics from your Kubernetes cluster to Logz.io with the OpenTelemetry collector.
+
+**logzio-otel-k8s-metrics** allows you to ship metrics from your Kubernetes cluster to Logz.io with the OpenTelemetry collector.
 
 <!-- info-box-start:info -->
 This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) helm chart, it is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, that will be installed by default. To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -5,25 +5,21 @@ logo:
   orientation: horizontal
 data-source: Kubernetes over Helm with OpenTelemetry
 open-source:
-  - title: Kubernetes metrics with Helm and OpenTelemetry
-    github-repo: logzio-otel-k8s-metrics
+  - title: logzio-helm-opentelemetry  #is this correct?
+    github-repo: logzio-otel-k8s-metrics  #is this correct? Should it be https://github.com/logzio/logzio-helm/tree/master/charts/opentelemetry
 templates: ["k8s-daemonset"]
 contributors:
   - yotamloe
   - yberlinger
 shipping-tags:
-  - container
+  - container  #is this tag correct? 
 ---
 
 
 ##  Overview
 
-<!-- logzio-otel-k8s-metrics 
-This should be the repo url after we merge: https://github.com/logzio/logzio-helm/tree/master/charts/opentelmetry -->
-
 You can use a Helm chart to ship Kubernetes logs to Logz.io via the OpenTelemetry collector.
-
-The Helm tool is used to manage packages of pre-configured Kubernetes resources that use Charts.
+The Helm tool is used to manage packages of pre-configured Kubernetes resources that use charts.
 
 **logzio-otel-k8s-metrics** allows you to ship metrics from your Kubernetes cluster to Logz.io with the OpenTelemetry collector.
 
@@ -108,5 +104,3 @@ To uninstall the `logzio-otel-k8s-metrics` deployment, use the following command
 helm uninstall logzio-otel-k8s-metrics
 ```
 
-
-### Change log

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -28,7 +28,9 @@ The Helm tool is used to manage packages of pre-configured Kubernetes resources 
 **logzio-otel-k8s-metrics** allows you to ship metrics from your Kubernetes cluster to Logz.io with the OpenTelemetry collector.
 
 <!-- info-box-start:info -->
-This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) helm chart, it is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, that will be installed by default. To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
+This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) Helm chart. 
+It is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, which are installed by default. 
+To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
 {:.info-box.note}
 <!-- info-box-end -->
 
@@ -38,9 +40,9 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 ##### Deploy
 
-Enter the relevant parameters for the placeholders and run the deployment code. 
+Enter the relevant parameters for the placeholders and run the code. 
 
-###### Parameter configuration
+###### Configure the parameters in the code
 
 Replace the Logz-io `<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping) of the metrics account to which you want to send your data.
 
@@ -49,7 +51,7 @@ Replace `<<LISTENER-HOST>>` with your region’s listener host (for example, `ht
 
 Replace `<<ENV-TAG>>` with the name for the environment's metrics, to easily identify the metrics for each environment.
 
-###### Deployment code
+###### Run the Helm deployment code
 
 ```
 helm install  \
@@ -61,12 +63,12 @@ logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics
 
 ##### Check Logz.io for your metrics
 
-Give your metrics some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/).
+Give your metrics some time to get from your system to ours, then open [Logz.io](https://app.logz.io/).
 
 
-####  Customizing default parameters
+####  Customizing Helm chart parameters
 
-You can use the following options to update your default parameter values: 
+You can use the following options to update the Helm chart parameters: 
 
 * Specify parameters using the `--set key=value[,key=value]` argument to `helm install`
 
@@ -80,7 +82,7 @@ You can use the following options to update your default parameter values:
 helm install logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics -f my_values.yaml 
 ```
 
-#### Customizing which metrics are collected  
+#### Customizing the metrics collected by the Helm chart 
 
 The default configuration uses the Prometheus receiver with the following scrape jobs:
 

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -38,9 +38,9 @@ To disable the dependency during installation, set `kubeStateMetrics.enabled` an
 
 <div class="tasklist">
 
-##### Deploy
+##### Deploy the Helm chart
 
-Enter the relevant parameters for the placeholders and run the code. 
+To deploy the Helm chart, enter the relevant parameters for the placeholders and run the code. 
 
 ###### Configure the parameters in the code
 
@@ -65,8 +65,13 @@ logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics
 
 Give your metrics some time to get from your system to ours, then open [Logz.io](https://app.logz.io/).
 
+</div>
 
 ####  Customizing Helm chart parameters
+
+<div class="tasklist">
+
+##### Configure customization options
 
 You can use the following options to update the Helm chart parameters: 
 
@@ -82,27 +87,26 @@ You can use the following options to update the Helm chart parameters:
 helm install logzio-otel-k8s-metrics logzio-otel/logzio-otel-k8s-metrics -f my_values.yaml 
 ```
 
-#### Customizing the metrics collected by the Helm chart 
+##### Customize the metrics collected by the Helm chart 
 
 The default configuration uses the Prometheus receiver with the following scrape jobs:
 
 * Cadvisor: Scrapes container metrics
 * Kubernetes service endpoints: These jobs scrape metrics from the node exporters, from Kube state metrics, from any other service for which the `prometheus.io/scrape: true` annotaion is set, and from services that expose Prometheus metrics at the `/metrics` endpoint.
-##### Customize the metrics collection
 
 To customize your configuration, edit the `config` section in the `values.yaml` file.
+
+</div>
 
 #### Uninstalling the Chart
 
 The uninstall command is used to remove all the Kubernetes components associated with the chart and to delete the release.  
 
-##### Uninstall the `logzio-otel-k8s-metrics` deployment
-
-Use the following command:
+To uninstall the `logzio-otel-k8s-metrics` deployment, use the following command:
 
 ```shell
 helm uninstall logzio-otel-k8s-metrics
 ```
-</div>
+
 
 ### Change log

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -37,6 +37,8 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 ##### Deploy
 
+Enter the relevant parameters for the placeholders and run the deployment code. 
+
 ###### Parameter configuration
 
 Replace the Logz-io `<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping) of the metrics account to which you want to send your data.
@@ -91,7 +93,7 @@ To customize your configuration, edit the `config` section in the `values.yaml` 
 
 The uninstall command is used to remove all the Kubernetes components associated with the chart and to delete the release.  
 
-##### To uninstall the `logzio-otel-k8s-metrics` deployment
+##### Uninstall the `logzio-otel-k8s-metrics` deployment
 
 Use the following command:
 

--- a/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
+++ b/_source/logzio_collections/_prometheus-sources/otel-metrics-k8s-helm.md
@@ -6,7 +6,7 @@ logo:
 data-source: Kubernetes over Helm with OpenTelemetry
 open-source:
   - title: Logzio-otel-k8s-metrics
-    github-repo: logzio-helm/tree/master/charts/opentelemetry
+    github-repo: logzio-helm/charts/opentelemetry
 templates: ["k8s-daemonset"]
 contributors:
   - yotamloe


### PR DESCRIPTION
### What changed

- New integration in the Metrics (Prometheus) tab appears here:  https://deploy-preview-1059--logz-docs.netlify.app/shipping/#prometheus-sources
-  New topic: https://deploy-preview-1059--logz-docs.netlify.app/shipping/prometheus-sources/otel-metrics-k8s-helm.html



New helm chart for Opentelemtry metrics for k8s 
This doc PR relates to the code PR https://github.com/logzio/logzio-helm/pull/34
1. Move topic from snippet directory to correct _metrics-sources folder so it appears in the Send Your Data (SYD) pages.
2. Add logo
3.  Needs logical title. Send Kubernetes metrics over Helm via OpenTelemetry
4. Missing the following metadata

```
data-source: Kubernetes over Helm ???
open-source: ???
  - title: ???
    github-repo: ???
templates: ["docker"]
```
   
Clarify: Where does this belong? :         https://github.com/logzio/logzio-helm/tree/master/charts/opentelemetry

AI: The ReadMe will need to be updated after this document is finalized.

