### PR TITLE
Add TTL to SIEM Lookup API (in bulk add elements)

### DIFF
--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3584,7 +3584,7 @@ paths:
           required: false
           type: integer
           format: int64
-          description: The expiration date and time of the lookup list as UNIX epoch milliseconds. When this parameter is left empty, the lookup list does not expire.
+          description: Optional. The expiration date and time of the lookup list as UNIX epoch milliseconds. When this parameter is left empty, the lookup list does not expire.
         - name: lookupListId
           in: path
           required: true
@@ -3645,7 +3645,7 @@ definitions:
       expirationDate:
         type: integer
         format: int64
-        description: Optional. The expiration date and time of the lookup list as UNIX epoch milliseconds
+        description: Optional. The expiration date and time of the lookup list as UNIX epoch milliseconds. When this parameter is left empty, the lookup list does not expire.
   LookupListElementCreateRequest:
     type: object
     required: 

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3653,6 +3653,10 @@ definitions:
         maxLength: 200
         description: Optional. A place to add a note or additional details about the value. For example, if the value is an IP address, the comment can identify the server.
         example: ABC Server
+      expirationDate:
+        type: integer
+        format: int64
+        description: Optional. The expiration date and time of the lookup list as UNIX epoch milliseconds
   LookupList:
     type: object
     summary: General indentifiers for the lookup - its ID, name, and description.

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3575,7 +3575,7 @@ paths:
         - Lookup lists
       operationId: addLookupListElements
       summary: Add elements in bulk
-      description: Adds an array of elements to an existing Lookup list.
+      description: Adds an array of elements to an existing Lookup list and sets the expiration date for the lookup.
       produces:
         - application/json
       parameters:

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3642,6 +3642,10 @@ definitions:
         description: Optional. A place to add a note or additional details about the value. For example, if the value is an IP address, the comment can identify the server.
         maxLength: 200
         example: ABC Server
+      expirationDate:
+        type: integer
+        format: int64
+        description: Optional. The expiration date and time of the lookup list as UNIX epoch milliseconds
   LookupListElementCreateRequest:
     type: object
     required: 

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3579,12 +3579,6 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: accountId
-          in: query
-          required: false
-          type: integer
-          format: int32
-          description:  Logz.io account ID
         - name: defaultTTL
           in: query
           required: false
@@ -3599,7 +3593,7 @@ paths:
           example: 7c985e09-3db6-5dc6-ae33-58403493e13f
         - in: body
           name: body
-          required: false
+          required: true
           schema:
             type: array
             items:

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3596,7 +3596,7 @@ paths:
           required: false
           type: integer
           format: int64
-          description: The expiration date and time of the lookup list as UNIX epoch milliseconds
+          description: The expiration date and time of the lookup list as UNIX epoch milliseconds. When this parameter is left empty, the lookup list does not expire.
         - name: lookupListId
           in: path
           required: true

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3666,7 +3666,7 @@ definitions:
       expirationDate:
         type: integer
         format: int64
-        description: Optional. The expiration date and time of the lookup list as UNIX epoch milliseconds
+        description: Optional. The expiration date and time of the lookup list as UNIX epoch milliseconds. When this parameter is left empty, the lookup list does not expire.
   LookupList:
     type: object
     summary: General indentifiers for the lookup - its ID, name, and description.

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3433,6 +3433,12 @@ paths:
       produces:
         - application/json
       parameters:
+        - name: accountID
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description:  Logz.io account ID
         - name: lookupListId
           in: path
           required: true
@@ -3579,6 +3585,18 @@ paths:
       produces:
         - application/json
       parameters:
+        - name: accountId
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description:  Logz.io account ID
+        - name: defaultTTL
+          in: query
+          required: false
+          type: integer
+          format: int64
+          description: The expiration date and time of the lookup list as UNIX epoch milliseconds
         - name: lookupListId
           in: path
           required: true
@@ -3587,7 +3605,7 @@ paths:
           example: 7c985e09-3db6-5dc6-ae33-58403493e13f
         - in: body
           name: body
-          required: true
+          required: false
           schema:
             type: array
             items:

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3426,7 +3426,7 @@ paths:
   /v1/lookup-lists/{lookupListId}/elements:
     post:
       summary: Add element to a lookup list
-      description: Adds a new element to an existing lookup list. An element is a field value and comment (helpful description that does not affect the lookup functionally).
+      description: Adds a new element to an existing lookup list and sets the expiration date and time for the lookup list. An element is a field value and comment (helpful description that does not affect the lookup functionally).
       tags:
         - Lookup lists
       operationId: createLookupListElement

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3433,12 +3433,6 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: accountID
-          in: query
-          required: false
-          type: integer
-          format: int32
-          description:  Logz.io account ID
         - name: lookupListId
           in: path
           required: true

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3426,7 +3426,7 @@ paths:
   /v1/lookup-lists/{lookupListId}/elements:
     post:
       summary: Add element to a lookup list
-      description: Adds a new element to an existing lookup list and sets the expiration date and time for the lookup list. An element is a field value and comment (helpful description that does not affect the lookup functionally).
+      description: Adds a new element to an existing lookup list. An element is a field value and comment (helpful description that does not affect the lookup functionally).
       tags:
         - Lookup lists
       operationId: createLookupListElement

--- a/_source/integrations/alice-slack-chatbot.md
+++ b/_source/integrations/alice-slack-chatbot.md
@@ -132,3 +132,4 @@ Alice looks for the account in this order: \\
 {:.paramlist}
 
 If you need help with how to write your commands, type `@Alice help` in Slack.
+<!--Check back in 1 month -->


### PR DESCRIPTION
# What changed

Descriptions for both TTL & expirationDate: both params are optional. "When this parameter is left empty, the lookup list does not expire."


Bulk add: https://deploy-preview-1070--logz-docs.netlify.app/api/#operation/addLookupListElements

[Add an element was affected because a definition changed :   https://deploy-preview-1070--logz-docs.netlify.app/api/#operation/createLookupListElement]

Only one POST method needed to have TTL parameter added: 
- /lookup-lists/{lookupListId}/bulk-add:  https://deploy-preview-1070--logz-docs.netlify.app/api/#operation/addLookupListElements

**In VSC:** 
+ ` /v1/lookup-lists/{lookupListId}/elements`:   approximately line 3426-3458
+ ` /v1/lookup-lists/{lookupListId}/elements/bulk-add:`:    approximately line 3578-3618
+ both endpoints reference the following definition `/LookupListElementCreateRequest'`: approximately line 3657-3677: added the `expirationDate`

`/v1/lookup-lists/{lookupListId}/elements`:  Line 3436 - Parameters section, removed
```
        - name: accountID
          in: query
          required: false
          type: integer
          format: int32
          description:  Logz.io account ID
```

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
@ohadza :
- [x] Done: What is the default value of TTL? Empty. Also expirationDate
- [x] Done: How can a user configure the list so that it never expires?  leave the param value empty (TTL & expirationDate
- [ ] **TBD**: Which value takes precedence: TTL or expirationDate. (one is in query, one is in request body schema)


## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
