### PR TITLE
add alerts v2

### DIFF
--- a/_source/integrations/terraform.md
+++ b/_source/integrations/terraform.md
@@ -32,8 +32,8 @@ The following Logz.io API endpoints are supported by this provider:
 * [User management](https://docs.logz.io/api/#tag/Manage-users)
 * [Notification channels](https://docs.logz.io/api/#tag/Manage-notification-endpoints)
 * [Sub accounts](https://docs.logz.io/api/#tag/Manage-sub-accounts)
-* [Logs-based alerts](https://docs.logz.io/api/#tag/Alerts)
-* [Log-based alerts](https://github.com/logzio/public-api/tree/master/alerts) (v1 - deprecated)
+* [Logs-based alerts v2](https://docs.logz.io/api/#tag/Alerts)
+* [Log-based alerts v1](https://github.com/logzio/public-api/tree/master/alerts) (deprecated)
 
 #### Working with Terraform
 

--- a/_source/integrations/terraform.md
+++ b/_source/integrations/terraform.md
@@ -11,6 +11,7 @@ tags:
   - integrations
 contributors:
   - yyyogev
+  - mirii1994
   - shalper
 ---
 
@@ -30,8 +31,9 @@ The following Logz.io API endpoints are supported by this provider:
 
 * [User management](https://docs.logz.io/api/#tag/Manage-users)
 * [Notification channels](https://docs.logz.io/api/#tag/Manage-notification-endpoints)
-* [Log-based alerts](https://github.com/logzio/public-api/tree/master/alerts)
 * [Sub accounts](https://docs.logz.io/api/#tag/Manage-sub-accounts)
+* [Logs-based alerts](https://docs.logz.io/api/#tag/Alerts)
+* [Log-based alerts](https://github.com/logzio/public-api/tree/master/alerts) (v1 - deprecated)
 
 #### Working with Terraform
 


### PR DESCRIPTION
# What changed

In the Capabilities list-
As we now support Alerts v2, added link to the alerts v2 api docs.
Marked the old alerts api (v1) as deprecated
----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
