### PR TITLE
SIEM _ STIX in private feed definitions

### DIFF
--- a/_source/logzio_collections/_log-sources/docker.md
+++ b/_source/logzio_collections/_log-sources/docker.md
@@ -81,6 +81,10 @@ logzio/docker-collector-logs
 | includeLines | Comma-separated list of regular expressions to match the lines that you want to include. **Note**: Regular expressions in this list should not contain commas. | -- |
 | excludeLines | Comma-separated list of regular expressions to match the lines that you want to exclude. **Note**: Regular expressions in this list should not contain commas. | -- |
 | renameFields | Rename fields with every message sent, formatted as `"oldName,newName;oldName2,newName2"`. To use an environment variable, format as `"oldName,newName;oldName2,$ENV_VAR_NAME"`. When using an environment variable, it should be the only value in the field. If the environment variable can't be resolved, the field will be omitted. | -- |
+| HOSTNAME | Include your host name to display it for the field `agent.name`. If no value is entered, `agent.name`displays the container id.| `''` |
+| multilinePattern | Include your regex pattern. See [Filebeat's official documentation](https://www.elastic.co/guide/en/beats/filebeat/7.12/multiline-examples.html#multiline) for more information. | `''` |
+| multilineNegate |Include `'true'` to negate the pattern. **Note**: Cannot be used without multilinePattern. See [Filebeat's official documentation](https://www.elastic.co/guide/en/beats/filebeat/7.12/multiline-examples.html#multiline) for more information.| `'false'`  |
+| multilineMatch | Specifies how Filebeat combines matching lines into an event. The settings are `after` or `before`. The behavior of these settings depends on what you specify for negate. **Note**: Cannot be used without multilinePattern. See [Filebeat's official documentation](https://www.elastic.co/guide/en/beats/filebeat/7.12/multiline-examples.html#multiline) for more information.| `'after'` |
 
 
 <!-- info-box-start:info -->

--- a/_source/user-guide/cloud-siem/private-feed.md
+++ b/_source/user-guide/cloud-siem/private-feed.md
@@ -37,7 +37,7 @@ Fill in the form to configure the connection.   <!--UPDATE THE SCREEN  -->
 1. **IOC type** - Select one type. Supported types include IPs, DNSs (domain), URLs, md5/sha1/sha256 hash-based signatures, user-agent HTTP headers, and custom indicators of your choice.
 2. **Use STIX** - Toggle the option on to use STIX format. _Structured Threat Information Expression_ (STIX™) is a language and serialization format used to exchange cyber threat intelligence (CTI). 
 
-Logz.io currently supports a single IOC type per feed for this format. We recommend that you define a separate private feed for each relevant IOC type that exists in your STIX feed.
+   Logz.io currently supports a single IOC type per feed for this format. We recommend that you define a separate private feed for each relevant IOC type that exists in your STIX feed.
 3. **Confidence** - Select a reliability score for your feed.
 4. **Description** - Give some context for your feed. It's a good idea to add contact info for the person who owns the feed.
 

--- a/_source/user-guide/cloud-siem/private-feed.md
+++ b/_source/user-guide/cloud-siem/private-feed.md
@@ -28,15 +28,18 @@ Go to **Threats > Threat Intelligence Feeds** from the top menu, and select the 
 
 ##### Configure the connection
 
-Fill in the form to configure the connection.
+Fill in the form to configure the connection.   <!--UPDATE THE SCREEN  -->
 
-![Configure a private feed](https://dytvr9ot2sszz.cloudfront.net/logz-docs/siem/configure-private-feed-alpha.png)
+![Configure a private feed](https://dytvr9ot2sszz.cloudfront.net/logz-docs/siem/configure-private-feed-alpha.png)   
 
 **About the feed**
 
 1. **IOC type** - Select one type. Supported types include IPs, DNSs (domain), URLs, md5/sha1/sha256 hash-based signatures, user-agent HTTP headers, and custom indicators of your choice.
-2. **Confidence** - Select a reliability score for your feed.
-3. **Description** - Give some context for your feed. It's a good idea to add contact info for the person who owns the feed.
+2. **Use STIX** - Toggle the option on to use STIX format. _Structured Threat Information Expression_ (STIX™) is a language and serialization format used to exchange cyber threat intelligence (CTI). 
+
+Logz.io currently supports a single IOC type per feed for this format. We recommend that you define a separate private feed for each relevant IOC type that exists in your STIX feed.
+3. **Confidence** - Select a reliability score for your feed.
+4. **Description** - Give some context for your feed. It's a good idea to add contact info for the person who owns the feed.
 
 **Configure the feed connection**
 

--- a/_source/user-guide/cloud-siem/private-feed.md
+++ b/_source/user-guide/cloud-siem/private-feed.md
@@ -67,6 +67,6 @@ To edit or delete a private feed, hover over the feed in the list,
   and click <i class="li li-pencil"></i> (edit)
   or <i class="li li-trash"></i> (delete).
 
-If you delete a private feed, Logz.io will stop using it to enrich logs immediately.
+If you delete a private feed, Logz.io will immediately stop using it to enrich logs.
 
 ![Configure a private feed](https://dytvr9ot2sszz.cloudfront.net/logz-docs/siem/feed-info.png)


### PR DESCRIPTION
# What changed
Added a line to explain STIX format. 
https://deploy-preview-1127--logz-docs.netlify.app/user-guide/cloud-siem/private-feeds.html#configure-the-connection

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
