### PR TITLE
WIP - Prometheus port configuration

### DIFF
--- a/_source/_includes/general-shipping/replace-placeholders-prometheus.html
+++ b/_source/_includes/general-shipping/replace-placeholders-prometheus.html
@@ -1,5 +1,4 @@
 Replace the placeholders to match your specifics. (They are indicated by the double angle brackets `<< >>`):
 
 * {% include /p8s-shipping/replace-prometheus-token.html %}
-
-* {% include log-shipping/listener-var.html %}
+* {% include/p8s-shipping/replace-prometheus-listener.html %}

--- a/_source/_includes/p8s-shipping/replace-prometheus-listener.html
+++ b/_source/_includes/p8s-shipping/replace-prometheus-listener.html
@@ -1,0 +1,1 @@
+Replace `<<LISTENER-HOST>>` with the Logz.io Listener URL [for your region](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions), configured to use port **8052** for http traffic, or port **8053** for https traffic. For example, `listener.logz.io` if your account is hosted on AWS US East, or `listener-nl.logz.io` if hosted on Azure West Europe.

--- a/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
+++ b/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
@@ -46,7 +46,7 @@ For the list of options, see the parameters below the code block.👇
 
 ``` yaml
 [[outputs.http]]
-  url = "http://<<LISTENER-HOST>>:8052"
+  url = "http://<<LISTENER-HOST>>:8053"
   data_format = "prometheusremotewrite"
   [outputs.http.headers]
      Content-Type = "application/x-protobuf"

--- a/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
+++ b/_source/logzio_collections/_prometheus-sources/prometheus-telegraf-output.md
@@ -46,7 +46,7 @@ For the list of options, see the parameters below the code block.👇
 
 ``` yaml
 [[outputs.http]]
-  url = "http://<<LISTENER-HOST>>:8050"
+  url = "http://<<LISTENER-HOST>>:8052"
   data_format = "prometheusremotewrite"
   [outputs.http.headers]
      Content-Type = "application/x-protobuf"

--- a/_source/logzio_collections/_prometheus-sources/python-custom-prometheus.md
+++ b/_source/logzio_collections/_prometheus-sources/python-custom-prometheus.md
@@ -58,7 +58,7 @@ from opentelemetry.sdk.metrics import MeterProvider
 
 # configure the Logz.io listener endpoint and Prometheus metrics account token
 exporter = PrometheusRemoteWriteMetricsExporter(
-    endpoint="<<LISTENER-HOST>>",
+    endpoint="<<LISTENER-HOST>>:8053",
     headers={
         "Authorization": "Bearer <<PROMETHEUS-METRICS-SHIPPING-TOKEN>>",
     }

--- a/_source/logzio_collections/_prometheus-sources/python-custom-prometheus.md
+++ b/_source/logzio_collections/_prometheus-sources/python-custom-prometheus.md
@@ -36,6 +36,7 @@ Windows: `pip install python_snappy-0.5-cp36-cp36m-win_amd64.whl`
 ```
 pip install opentelemetry-exporter-prometheus-remote-write
 ```
+
 ##### Add instruments to your application
 
 Replace the placeholders in the `exporter` section code (indicated by the double angle brackets `<< >>`) to match your specifics.


### PR DESCRIPTION
# What changed
- Fixed H6 that displayed incorrectly in Python SYD integration
   https://deploy-preview-1067--logz-docs.netlify.app/shipping/prometheus-sources/python-custom-prometheus.html
- Updated  https://deploy-preview-1067--logz-docs.netlify.app/shipping/prometheus-sources/prometheus-telegraf-output.html
   - updated _source/_includes/general-shipping/replace-placeholders-prometheus.html
   - created  _source/_includes/p8s-shipping/replace-prometheus-listener.html
   - examples use port 8053

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
