### PR TITLE
Fix some typo in documentation

### DIFF
--- a/_source/logzio_collections/_log-sources/dotnet.md
+++ b/_source/logzio_collections/_log-sources/dotnet.md
@@ -93,15 +93,15 @@ var logzioAppender = new LogzioAppender();
 logzioAppender.AddToken("<<LOG-SHIPPING-TOKEN>>");
 logzioAppender.AddType("log4net");
 logzioAppender.AddListenerUrl("https://<<LISTENER-HOST>>:8071");
-logzioAppender.AddBufferSize("100");
-logzioAppender.AddBufferTimeout("00:00:05");
-logzioAppender.AddRetriesMaxAttempts("3");
-logzioAppender.AddRetriesInterval("00:00:02");
+logzioAppender.AddBufferSize(100);
+logzioAppender.AddBufferTimeout(TimeSpan.FromSeconds(5));
+logzioAppender.AddRetriesMaxAttempts(3);
+logzioAppender.AddRetriesInterval(TimeSpan.FromSeconds(2));
 logzioAppender.AddDebug(false);
 logzioAppender.AddGzip(true);
 // <-- Uncomment and edit this line to enable proxy routing: --> 
 // logzioAppender.AddProxyAddress("http://your.proxy.com:port");
-// <-- Uncomment this to prase messages as Json -->  
+// <-- Uncomment this to parse messages as Json -->  
 // logzioAppender.ParseJsonMessage(true);
 hierarchy.Root.AddAppender(logzioAppender);
 hierarchy.Configured = true;

--- a/_source/logzio_collections/_log-sources/dotnet.md
+++ b/_source/logzio_collections/_log-sources/dotnet.md
@@ -101,7 +101,7 @@ logzioAppender.AddDebug(false);
 logzioAppender.AddGzip(true);
 // <-- Uncomment and edit this line to enable proxy routing: --> 
 // logzioAppender.AddProxyAddress("http://your.proxy.com:port");
-// <-- Uncomment this to parse messages as Json -->  
+// <-- Uncomment this to parse messages as JSON -->  
 // logzioAppender.ParseJsonMessage(true);
 hierarchy.Root.AddAppender(logzioAppender);
 hierarchy.Configured = true;

--- a/_source/logzio_collections/_log-sources/dotnet.md
+++ b/_source/logzio_collections/_log-sources/dotnet.md
@@ -81,6 +81,7 @@ For a complete list of options, see the configuration parameters below the code 
   </root>
 </log4net>
 ```
+
 Add a reference to the configuration file in your code, as shown in the example [here](https://github.com/logzio/logzio-dotnet/blob/master/sample-applications/LogzioLog4netSampleApplication/Program.cs).
 
 ###### Option 2: In the code
@@ -119,11 +120,9 @@ hierarchy.Configured = true;
 | retriesMaxAttempts | Maximum number of attempts to connect to Logz.io. | `3` |
 | retriesInterval | Time to wait between retries, as _hh:mm:ss.fff_. | `00:00:02` |
 | gzip | To compress the data before shipping, `true`. Otherwise, `false`. | `false` |
-| debug | To print debug messages to the console and trace log, `true`. Otherwise, `false`. | `false` 
+| debug | To print debug messages to the console and trace log, `true`. Otherwise, `false`. | `false`
 | parseJsonMessage | To parse your message as JSON format, add this field and set it to `true`. | `false` |
 | proxyAddress | Proxy address to route your logs through. | `None` |
-
-
 
 ###### Code sample
 
@@ -167,7 +166,7 @@ These custom fields must be children of `<appender>`, as shown here.
   <customField>
     <key>Environment</key>
     <value>Production</value>
-  <customField>
+  </customField>
   <customField>
     <key>Location</key>
     <value>New Jerseay B1</value>
@@ -195,7 +194,6 @@ For the example above, you'd use `MyAppLogzioAppender`.
 
 </div>
 <!-- tab:end -->
-
 
 <!-- tab:start -->
 <div id="nlog-config">
@@ -225,7 +223,6 @@ You can configure the appender in a configuration file or directly in the code.
 Use the samples in the code blocks below as a starting point, and replace them with a configuration that matches your needs. See [NLog documentation 🔗](https://github.com/NLog/NLog/wiki/Configuration-file) to learn more about configuration options.
 
 For a complete list of options, see the configuration parameters below the code blocks.👇
-
 
 ###### Option 1: In a configuration file
 
@@ -261,7 +258,6 @@ For a complete list of options, see the configuration parameters below the code 
 
 ###### Option 2: In the code
 
-
 ```csharp
 var config = new LoggingConfiguration();
 
@@ -284,9 +280,7 @@ config.AddRule(LogLevel.Debug, LogLevel.Fatal, logzioTarget);
 LogManager.Configuration = config;
 ```
 
-
 ###### Parameters
-
 
 | Parameter | Description | Default/Required |
 |---|---|---|
@@ -300,7 +294,6 @@ LogManager.Configuration = config;
 | debug | To print debug messages to the console and trace log, `true`. Otherwise, `false`. | `false` |
 | parseJsonMessage | To parse your message as JSON format, add this field and set it to `true`. | `false` |
 | proxyAddress | Proxy address to route your logs through. | `None` |
-
 
 ###### Code sample
 
@@ -372,7 +365,7 @@ When using 'JsonLayout' set the name of the attribute to **other than** 'message
 
 ```xml
 <layout type="JsonLayout" includeAllProperties="true">
-	<attribute name="msg"  layout="${message}" encode="false"/>
+ <attribute name="msg"  layout="${message}" encode="false"/>
 </layout>
 ```
 
@@ -441,7 +434,6 @@ For a complete list of options, see the configuration parameters below the code 
 </log4net>
 ```
 
-
 ###### Option 2: In the code
 
 ```csharp
@@ -478,11 +470,9 @@ hierarchy.Configured = true;
 | retriesMaxAttempts | Maximum number of attempts to connect to Logz.io. | `3` |
 | retriesInterval | Time to wait between retries, as _hh:mm:ss.fff_. | `00:00:02` |
 | gzip | To compress the data before shipping, `true`. Otherwise, `false`. | `false` |
-| debug | To print debug messages to the console and trace log, `true`. Otherwise, `false`. | `false` 
+| debug | To print debug messages to the console and trace log, `true`. Otherwise, `false`. | `false`
 | parseJsonMessage | To parse your message as JSON format, add this field and set it to `true`. | `false` |
 | proxyAddress | Proxy address to route your logs through. | `None` |
-
-
 
 ###### Code sample
 
@@ -580,7 +570,7 @@ These custom fields must be children of `<appender>`, as shown in the code below
   <customField>
     <key>Environment</key>
     <value>Production</value>
-  <customField>
+  </customField>
   <customField>
     <key>Location</key>
     <value>New Jerseay B1</value>


### PR DESCRIPTION
# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

Fix some typo or error in the dotnet documentation

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
