### PR TITLE
DOC-185: Added Required filter to Enabled parameter of Search request

### DIFF
--- a/_source/api/logzio-public-api.yml
+++ b/_source/api/logzio-public-api.yml
@@ -6266,6 +6266,8 @@ definitions:
 
   ShippingTokensFilterRequest:
       type: object
+      required:
+      - enabled
       description: Filters your search for token attributes.
       properties:
         enabled:


### PR DESCRIPTION
# What changed

Added Required filter to Enabled parameter of Search request https://deploy-preview-1155--logz-docs.netlify.app/api/#operation/searchLogShippingTokens

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
