### PR TITLE
DOC-180: added Default parsing log types list

### DIFF
--- a/_source/user-guide/log-shipping/built-in-log-types.md
+++ b/_source/user-guide/log-shipping/built-in-log-types.md
@@ -33,9 +33,9 @@ This table shows the log types that Logz.io parses automatically.
 | AWS ELB               | `elb`                                      | Prebuilt |
 | AWS Fargate           | `fargate`                                  | No prebuilt pipeline. Auto-parsed as part of platform integration. |
 | AWS GuardDuty             | `guardduty`                                | Prebuilt |
-| AWS VPCFlow           | `vpcflow`                                  | Prebuilt |
 | AWS Route 53          | `route_53`                                 | Prebuilt |
 | AWS S3 access         | `S3Access`                                 | Prebuilt |
+| AWS VPC Flow           | `vpcflow`                                  | Prebuilt |
 | AWS WAF         | `awswaf`                                 | No prebuilt pipeline. Auto-parsed as part of platform integration. |
 | Checkpoint            | `checkpoint`                               | Prebuilt |
 | Cisco ASA             | `cisco-asa`                                | Prebuilt |
@@ -76,7 +76,6 @@ This table shows the log types that Logz.io parses automatically.
 | Sophos Intercept X       | `sophos-ep`                                  | No prebuilt pipeline. Auto-parsed as part of platform integration. |
 | Stormshield                | `stormshield`                              | Prebuilt |
 | Sysmon                | `wineventlog`                              | Prebuilt |
-| VPC Flow           | `vpcflow`                             | Prebuilt |
 | Windows WinEventLog          | `wineventlog`                             | Prebuilt |
 | Zeek           | `zeek`                              | Prebuilt |
 | Zipkin span           | `zipkinSpan`                             | Prebuilt |

--- a/_source/user-guide/log-shipping/built-in-log-types.md
+++ b/_source/user-guide/log-shipping/built-in-log-types.md
@@ -10,6 +10,7 @@ contributors:
   - shalper
   - schwin007
   - imnotashrimp
+  - nshishkin
 ---
 
 Logz.io automatically parses logs shipped from many platforms, services, containers, servers, and more.
@@ -20,62 +21,62 @@ Logz.io offers many pre-built parsing pipelines for a large number of log source
 
 ## Built-in log types
 
-This table shows the log types that Logz.io parses automatically using pre-built pipelines.
+This table shows the log types that Logz.io parses automatically.
 
-| Description           | Type                                       |
+| Description           | Type                                       | Pipeline |
 |-----------------------|--------------------------------------------|
