### PR TITLE
DOC-141: Remove nxlog example from json uploads doc

### DIFF
--- a/_source/logzio_collections/_log-sources/json-uploads.md
+++ b/_source/logzio_collections/_log-sources/json-uploads.md
@@ -156,7 +156,7 @@ Using the certificate you just downloaded,
 send the logs to TCP port 5052.
 
 ```shell
-sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt --create-dirs -o /etc/pki/tls/certs/TrustExternalCARoot_and_USERTrustRSAAAACA.crt
+sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
 ```
 
 {% include /general-shipping/replace-placeholders.html %}
@@ -168,48 +168,6 @@ Give your logs some time to get from your system to ours, and then open [Kibana]
 If you still don't see your logs, see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
 
 </div>
-
-<!-- 21 April 2021 Removing NXLog scode sample: needs rewrite -->
-
-<!--  temporary deprecation starts here --.
-
-### Code sample: NXLog
-
-
-```conf
-User nxlog
-Group nxlog
-LogFile /var/log/nxlog/nxlog.log
-LogLevel INFO
-<Extension json>
-    Module      xm_json
-</Extension>
-<Input in>
-    Module  im_file
-    File    "/var/log/samples.log"
-    Exec    $token="<<LOG-SHIPPING-TOKEN>>"; $type="samples_log"; $message = $raw_event;
-    SavePos TRUE
-</Input>
-<Output out>
-    Module  om_ssl
-    CAFile /etc/nxlog/certs/COMODORSADomainValidationSecureServerCA.crt
-    AllowUntrusted FALSE
-    Host    <<LISTENER-HOST>>
-    Exec    $OutputModule="om_ssl"; to_json();
-    Port    5052
-</Output>
-<Route 1>
-    Path    in => out
-</Route>
-```
-
-.-- temporary deprecation of NXLog sample ends here 21 April 2021 -->
-
-<!-- info-box-start:info -->
-To configure NXLog for log shipping, see [Ship Windows logs (NXLog)]({{site.baseurl}}/shipping/log-sources/windows.html).
-{:.info-box.read}
-<!-- info-box-end -->
-
 
 
 </div>

--- a/_source/logzio_collections/_log-sources/json-uploads.md
+++ b/_source/logzio_collections/_log-sources/json-uploads.md
@@ -152,10 +152,10 @@ Keep to these practices when shipping JSON logs over TCP:
 
 ##### Send the logs
 
-Using the certificate you just downloaded,
-send the logs to TCP port 5052.
-
-{% include log-shipping/replace-vars.html %}
+  Using the certificate you just downloaded,
+send the logs to TCP port 5052 at
+<!-- logzio-inject:listener-url -->
+{% include log-shipping/replace-vars.html listener='noReplace' isMidSentence=true %}
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_log-sources/json-uploads.md
+++ b/_source/logzio_collections/_log-sources/json-uploads.md
@@ -155,11 +155,7 @@ Keep to these practices when shipping JSON logs over TCP:
 Using the certificate you just downloaded,
 send the logs to TCP port 5052.
 
-```shell
-sudo curl https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt --create-dirs -o /etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt
-```
-
-{% include /general-shipping/replace-placeholders.html %}
+{% include log-shipping/replace-vars.html listener='noReplace' isMidSentence=true %}
 
 ##### Check Logz.io for your logs
 

--- a/_source/logzio_collections/_log-sources/json-uploads.md
+++ b/_source/logzio_collections/_log-sources/json-uploads.md
@@ -155,7 +155,7 @@ Keep to these practices when shipping JSON logs over TCP:
 Using the certificate you just downloaded,
 send the logs to TCP port 5052.
 
-{% include log-shipping/replace-vars.html listener='noReplace' isMidSentence=true %}
+{% include log-shipping/replace-vars.html %}
 
 ##### Check Logz.io for your logs
 


### PR DESCRIPTION
# What changed

https://deploy-preview-1204--logz-docs.netlify.app/shipping/log-sources/json-uploads.html#tcp-config

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
