### PR TITLE
Deployment markers: API and UG content

### DIFF
--- a/_source/_data/toc.yml
+++ b/_source/_data/toc.yml
@@ -21,6 +21,8 @@ firstLevel:
       url: /user-guide/kibana/
     - title: Exceptions
       url: /user-guide/insights/exceptions/
+    - title: Deployment markers
+      url: /user-guide/insights/exceptions/deployments/
     - title: Patterns
       url: /user-guide/kibana/log-patterns.html
     - title: Wildcard searches

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -115,7 +115,7 @@ tags:
   
   - name: Deployments
     description: >-
-      Send deployment logs by API to automatically correlate exceptions with service deployments directly in your Logz.io Exceptions tab.
+      Send deployment logs by API to automatically correlate exceptions with service deployments directly in your Logz.io Exceptions tab. The API endpoints documented here are in Beta, and are subject to change.
 
   - name: Insights
     description: >-
@@ -242,7 +242,7 @@ x-tagGroups:
     tags:
       - Search logs
       - Alerts
-      - Deployment markers
+      - Deployments
       - Insights
       - Logz.io snapshots
   - name: Cloud SIEM
@@ -1214,7 +1214,7 @@ paths:
   /v2/markers/create-markers:
     post:
       tags:
-        - Deployment markers
+        - Deployments
       operationId: createMarkers
       summary: Add deployment markers to Exception graphs
       description: Send logs with details of service deployments to annotate Exception graphs in Kibana Discover. [Learn more about Deployment markers](/user-guide/insights/exceptions/deployments.html)
@@ -4528,7 +4528,7 @@ definitions:
         example: ServiceA
       tag:
         type: string
-        description: Specify `DEPLOYMENT` for the Deployment marker to appear in the Deployments list in your ceptions   tab.
+        description: Specify `DEPLOYMENT` for the Deployment marker to appear in the Deployments list in your Exceptions tab.
         default: OTHER
       example: DEPLOYMENT
       enum:

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -112,6 +112,11 @@ tags:
 
 
       To ensure system performance and data availability, we've introduced some limitations to the original Elasticsearch specification. These limitations are detailed in the applicable API calls below.
+  
+  - name: Deployments
+    description: >-
+      Send deployment logs by API to automatically correlate exceptions with service deployments directly in your Logz.io Exceptions tab.
+
   - name: Insights
     description: >-
       Logz.io monitors your logs for Insights to help you preempt issues and alert you of potential problems.
@@ -237,6 +242,7 @@ x-tagGroups:
     tags:
       - Search logs
       - Alerts
+      - Deployment markers
       - Insights
       - Logz.io snapshots
   - name: Cloud SIEM
@@ -1203,6 +1209,26 @@ paths:
         default:
           description: successful operation
 
+  
+  # ::::: Deployment markers
+  /v2/markers/create-markers:
+    post:
+      tags:
+        - Deployment markers
+      operationId: createMarkers
+      summary: Add deployment markers to Exception graphs
+      description: Send logs with details of service deployments to annotate Exception graphs in Kibana Discover. [Learn more about Deployment markers](/user-guide/insights/exceptions/deployments.html)
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/CreateMarkersRequest'
+      responses:
+        default:
+          description: successful operation
 
 
   # ::::: Log Insights
@@ -4480,6 +4506,56 @@ definitions:
           type: object
         description: Tags are labels used to organize security rules
 