-| Alcide kAudit         | `alcide-kaudit` |
-| Apache access         | `apache`, `apache_access`, `apache-access` |
-| Auditd                | `auditd`                                   |
-| AWS CloudFront        | `cloudfront`                               |
-| AWS CloudTrail        | `cloudtrail`                               |
-| AWS ELB               | `elb`                                      |
-| AWS Fargate           | `fargate`                                  |
-| AWS GuardDuty             | `guardduty`                                |
-| AWS VPCFlow           | `vpcflow`                                  |
-| AWS Route 53          | `route_53`                                 |
-| AWS S3 access         | `S3Access`                                 |
-| AWS WAF         | `awswaf`                                 |
-| Checkpoint            | `checkpoint`                               |
-| Cisco ASA             | `cisco-asa`                                |
-| Cisco Meraki          | `cisco-meraki`                             |
-| Crowdstrike           | `crowdstrike`                              |
-| Docker                | `docker_logs`                              |
-| Docker Collector Logs | `docker-collector-logs`                    |
-| Elasticsearch         | `elasticsearch`                            |
-| Fail2ban              | `fail2ban`                                 |
-| Falco                 | `falco`                                    |
-| Fargate                 | `fargate`                                |
-| Fortigate             | `fortigate`                               |
-| GitHub                  | `github`                                     |
-| GPFS                  | `gpfs`                                     |
-| HAProxy Load Balancer              | `haproxy`                                  |
-| Jenkins               | `jenkins`                                  |
-| Juniper                  | `juniper`                             |
-| Kafka                 | `kafka_server`                             |
-| Kubernetes                 | `k8s`                             |
-| Mcafee EPO            | `mcafee_epo`                                      |
-| Microsoft IIS         | `iis`                                      |
-| ModSecurity               | `modsecurity`                                  |
-| MongoDB               | `mongodb`                                  |
-| Monit                 | `monit`                                    |
-| MySQL                 | `mysql`                                    |
-| MySQL error           | `mysql_error`                              |
-| MySQL monitor         | `mysql_monitor`                            |
-| MySQL slow query      | `mysql_slow_query`                         |
-| Nagios                | `nagios`                                   |
-| NGINX access          | `nginx`, `nginx_access`, `nginx-access`    |
-| NGINX error           | `nginx-error`                              |
-| OpenVAS                 | `openvas`                                    |
-| OSSEC                 | `ossec`                                    |
-| Trend Micro                 | `trendmicro_deep`                    |
-| Palo Alto Networks    | `paloalto`                                  |
-| Performance-tab       | `performance-tab`                                  |
-| Sonicwall                | `sonicwall`                                  |
-| Sophos Intercept X       | `sophos-ep`                                  |
-| Stormshield                | `stormshield`                              |
-| Sysmon                | `wineventlog`                              |
-| VPC Flow           | `vpcflow`                             |
-| Windows WinEventLog          | `wineventlog`                             |
-| Zeek           | `zeek`                              |
-| Zipkin span           | `zipkinSpan`                             |
+| Alcide kAudit         | `alcide-kaudit` | No prebuilt pipeline. Auto-parsed as part of platform integration. |
+| Apache access         | `apache`, `apache_access`, `apache-access` | Prebuilt |
+| Auditd                | `auditd`                                   | Prebuilt |
+| AWS CloudFront        | `cloudfront`                               | Prebuilt |
+| AWS CloudTrail        | `cloudtrail`                               | Prebuilt |
+| AWS ELB               | `elb`                                      | Prebuilt |
+| AWS Fargate           | `fargate`                                  | No prebuilt pipeline. Auto-parsed as part of platform integration. |
+| AWS GuardDuty             | `guardduty`                                | Prebuilt |
+| AWS VPCFlow           | `vpcflow`                                  | Prebuilt |
+| AWS Route 53          | `route_53`                                 | Prebuilt |
+| AWS S3 access         | `S3Access`                                 | Prebuilt |
+| AWS WAF         | `awswaf`                                 | No prebuilt pipeline. Auto-parsed as part of platform integration. |
+| Checkpoint            | `checkpoint`                               | Prebuilt |
+| Cisco ASA             | `cisco-asa`                                | Prebuilt |
+| Cisco Meraki          | `cisco-meraki`                             | Prebuilt |
+| Crowdstrike           | `crowdstrike`                              | Prebuilt |
+| Docker                | `docker_logs`                              | Prebuilt |
+| Docker Collector Logs | `docker-collector-logs`                    | Prebuilt |
+| Elasticsearch         | `elasticsearch`                            | Prebuilt |
+| Fail2ban              | `fail2ban`                                 | Prebuilt |
+| Falco                 | `falco`                                    | Prebuilt |
+| Fargate                 | `fargate`                                | No prebuilt pipeline. Auto-parsed as part of platform integration. |
+| Fortigate             | `fortigate`                               | Prebuilt |
+| GitHub                  | `github`                                     | No prebuilt pipeline. Auto-parsed as part of platform integration. |
+| GPFS                  | `gpfs`                                     | Prebuilt |
+| HAProxy Load Balancer              | `haproxy`                                  | Prebuilt |
+| Jenkins               | `jenkins`                                  | Prebuilt |
+| Juniper                  | `juniper`                             | Prebuilt |
+| Kafka                 | `kafka_server`                             | Prebuilt |
+| Kubernetes                 | `k8s`                             | No prebuilt pipeline. Auto-parsed as part of platform integration. |
+| Mcafee EPO            | `mcafee_epo`                                      | Prebuilt |
+| Microsoft IIS         | `iis`                                      | Prebuilt |
+| ModSecurity               | `modsecurity`                                  | No prebuilt pipeline. Auto-parsed as part of platform integration. |
+| MongoDB               | `mongodb`                                  | Prebuilt |
+| Monit                 | `monit`                                    | Prebuilt |
+| MySQL                 | `mysql`                                    | Prebuilt |
+| MySQL error           | `mysql_error`                              | Prebuilt |
+| MySQL monitor         | `mysql_monitor`                            | Prebuilt |
+| MySQL slow query      | `mysql_slow_query`                         | Prebuilt |
+| Nagios                | `nagios`                                   | Prebuilt |
+| NGINX access          | `nginx`, `nginx_access`, `nginx-access`    | Prebuilt |
+| NGINX error           | `nginx-error`                              | Prebuilt |
+| OpenVAS                 | `openvas`                                    | Prebuilt |
+| OSSEC                 | `ossec`                                    | Prebuilt |
+| Trend Micro                 | `trendmicro_deep`                    | Prebuilt |
+| Palo Alto Networks    | `paloalto`                                  | Prebuilt |
+| Performance-tab       | `performance-tab`                                  | Prebuilt |
+| Sonicwall                | `sonicwall`                                  | Prebuilt |
+| Sophos Intercept X       | `sophos-ep`                                  | No prebuilt pipeline. Auto-parsed as part of platform integration. |
+| Stormshield                | `stormshield`                              | Prebuilt |
+| Sysmon                | `wineventlog`                              | Prebuilt |
+| VPC Flow           | `vpcflow`                             | Prebuilt |
+| Windows WinEventLog          | `wineventlog`                             | Prebuilt |
+| Zeek           | `zeek`                              | Prebuilt |
+| Zipkin span           | `zipkinSpan`                             | Prebuilt |

