### PR TITLE
change the link to "grok patterns"

### DIFF
--- a/_source/user-guide/mapping-and-parsing/data-parsing-wizard.md
+++ b/_source/user-guide/mapping-and-parsing/data-parsing-wizard.md
@@ -76,7 +76,7 @@ Type your grok pattern in the **Parse method** text box.
 To help make the best grok pattern for your logs,
 use the [Grok Debugger](https://grokdebug.herokuapp.com/).
 For reference,
-see [grok patterns](https://github.com/logstash-plugins/logstash-patterns-core/blob/master/patterns/grok-patterns)
+see [grok patterns](https://github.com/logstash-plugins/logstash-patterns-core/blob/master/patterns/ecs-v1/grok-patterns)
 from Elastic.
 {:.info-box.tip}
 

--- a/_source/user-guide/mapping-and-parsing/data-parsing-wizard.md
+++ b/_source/user-guide/mapping-and-parsing/data-parsing-wizard.md
@@ -76,7 +76,7 @@ Type your grok pattern in the **Parse method** text box.
 To help make the best grok pattern for your logs,
 use the [Grok Debugger](https://grokdebug.herokuapp.com/).
 For reference,
-see [grok patterns](https://github.com/logstash-plugins/logstash-patterns-core/blob/master/patterns/ecs-v1/grok-patterns)
+see [grok patterns](https://github.com/elastic/elasticsearch/blob/master/libs/grok/src/main/resources/patterns/grok-patterns)
 from Elastic.
 {:.info-box.tip}
 


### PR DESCRIPTION
the link doesn't exists in github anymore, I found this one in the same repository that was linked: 
https://github.com/logstash-plugins/logstash-patterns-core/blob/master/patterns/ecs-v1/grok-patterns

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
