### PR TITLE
DOC-183: added unfiltered query to Retrieve Security Rules

### DIFF
--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -3146,7 +3146,9 @@ paths:
           name: body
           required: false
           schema:
-            $ref: '#/definitions/AlertsSearchRequest'
+            oneOf:
+              - $ref: '#/definitions/AlertsSearchRequestFiltered'
+              - $ref: '#/definitions/AlertsSearchRequestUnfiltered'
       responses:
         '200':
           description: successful operation
@@ -4510,8 +4512,7 @@ definitions:
       pagination:
         $ref: '#/definitions/Pagination'
 
-
-  AlertsSearchRequest:
+  AlertsSearchRequestFiltered:
     type: object
     properties:
       filter:
@@ -4522,6 +4523,23 @@ definitions:
         $ref: '#/definitions/AlertsSortRequest'
       pagination:
         $ref: '#/definitions/Pagination'
+  AlertsSearchRequestUnfiltered:
+    type: object
+    properties:
+      query:
+        type: object
+        description: Search query.
+        properties:
+            bool:
+              type: object
+              properties:
+                  must:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        match_all:
+                          type: object
   AlertsSortRequest:
     type: object
     required:

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -4513,7 +4513,7 @@ definitions:
         $ref: '#/definitions/Pagination'
 
   AlertsSearchRequestFiltered:
-    title: Filtered request  
+    title: Filtered Results  
     type: object
     properties:
       filter:
@@ -4525,7 +4525,7 @@ definitions:
       pagination:
         $ref: '#/definitions/Pagination'
   AlertsSearchRequestUnfiltered:
-    title: Unfiltered request  
+    title: Unfiltered Results  
     type: object
     properties:
       query:

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -4513,6 +4513,7 @@ definitions:
         $ref: '#/definitions/Pagination'
 
   AlertsSearchRequestFiltered:
+    title: Filtered request  
     type: object
     properties:
       filter:
@@ -4524,6 +4525,7 @@ definitions:
       pagination:
         $ref: '#/definitions/Pagination'
   AlertsSearchRequestUnfiltered:
+    title: Unfiltered request  
     type: object
     properties:
       query:


### PR DESCRIPTION
# What changed

Added unfiltered query example: https://deploy-preview-1145--logz-docs.netlify.app/api/#operation/searchAccountSecurityRules
----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