--- a/_source/user-guide/log-shipping/built-in-log-types.md
+++ b/_source/user-guide/log-shipping/built-in-log-types.md
@@ -23,10 +23,10 @@ Logz.io offers many pre-built parsing pipelines for a large number of log source
 
 This table shows the log types that Logz.io parses automatically.
 
-| Description           | Type                                       | Parsing pipeline |
+| Description           | Type                                       | Prebuilt parsing pipeline unless marked |
 |-----------------------|--------------------------------------------|
-| Alcide kAudit         | `alcide-kaudit` | No prebuilt pipeline. Auto-parsed as part of platform integration. |
-| Apache access         | `apache`, `apache_access`, `apache-access` | Prebuilt |
+| Alcide kAudit         | `alcide-kaudit` | &#9746; Auto-parsed as part of platform integration. |
+| Apache access         | `apache`, `apache_access`, `apache-access` | &#9745; |
 | Auditd                | `auditd`                                   | Prebuilt |
 | AWS CloudFront        | `cloudfront`                               | Prebuilt |
 | AWS CloudTrail        | `cloudtrail`                               | Prebuilt |

--- a/_source/user-guide/log-shipping/built-in-log-types.md
+++ b/_source/user-guide/log-shipping/built-in-log-types.md
@@ -23,7 +23,7 @@ Logz.io offers many pre-built parsing pipelines for a large number of log source
 
 This table shows the log types that Logz.io parses automatically.
 
-| Description           | Type                                       | Pipeline |
+| Description           | Type                                       | Parsing pipeline |
 |-----------------------|--------------------------------------------|
 | Alcide kAudit         | `alcide-kaudit` | No prebuilt pipeline. Auto-parsed as part of platform integration. |
 | Apache access         | `apache`, `apache_access`, `apache-access` | Prebuilt |

--- a/_source/user-guide/log-shipping/built-in-log-types.md
+++ b/_source/user-guide/log-shipping/built-in-log-types.md
@@ -25,18 +25,18 @@ This table shows the log types that Logz.io parses automatically.
 
 | Description           | Type                                       | Prebuilt parsing pipeline unless marked |
 |-----------------------|--------------------------------------------|
-| Alcide kAudit         | `alcide-kaudit` | ⨯ Auto-parsed as part of platform integration. |
+| Alcide kAudit         | `alcide-kaudit` | ✖️ Auto-parsed as part of platform integration. |
 | Apache access         | `apache`, `apache_access`, `apache-access` | ✔ |
 | Auditd                | `auditd`                                   | ✔ |
 | AWS CloudFront        | `cloudfront`                               | ✔ |
 | AWS CloudTrail        | `cloudtrail`                               | ✔ |
 | AWS ELB               | `elb`                                      | ✔ |