+
+
+  # ::::: DEPLOYMENT MARKER DEFINITIONS
+  CreateMarkersRequest:
+    type: object
+    properties:
+      markers:
+        type: array
+        items:
+          $ref: '#/definitions/MarkerDataPoint'
+  MarkerDataPoint:
+    type: object
+    required:
+      - title
+      - description
+    properties:
+      title:
+        type: string
+        description: Specify a marker title, for example, a service name. The title appears in the Deployments list    your Exceptions tab.
+        example: ServiceA
+      tag:
+        type: string
+        description: Specify `DEPLOYMENT` for the Deployment marker to appear in the Deployments list in your ceptions   tab.
+        default: OTHER
+      example: DEPLOYMENT
+      enum:
+        - DEPLOYMENT
+        - OTHER
+      timestamp:
+           type: integer
+           format: int64
+           description: Date of the deployment event, as Unix epoch milliseconds
+           example: 1613311091679
+      description:
+        type: string
+        description: Add a description to provide additional detail.
+        example: Description with additional context
+        required: true
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          version: version 5
+          deployer: iron man
+        description: >-
+          Provides additional metadata with details of the deployment.
+          
+          
+          (Future functionality: Metadata will be used to filter deploymentsby several dimensions. For example, to filter deployments by service and region to focus on deployments performed on a specific service and a specific region.
 
 
 

--- a/_source/no-search/beta-api.yml
+++ b/_source/no-search/beta-api.yml
@@ -130,7 +130,7 @@ definitions:
           Provides additional metadata with details of the deployment.
           
           
-          (Future functionality: Metadata will be used to filter deploymentsby several dimensions. For example, to filter deployments by service and region to focus on deployments performed on a specific service and a specific region.
+          (Future functionality: Metadata will be used to filter deployments by several dimensions. For example, to filter deployments by service and region to focus on deployments performed on a specific service and a specific region.
 
             
 

--- a/_source/no-search/beta-api.yml
+++ b/_source/no-search/beta-api.yml
@@ -130,7 +130,7 @@ definitions:
           Provides additional metadata with details of the deployment.
           
           
-          (Future functionality: Metadata will be used to filter deploymentsby several dimensions. For example, to filter deployments byservice and region to focus on deployments performed on a specificservice and a specific region.
+          (Future functionality: Metadata will be used to filter deploymentsby several dimensions. For example, to filter deployments by service and region to focus on deployments performed on a specific service and a specific region.
 
             
 

--- a/_source/user-guide/insights/markers.md
+++ b/_source/user-guide/insights/markers.md
@@ -12,7 +12,7 @@ contributors:
   - quintessence
 ---
 
-To help you understand the context surrounding your insights, you can add markers. Markers reflect significant events that could be potential catalysts for issues, such as new deployments, rollbacks, and specific alerts that may have been triggered.
+To help you understand the context surrounding your insights, you can add markers. Markers reflect significant events that could be potential catalysts for issues, such as [new deployments](/user-guide/insights/exceptions/deployments.html), rollbacks, and specific alerts that may have been triggered.
 
 ![Insights marker on the chart](https://dytvr9ot2sszz.cloudfront.net/logz-docs/insights/insights--marker-on-chart.png)
 

--- a/_source/user-guide/kibana/exceptions-deployments.md
+++ b/_source/user-guide/kibana/exceptions-deployments.md
@@ -1,0 +1,77 @@
+---
+layout: article
+title: Deployment markers
+permalink: /user-guide/insights/exceptions/deployments.html
+flags:
+  logzio-plan: community
+  beta: true
+tags:
+  - insights
+  - exceptions
+  - deployment markers
+  - markers
+contributors:
+  - shalper
+---
+
+{% include page-info/early-access.md type="Beta" %}
+
+
+![Exceptions count in Kibana Discover](https://dytvr9ot2sszz.cloudfront.net/logz-docs/kibana-discover/deployments.png)
+
+#### Adding Deployment markers to Exception graphs
+
+You can send deployment logs by API to automatically correlate exceptions with service deployments directly in your Logz.io Exceptions tab.
+
+<div class="tasklist">
+
+##### Send deployment logs by API
+
+Use the [API endpoint](/api/#operation/createMarkers) to create **Deployment markers**.
+
+Here's an example payload:
+
+```
+{
+  "markers": [
+    {
+      "description": "marker description",
+      "title": "marker title",
+      "tag": "DEPLOYMENT",
+      "timestamp": 1613311091679,
+      "metadata": {
+        "region": "us-east-1",
+        "deployedBy": "bot"
+      }
+    }
+  ]
+}
+```
+
+##### Select the markers you want to view
+
+The deployment logs you sent by API in the previous step appear as Deployment markers in your Logz.io Exception graphs. All Deployment markers are selected by default.
+
+Open the Deployments menu to view all markers that appear in your search time frame. You can select/unselect markers to focus on the ones of interest to you.
+
+![Select Deployment markers to enable them in Exception graphs](https://dytvr9ot2sszz.cloudfront.net/logz-docs/kibana-discover/select-deployments.png)
+
+
+
+##### View the markers in the Exceptions tab in Kibana Discover
+
+Hover over the markers in your Exception graphs to view their title and time stamp.
+
+When sending Deployment marker logs, it is recommended to send the service name in the **title** field.
+{:.info-box.tip}
+
+
+##### View additional details in the marker log
+
+Some of the fields in the deployment logs sent by API are not rendered in the Exceptions tab view. These include the **description** and additional **metadata** fields.
+
+You can run the search `_exists_: __logzio_marker_title` to retrieve your marker logs. Switch to the JSON log view to look up the additional details and context available for your Deployment markers.
+
+![Search deployment logs](https://dytvr9ot2sszz.cloudfront.net/logz-docs/kibana-discover/search-deployment-logs1.png)
+
+</div>


### PR DESCRIPTION
# What changed

- API: Deployments section added & POST /v2/markers/create-markers added: 
   -  https://deploy-preview-1096--logz-docs.netlify.app/api/#tag/Deployments
- UG: Deployment markers topic added in **Log Management > Kibana discover** 
   -  https://deploy-preview-1096--logz-docs.netlify.app/user-guide/insights/exceptions/deployments.html
- UG: Added link to Deployment markers in Insights > Markers topic
   - https://deploy-preview-1096--logz-docs.netlify.app/user-guide/insights/markers.html
- Note: Content still exists in `_source/no-search/beta-api.yml`   and  in `_source/no-search/exceptions-deployments.md` for now, I want to retain the beta API topic 


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
