### PR TITLE
DOC-176: Updated empty array requirement

### DIFF
--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -4032,7 +4032,7 @@ definitions:
           type: integer
           format: int32
           example: [ 88888, 55555 ]
-        description: IDs of accounts that can access this account's data.
+        description: IDs of accounts that can access this account's data. The array is required, but can be empty.
       docSizeSetting:
         $ref: '#/definitions/DocSizeSetting'
       utilizationSettings:
@@ -4088,7 +4088,7 @@ definitions:
           type: integer
           format: int32
           example: [ ]
-        description: IDs of accounts that can access this account's data.
+        description: IDs of accounts that can access this account's data. The array is required, but can be empty.
       docSizeSetting:
         $ref: '#/definitions/DocSizeSetting'
       utilizationSettings:

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -365,7 +365,9 @@ paths:
           name: body
           required: false
           schema:
-            $ref: '#/definitions/TimeBasedAccountCreateRequest'
+            oneOf:
+              - $ref: '#/definitions/TimeBasedAccountCreateRequest'
+              - $ref: '#/definitions/TimeBasedAccountCreateRequestEmptyArray'
       responses:
         200:
           description: successful operation
@@ -4117,11 +4119,76 @@ definitions:
           type: integer
           format: int32
           example: [ 88888, 55555 ]
-        description: IDs of accounts that can access this account's data
+        description: IDs of accounts that can access this account's data. The array is required, but can be empty.
       docSizeSetting:
         $ref: '#/definitions/DocSizeSetting'
       utilizationSettings:
         $ref: '#/definitions/AccountUtilizationSettings'
+
+  TimeBasedAccountCreateRequestEmptyArray:
+    type: object
+    required:
+      - accountName
+      - email
+      - sharingObjectsAccounts
+      - retentionDays
+    properties:
+      email:
+        type: string
+        pattern: "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z]{2,})$"
+        description: Account administrator's email address
+        example: help@logz.io
+      accountName:
+        type: string
+        description: Name of the account
+        example: AWS Lambda svr 3
+      reservedDailyGB:
+        type: number
+        format: float
+        default: null
+        description: >-
+          * If `isFlexible=false`, don't send this field or send it null.
+
+
+          * If `isFlexible=true`, this parameter is required. It determines the volume that is reserved for the account.
+        example: 3
+      maxDailyGB:
+        type: number
+        format: float
+        description: >-
+          The maximum volume of data that an account can index per calendar day.
+
+
+          * If `isFlexible=false` this is the only capacity reserved for use by the account. Cannot be null.
+
+
+          * If `isFlexible=true` this is used to limit the account's access to shared volume. Once the data shipped to the account exceeds the account's reserved capacity, the account can continue to index data up to its `maxDailyGB`, as long as shared volume is available.
+
+
+          * If null (and `isFlexible=true`), the account is uncapped and can continue to index data as long as shared volume is available.
+        example: 5
+      retentionDays:
+        type: integer
+        format: int32
+        description: How long log data is stored and searchable in Kibana, in days.
+        minimum: 1
+        example: 5
+      searchable:
+        $ref: "#/definitions/Searchable"
+      accessible:
+        $ref: "#/definitions/Accessible"
+      sharingObjectsAccounts:
+        type: array
+        items:
+          type: integer
+          format: int32
+          example: [ ]
+        description: IDs of accounts that can access this account's data. The array is required, but can be empty.
+      docSizeSetting:
+        $ref: '#/definitions/DocSizeSetting'
+      utilizationSettings:
+        $ref: '#/definitions/AccountUtilizationSettings'
+ 
   SharingAccount:
     type: object
     properties:

--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -449,7 +449,9 @@ paths:
           name: body
           required: false
           schema:
-            $ref: '#/definitions/TimeBasedAccountUpdateRequest'
+            oneOf:
+              - $ref: '#/definitions/TimeBasedAccountUpdateRequest'
+              - $ref: '#/definitions/TimeBasedAccountUpdateRequestEmptyArray'
       responses:
         204:
           description: successful operation
@@ -4030,6 +4032,62 @@ definitions:
           type: integer
           format: int32
           example: [ 88888, 55555 ]
+        description: IDs of accounts that can access this account's data.
+      docSizeSetting:
+        $ref: '#/definitions/DocSizeSetting'
+      utilizationSettings:
+        $ref: '#/definitions/AccountUtilizationSettings'
+  TimeBasedAccountUpdateRequestEmptyArray:
+    type: object
+    required:
+      - accountName
+      - sharingObjectsAccounts
+    properties:
+      accountName:
+        type: string
+        description: Name of the account
+        example: AWS Lambda svr 3
+      reservedDailyGB:
+        type: number
+        format: float
+        default: null
+        description: >-
+          * If `isFlexible=false`, this field does not apply. Leave it null.
+   
+         
+          * If `isFlexible=true`, this parameter is required. It determines the volume that is reserved for the account.
+        example: 3
+      maxDailyGB:
+        type: number
+        format: float
+        description: >-
+          The maximum volume of data that an account can index per calendar day.
+
+
+          * If `isFlexible=false` this parameter can only be used to update a sub account, but not a main account. It determines the only capacity reserved for use by the account. It cannot be null.
+
+
+          * If `isFlexible=true` this is used to limit the account's access to shared volume. Once the data shipped to the account exceeds the account's reserved capacity, the account can continue to index data up to its `maxDailyGB`, as long as shared volume is available.
+          
+          
+          * If null (and `isFlexible=true`), the account is uncapped and can continue to index data as long as shared volume is available.
+        example: 5
+      retentionDays:
+        type: integer
+        format: int32
+        description: This is how long log data is stored and searchable in Kibana, in days.
+        minimum: 1
+        example: 5
+      searchable:
+        $ref: "#/definitions/Searchable"
+      accessible:
+        $ref: "#/definitions/Accessible"
+      sharingObjectsAccounts:
+        type: array
+        items:
+          type: integer
+          format: int32
+          example: [ ]
         description: IDs of accounts that can access this account's data.
       docSizeSetting:
         $ref: '#/definitions/DocSizeSetting'


### PR DESCRIPTION
# What changed

I added an example request with the sharingObjectsAccounts array empty and specified in the description that the array is required but can be empty. https://deploy-preview-1146--logz-docs.netlify.app/api/#operation/createTimeBasedAccount

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
