### PR TITLE
DOC-156: download certificate to credentials server

### DIFF
--- a/_source/_includes/log-shipping/certificate.md
+++ b/_source/_includes/log-shipping/certificate.md
@@ -1,4 +1,4 @@
-##### Download the Logz.io public certificate to your Filebeat server
+##### Download the Logz.io public certificate to the relevant credentials server in your system
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 

--- a/_source/_includes/log-shipping/certificate.md
+++ b/_source/_includes/log-shipping/certificate.md
@@ -1,4 +1,4 @@
-##### Download the Logz.io public certificate to the relevant credentials server in your system
+##### Download the Logz.io public certificate to your credentials server
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 


### PR DESCRIPTION
# What changed
https://deploy-preview-1072--logz-docs.netlify.app/shipping/log-sources/rsyslog.html
https://deploy-preview-1072--logz-docs.netlify.app/shipping/log-sources/network-device.html
https://deploy-preview-1072--logz-docs.netlify.app/shipping/log-sources/json-uploads.html#tcp-config
updated step created as an include that guides user to upload our certificate to credentials server in this file: 
`_source/_includes/log-shipping/certificate.md`

> ##### Download the Logz.io public certificate to your credentials server
> 
> For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
> 
> 
> ```shell
> sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/AAACertificateServices.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
> 

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