-| AWS Fargate           | `fargate`                                  | ⨯ Auto-parsed as part of platform integration. |
+| AWS Fargate           | `fargate`                                  | ✖️ Auto-parsed as part of platform integration. |
 | AWS GuardDuty             | `guardduty`                                | ✔ |
 | AWS Route 53          | `route_53`                                 | ✔ |
 | AWS S3 access         | `S3Access`                                 | ✔ |
 | AWS VPC Flow           | `vpcflow`                                  | ✔ |
-| AWS WAF         | `awswaf`                                 | ⨯ Auto-parsed as part of platform integration. |
+| AWS WAF         | `awswaf`                                 | ✖️ Auto-parsed as part of platform integration. |
 | Checkpoint            | `checkpoint`                               | ✔ |
 | Cisco ASA             | `cisco-asa`                                | ✔ |
 | Cisco Meraki          | `cisco-meraki`                             | ✔ |
@@ -46,18 +46,18 @@ This table shows the log types that Logz.io parses automatically.
 | Elasticsearch         | `elasticsearch`                            | ✔ |
 | Fail2ban              | `fail2ban`                                 | ✔ |
 | Falco                 | `falco`                                    | ✔ |
-| Fargate                 | `fargate`                                | ⨯ Auto-parsed as part of platform integration. |
+| Fargate                 | `fargate`                                | ✖️ Auto-parsed as part of platform integration. |
 | Fortigate             | `fortigate`                               | ✔ |
-| GitHub                  | `github`                                     | ⨯ Auto-parsed as part of platform integration. |
+| GitHub                  | `github`                                     | ✖️ Auto-parsed as part of platform integration. |
 | GPFS                  | `gpfs`                                     | ✔ |
 | HAProxy Load Balancer              | `haproxy`                                  | ✔ |
 | Jenkins               | `jenkins`                                  | ✔ |
 | Juniper                  | `juniper`                             | ✔ |
 | Kafka                 | `kafka_server`                             | ✔ |
-| Kubernetes                 | `k8s`                             | ⨯ Auto-parsed as part of platform integration. |
+| Kubernetes                 | `k8s`                             | ✖️ Auto-parsed as part of platform integration. |
 | Mcafee EPO            | `mcafee_epo`                                      | ✔ |
 | Microsoft IIS         | `iis`                                      | ✔ |
-| ModSecurity               | `modsecurity`                                  | ⨯ Auto-parsed as part of platform integration. |
+| ModSecurity               | `modsecurity`                                  | ✖️ Auto-parsed as part of platform integration. |
 | MongoDB               | `mongodb`                                  | ✔ |
 | Monit                 | `monit`                                    | ✔ |
 | MySQL                 | `mysql`                                    | ✔ |
@@ -73,7 +73,7 @@ This table shows the log types that Logz.io parses automatically.
 | Palo Alto Networks    | `paloalto`                                  | ✔ |
 | Performance-tab       | `performance-tab`                                  | ✔ |
 | Sonicwall                | `sonicwall`                                  | ✔ |
-| Sophos Intercept X       | `sophos-ep`                                  | ⨯ Auto-parsed as part of platform integration. |
+| Sophos Intercept X       | `sophos-ep`                                  | ✖️ Auto-parsed as part of platform integration. |
 | Stormshield                | `stormshield`                              | ✔ |
 | Sysmon                | `wineventlog`                              | ✔ |
 | Windows WinEventLog          | `wineventlog`                             | ✔ |

--- a/_source/user-guide/log-shipping/built-in-log-types.md
+++ b/_source/user-guide/log-shipping/built-in-log-types.md
@@ -25,57 +25,57 @@ This table shows the log types that Logz.io parses automatically.
 
 | Description           | Type                                       | Prebuilt parsing pipeline unless marked |
 |-----------------------|--------------------------------------------|
