### PR TITLE
DOC-6: added a note for Logzio_modules

### DIFF
--- a/_source/_includes/metric-shipping/aws-metrics.md
+++ b/_source/_includes/metric-shipping/aws-metrics.md
@@ -6,7 +6,7 @@
 | LOGZIO_MODULES | Comma-separated list of Metricbeat modules to enable on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/modules`. | Required |
 
 <!-- info-box-start:info -->
-The `LOGZIO_MODULES` parameter by default supports only these prebuilt modules: `aws`, `system` and `docker`.
+By default, the `LOGZIO_MODULES` parameter supports only the following prebuilt modules: `aws`, `system` and `docker`.
 {:.info-box.note}
 <!-- info-box-end --> 
 

--- a/_source/_includes/metric-shipping/aws-metrics.md
+++ b/_source/_includes/metric-shipping/aws-metrics.md
@@ -4,6 +4,12 @@
 |---|---|---|
 | LOGZIO_TOKEN | Your Logz.io Metrics account token. {% include metric-shipping/replace-metrics-token.html %} | Required |
 | LOGZIO_MODULES | Comma-separated list of Metricbeat modules to enable on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/modules`. | Required |
+
+<!-- info-box-start:info -->
+The `LOGZIO_MODULES` parameter by default supports only these prebuilt modules: `aws`, `system` and `docker`.
+{:.info-box.note}
+<!-- info-box-end --> 
+
 | LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL.  You can find your region code in the [Regions and URLs](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. | US East |
 | LOGZIO_TYPE | This field is needed only if you're shipping metrics to Kibana and you want to override the default value.  In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. | `docker-collector-metrics` |
 | LOGZIO_LOG_LEVEL | The log level the module startup scripts will generate. | `"INFO"` |

--- a/_source/logzio_collections/_metrics-sources/docker.md
+++ b/_source/logzio_collections/_metrics-sources/docker.md
@@ -82,7 +82,7 @@ logzio/docker-collector-metrics
 | LOGZIO_MODULES  | Comma-separated list of Metricbeat modules to be enabled on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/modules`. | N/A |
 
 <!-- info-box-start:info -->
-The `LOGZIO_MODULES` parameter by default supports only these prebuilt modules: `aws`, `system` and `docker`.
+By default, the `LOGZIO_MODULES` parameter supports only the following prebuilt modules: `aws`, `system` and `docker`.
 {:.info-box.note}
 <!-- info-box-end --> 
 

--- a/_source/logzio_collections/_metrics-sources/docker.md
+++ b/_source/logzio_collections/_metrics-sources/docker.md
@@ -80,6 +80,12 @@ logzio/docker-collector-metrics
 |---|---|---|
 | LOGZIO_TOKEN | Your Logz.io Metrics account token. {% include /metric-shipping/replace-metrics-token.html %} |Required|
 | LOGZIO_MODULES  | Comma-separated list of Metricbeat modules to be enabled on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/modules`. | N/A |
+
+<!-- info-box-start:info -->
+The `LOGZIO_MODULES` parameter by default supports only these prebuilt modules: `aws`, `system` and `docker`.
+{:.info-box.note}
+<!-- info-box-end --> 
+
 {% include general-shipping/region-parameter.md %}
 | LOGZIO_TYPE | This field is needed only if you're shipping metrics to Kibana and you want to override the default value.    In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. | `docker-collector-metrics`|
 | LOGZIO_LOG_LEVEL | The log level the module startup scripts will generate. | `"INFO"`|

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -226,6 +226,12 @@ logzio/docker-collector-metrics
 |---|---|---|
 | LOGZIO_TOKEN  | Your Metrics account token. {% include metric-shipping/replace-metrics-token.html %} | Required |
 | LOGZIO_MODULES  | Comma-separated list of Metricbeat modules to be enabled on this container (formatted as `"module1,module2,module3"`). To use a custom module configuration file, mount its folder to `/logzio/modules`. | Required |
+
+<!-- info-box-start:info -->
+The `LOGZIO_MODULES` parameter by default supports only these prebuilt modules: `aws`, `system` and `docker`.
+{:.info-box.note}
+<!-- info-box-end --> 
+
 | LOGZIO_REGION | Two-letter region code, or blank for US East (Northern Virginia). This determines your listener URL (where you're shipping the logs to) and API URL.    You can find your region code in the [Regions and URLs](docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls) table. | Blank (US East) |
 | LOGZIO_TYPE | This field is needed only if you're shipping metrics to Kibana and you want to override the default value.    In Kibana, this is shown in the `type` field. Logz.io applies parsing based on `type`. | `docker-collector-metrics` |
 | LOGZIO_LOG_LEVEL  | The log level the module startup scripts will generate. | `"INFO"` |

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -174,7 +174,7 @@ that runs Metricbeat with the modules you enable at runtime.
 
 <!-- info-box-start:info -->
 This Docker container monitors Linux system metrics only.
-For other OSes, we recommend running Metricbeat locally on the system itself.
+For other operating systems, we recommend running Metricbeat locally on the system itself.
 {:.info-box.note}
 <!-- info-box-end -->
 


### PR DESCRIPTION
# What changed

Added a note as requested in DOC-6 to:

https://deploy-preview-1163--logz-docs.netlify.app/shipping/metrics-sources/docker.html
https://deploy-preview-1163--logz-docs.netlify.app/shipping/metrics-sources/system.html#docker-config

Also added this to the snippet aws-metrics.md, which is used across AWS integration docs.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
