### PR TITLE
upgrade to 7.13.2, add clusterroles

### DIFF
--- a/shipping-config-samples/k8s-filebeat.yaml
+++ b/shipping-config-samples/k8s-filebeat.yaml
@@ -66,6 +66,15 @@ rules:
     resources:
     - namespaces
     - pods
+    - nodes
+    verbs:
+    - get
+    - watch
+    - list
+  - apiGroups:
+    - "apps"
+    resources:
+    - replicasets
     verbs:
     - get
     - watch
@@ -108,7 +117,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: filebeat
-        image: "docker.elastic.co/beats/filebeat:7.8.1"
+        image: "docker.elastic.co/beats/filebeat:7.13.2"
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",


### PR DESCRIPTION
# What changed

Update Filebeat daemonset:
- Upgrade version (7.8 -> 7.13.2)
- Add cluster roles, to match the new Filebeat version.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
