### PR TITLE
Update sawmill-parsing.md

### DIFF
--- a/_source/user-guide/mapping-and-parsing/sawmill-parsing.md
+++ b/_source/user-guide/mapping-and-parsing/sawmill-parsing.md
@@ -5,7 +5,7 @@ permalink: /user-guide/mapping-and-parsing/sawmill-parsing
 flags:
   admin: true
   beta: true
-  logzio-plan: community
+  logzio-plan: pro
 tags:
   - parsing
 contributors:
@@ -22,7 +22,7 @@ You must be an account admin to apply a parsing pipeline to an account.
 
 ## What is Sawmill and what is the Logz.io Parsing editor?
 
-The [Sawmill open source library](https://github.com/logzio/sawmill) is used for JSON text transformations. 
+The [Sawmill open source library](https://github.com/logzio/sawmill) is used for text transformations. 
 
 A Sawmill pipeline is composed of a series of steps that are applied to a specific log type. Each step is a Sawmill processor which performs an action, a transformation, or includes some logic to enrich your logs. You set the processor step order according to the transformations and changes you need to apply to meet your parsing requirements.
 
@@ -90,7 +90,7 @@ Use **Auto re-format** to clean up your indentations.
 
 ##### Validate your pipeline
 
-Once you're satisfied with tyour draft pipeline, click **Validate your pipeline** to execute your pipeline rules against the log sample you provided. 
+Once you're satisfied with your draft pipeline, click **Validate your pipeline** to execute your pipeline rules against the log sample you provided. 
 
 <!-- info-box-start:info -->
 The Logz.io backend has a sequence of pipelines that run on your logs: Some of the pipelines are system wide and may affect the final result you see. <br><br>  Once validation is complete, you'll  be able to see the results in the Parsed log tab of the right panel. Use the display in the right panel to verify that your results reflect the parsed logs you expect to see.


### PR DESCRIPTION
- Removed "JSON" from "The Sawmill open source library is used for JSON text transformations." as the content does not haveto be a JSON.
- Fixed typo in line #93
- Changed plan to PRO and above as community plans do not have API access by default

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