-| Alcide kAudit         | `alcide-kaudit` | &#9746; Auto-parsed as part of platform integration. |
-| Apache access         | `apache`, `apache_access`, `apache-access` | :*:\check:: |
-| Auditd                | `auditd`                                   | Prebuilt |
-| AWS CloudFront        | `cloudfront`                               | Prebuilt |
-| AWS CloudTrail        | `cloudtrail`                               | Prebuilt |
-| AWS ELB               | `elb`                                      | Prebuilt |
-| AWS Fargate           | `fargate`                                  | No prebuilt pipeline. Auto-parsed as part of platform integration. |
-| AWS GuardDuty             | `guardduty`                                | Prebuilt |
-| AWS Route 53          | `route_53`                                 | Prebuilt |
-| AWS S3 access         | `S3Access`                                 | Prebuilt |
-| AWS VPC Flow           | `vpcflow`                                  | Prebuilt |
-| AWS WAF         | `awswaf`                                 | No prebuilt pipeline. Auto-parsed as part of platform integration. |
-| Checkpoint            | `checkpoint`                               | Prebuilt |
-| Cisco ASA             | `cisco-asa`                                | Prebuilt |
-| Cisco Meraki          | `cisco-meraki`                             | Prebuilt |
-| Crowdstrike           | `crowdstrike`                              | Prebuilt |
-| Docker                | `docker_logs`                              | Prebuilt |
-| Docker Collector Logs | `docker-collector-logs`                    | Prebuilt |
-| Elasticsearch         | `elasticsearch`                            | Prebuilt |
-| Fail2ban              | `fail2ban`                                 | Prebuilt |
-| Falco                 | `falco`                                    | Prebuilt |
-| Fargate                 | `fargate`                                | No prebuilt pipeline. Auto-parsed as part of platform integration. |
-| Fortigate             | `fortigate`                               | Prebuilt |
-| GitHub                  | `github`                                     | No prebuilt pipeline. Auto-parsed as part of platform integration. |
-| GPFS                  | `gpfs`                                     | Prebuilt |
-| HAProxy Load Balancer              | `haproxy`                                  | Prebuilt |
-| Jenkins               | `jenkins`                                  | Prebuilt |
-| Juniper                  | `juniper`                             | Prebuilt |
-| Kafka                 | `kafka_server`                             | Prebuilt |
-| Kubernetes                 | `k8s`                             | No prebuilt pipeline. Auto-parsed as part of platform integration. |
-| Mcafee EPO            | `mcafee_epo`                                      | Prebuilt |
-| Microsoft IIS         | `iis`                                      | Prebuilt |
-| ModSecurity               | `modsecurity`                                  | No prebuilt pipeline. Auto-parsed as part of platform integration. |
-| MongoDB               | `mongodb`                                  | Prebuilt |
-| Monit                 | `monit`                                    | Prebuilt |
-| MySQL                 | `mysql`                                    | Prebuilt |
-| MySQL error           | `mysql_error`                              | Prebuilt |
-| MySQL monitor         | `mysql_monitor`                            | Prebuilt |
-| MySQL slow query      | `mysql_slow_query`                         | Prebuilt |
-| Nagios                | `nagios`                                   | Prebuilt |
-| NGINX access          | `nginx`, `nginx_access`, `nginx-access`    | Prebuilt |
-| NGINX error           | `nginx-error`                              | Prebuilt |
-| OpenVAS                 | `openvas`                                    | Prebuilt |
-| OSSEC                 | `ossec`                                    | Prebuilt |
-| Trend Micro                 | `trendmicro_deep`                    | Prebuilt |
-| Palo Alto Networks    | `paloalto`                                  | Prebuilt |
-| Performance-tab       | `performance-tab`                                  | Prebuilt |
-| Sonicwall                | `sonicwall`                                  | Prebuilt |
-| Sophos Intercept X       | `sophos-ep`                                  | No prebuilt pipeline. Auto-parsed as part of platform integration. |
-| Stormshield                | `stormshield`                              | Prebuilt |
-| Sysmon                | `wineventlog`                              | Prebuilt |
-| Windows WinEventLog          | `wineventlog`                             | Prebuilt |
-| Zeek           | `zeek`                              | Prebuilt |
-| Zipkin span           | `zipkinSpan`                             | Prebuilt |
+| Alcide kAudit         | `alcide-kaudit` | ⨯ Auto-parsed as part of platform integration. |
+| Apache access         | `apache`, `apache_access`, `apache-access` | ✔ |
+| Auditd                | `auditd`                                   | ✔ |
+| AWS CloudFront        | `cloudfront`                               | ✔ |
+| AWS CloudTrail        | `cloudtrail`                               | ✔ |
+| AWS ELB               | `elb`                                      | ✔ |
+| AWS Fargate           | `fargate`                                  | ⨯ Auto-parsed as part of platform integration. |
+| AWS GuardDuty             | `guardduty`                                | ✔ |
+| AWS Route 53          | `route_53`                                 | ✔ |
+| AWS S3 access         | `S3Access`                                 | ✔ |
+| AWS VPC Flow           | `vpcflow`                                  | ✔ |
+| AWS WAF         | `awswaf`                                 | ⨯ Auto-parsed as part of platform integration. |
+| Checkpoint            | `checkpoint`                               | ✔ |
+| Cisco ASA             | `cisco-asa`                                | ✔ |
+| Cisco Meraki          | `cisco-meraki`                             | ✔ |
+| Crowdstrike           | `crowdstrike`                              | ✔ |
+| Docker                | `docker_logs`                              | ✔ |
+| Docker Collector Logs | `docker-collector-logs`                    | ✔ |
+| Elasticsearch         | `elasticsearch`                            | ✔ |
+| Fail2ban              | `fail2ban`                                 | ✔ |
+| Falco                 | `falco`                                    | ✔ |
+| Fargate                 | `fargate`                                | ⨯ Auto-parsed as part of platform integration. |
+| Fortigate             | `fortigate`                               | ✔ |
+| GitHub                  | `github`                                     | ⨯ Auto-parsed as part of platform integration. |
+| GPFS                  | `gpfs`                                     | ✔ |
+| HAProxy Load Balancer              | `haproxy`                                  | ✔ |
+| Jenkins               | `jenkins`                                  | ✔ |
+| Juniper                  | `juniper`                             | ✔ |
+| Kafka                 | `kafka_server`                             | ✔ |
+| Kubernetes                 | `k8s`                             | ⨯ Auto-parsed as part of platform integration. |
+| Mcafee EPO            | `mcafee_epo`                                      | ✔ |
+| Microsoft IIS         | `iis`                                      | ✔ |
+| ModSecurity               | `modsecurity`                                  | ⨯ Auto-parsed as part of platform integration. |
+| MongoDB               | `mongodb`                                  | ✔ |
+| Monit                 | `monit`                                    | ✔ |
+| MySQL                 | `mysql`                                    | ✔ |
+| MySQL error           | `mysql_error`                              | ✔ |
+| MySQL monitor         | `mysql_monitor`                            | ✔ |
+| MySQL slow query      | `mysql_slow_query`                         | ✔ |
+| Nagios                | `nagios`                                   | ✔ |
+| NGINX access          | `nginx`, `nginx_access`, `nginx-access`    | ✔ |
+| NGINX error           | `nginx-error`                              | ✔ |
+| OpenVAS                 | `openvas`                                    | ✔ |
+| OSSEC                 | `ossec`                                    | ✔ |
+| Trend Micro                 | `trendmicro_deep`                    | ✔ |
+| Palo Alto Networks    | `paloalto`                                  | ✔ |
+| Performance-tab       | `performance-tab`                                  | ✔ |
+| Sonicwall                | `sonicwall`                                  | ✔ |
+| Sophos Intercept X       | `sophos-ep`                                  | ⨯ Auto-parsed as part of platform integration. |
+| Stormshield                | `stormshield`                              | ✔ |
+| Sysmon                | `wineventlog`                              | ✔ |
+| Windows WinEventLog          | `wineventlog`                             | ✔ |
+| Zeek           | `zeek`                              | ✔ |
+| Zipkin span           | `zipkinSpan`                             | ✔ |

--- a/_source/user-guide/log-shipping/built-in-log-types.md
+++ b/_source/user-guide/log-shipping/built-in-log-types.md
@@ -26,7 +26,7 @@ This table shows the log types that Logz.io parses automatically.
 | Description           | Type                                       | Prebuilt parsing pipeline unless marked |
 |-----------------------|--------------------------------------------|
 | Alcide kAudit         | `alcide-kaudit` | &#9746; Auto-parsed as part of platform integration. |
-| Apache access         | `apache`, `apache_access`, `apache-access` | &#9745; |
+| Apache access         | `apache`, `apache_access`, `apache-access` | :*:\check:: |
 | Auditd                | `auditd`                                   | Prebuilt |
 | AWS CloudFront        | `cloudfront`                               | Prebuilt |
 | AWS CloudTrail        | `cloudtrail`                               | Prebuilt |


### PR DESCRIPTION
# What changed

https://deploy-preview-1179--logz-docs.netlify.app/user-guide/log-shipping/built-in-log-types

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
