### PR TITLE
Fixed docker plugin version

### DIFF
--- a/_source/logzio_collections/_log-sources/docker.md
+++ b/_source/logzio_collections/_log-sources/docker.md
@@ -118,7 +118,7 @@ Docker Community Edition (Docker CE) 18.03 or later
 ##### Install the plugin from the Docker store
 
 ```shell
-docker plugin install store/logzio/logzio-logging-plugin:1.0.0 \
+docker plugin install store/logzio/logzio-logging-plugin:1.0.2 \
 --alias logzio/logzio-logging-plugin
 ```
 


### PR DESCRIPTION
1.0.0 has a bug that causes empty loglines to be shipped.

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
