### PR TITLE
DOC-40: added Windows instructions for encrypted

### DIFF
--- a/_source/logzio_collections/_log-sources/logstash.md
+++ b/_source/logzio_collections/_log-sources/logstash.md
@@ -33,7 +33,7 @@ We recommend using it for shipping to Logz.io only when you have an existing Log
 
 For most other cases, we recommend using [Filebeat]({{site.baseurl}}/shipping/shippers/filebeat.html).
 
-These instructions apply to Logstash running on MacOS, Lunix and Windows.
+These instructions apply to Logstash running on MacOS, Linux and Windows.
 
 </div>
 <!-- tab:end -->

--- a/_source/logzio_collections/_log-sources/logstash.md
+++ b/_source/logzio_collections/_log-sources/logstash.md
@@ -33,6 +33,8 @@ We recommend using it for shipping to Logz.io only when you have an existing Log
 
 For most other cases, we recommend using [Filebeat]({{site.baseurl}}/shipping/shippers/filebeat.html).
 
+These instructions apply to Logstash running on MacOS, Lunix and Windows.
+
 </div>
 <!-- tab:end -->
 
@@ -50,12 +52,15 @@ For most other cases, we recommend using [Filebeat]({{site.baseurl}}/shipping/sh
 
 For HTTPS shipping, download the Logz.io public certificate to your certificate authority folder.
 
+* For MacOS and Linux:
 
 ```shell
 sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/AAACertificateServices.crt --create-dirs -o /usr/share/logstash/keys/COMODORSADomainValidationSecureServerCA.crt
 ```
 
+* For Windows:
 
+Download the [Logz.io public certificate]({% include log-shipping/certificate-path.md %}) to `C:\ProgramData\ElkStack\logstash-<<YOUR-LOGSTASH-VERSION-NUMBER>>\configLogzio.crt` on your machine.
 
 ##### Add Logz.io to your configuration file
 
@@ -66,6 +71,8 @@ Make sure the `mutate` block is the last item in the `filters` block.
 {% include log-shipping/log-shipping-token.html %}
 
 {% include log-shipping/listener-var.html %}
+
+* For MacOS and Linux:
 
 ```conf
 filter {
@@ -81,6 +88,27 @@ output {
     hosts => ["<<LISTENER-HOST>>"]
     port => 5006
     ssl_certificate => "/usr/share/logstash/keys/COMODORSADomainValidationSecureServerCA.crt"
+    codec => "json_lines"
+  }
+}
+```
+
+* For Windows:
+
+```conf
+filter {
+  # ...
+  # ...
+  mutate {
+    add_field => { "token" => "<<LOG-SHIPPING-TOKEN>>" }
+  }
+}
+
+output {
+  lumberjack {
+    hosts => ["<<LISTENER-HOST>>"]
+    port => 5006
+    ssl_certificate => "/C:\ProgramData\ElkStack\logstash-<<YOUR-LOGSTASH-VERSION-NUMBER>>\configLogzio.crt"
     codec => "json_lines"
   }
 }


### PR DESCRIPTION
# What changed

https://deploy-preview-1193--logz-docs.netlify.app/shipping/log-sources/logstash.html#encrypted

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
