### PR TITLE
Refactoring of the Tracing page structure + new document on Java auto instrumentation

### DIFF
--- a/_source/_data/shipper-tabs.yml
+++ b/_source/_data/shipper-tabs.yml
@@ -68,7 +68,7 @@ tags:
     name: CI/CD
     order: 4
   - slug: components
-    name: Tracing components   
+    name: Tracing components
     order: 5
   - slug: container
     name: Containers & pods
@@ -82,60 +82,66 @@ tags:
   - slug: endpoint-security
     name: Endpoint security
     order: 8
+  - slug: existing-instrumentation
+    name: My code is instrumented
+    order: 9
   - slug: firewalls
     name: Firewalls
-    order: 9
+    order: 10
   - slug: from-your-code
     name: From your code
-    order: 10
+    order: 11
   - slug: gcp
     name: Google Cloud
-    order: 11
+    order: 12
   - slug: ids
     name: IDS
-    order: 12
+    order: 13
   - slug: identity
     name: Identity providers
-    order: 13
+    order: 14
   - slug: instrumentation
     name: Tracing instrumentation      
-    order: 14
+    order: 15
   - slug: k8s
     name: K8S
-    order: 15
+    order: 16
   - slug: linux
     name: Linux security
-    order: 16
+    order: 17
   - slug: networking
     name: Networking
-    order: 17
+    order: 18
+  - slug: new-instrumentation
+    name: My code is not instrumented   
+    order: 19
   - slug: platform-service
     name: Platforms & services
-    order: 18
+    order: 20
   - slug: prometheus
     name: Prometheus as a service
-    order: 20
+    order: 21
   - slug: os
     name: Operating systems
-    order: 21
+    order: 22
   - slug: security
     name: Security
-    order: 22
+    order: 23
   - slug: server-app
     name: Server apps & devices
-    order: 23 
+    order: 24
   - slug: traces
     name: Tracing
-    order: 24
+    order: 25
   - slug: vulnerability-scanners
     name: Vulnerability scanners
-    order: 25
+    order: 26
   - slug: web-firewalls
     name: Web application firewalls
-    order: 26
+    order: 27
   - slug: windows
     name: Windows security
-    order: 27
+    order: 28
 
 
 

--- a/_source/logzio_collections/_tracing-sources/cs_open_tracing-auto.md
+++ b/_source/logzio_collections/_tracing-sources/cs_open_tracing-auto.md
@@ -12,8 +12,7 @@ contributors:
   - yyyogev
   - yberlinger
 shipping-tags:
-  - instrumentation
-  - tracing
+  - new-instrumentation
 order: 970
 ---
 

--- a/_source/logzio_collections/_tracing-sources/cs_open_tracing-manual.md
+++ b/_source/logzio_collections/_tracing-sources/cs_open_tracing-manual.md
@@ -12,8 +12,7 @@ contributors:
   - yyyogev
   - yberlinger
 shipping-tags:
-  - instrumentation
-  - tracing 
+  - new-instrumentation
 order: 980
 ---
 

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -13,7 +13,7 @@ contributors:
   - yberlinger
   - doron-bargo
 shipping-tags:
-  - components
+  - existing-instrumentation
 order: 300
 ---
 

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -1,0 +1,157 @@
+---
+title: Sending traces from Java applications via auto instrumentation with OpenTelemetry
+logo:
+  logofile: java.svg
+  orientation: vertical
+data-source: Automatic Java instrumentation
+templates: ["network-device-filebeat"]
+contributors:
+  - nshishkin
+shipping-tags:
+  - new-instrumentation
+order: 1380
+---
+
+<!-- tabContainer:start -->
+<div class="branching-container">
+
+* [Overview](#overview)
+* [Local host](#local-host)
+{:.branching-tabs}
+
+<!-- tab:start -->
+<div id="overview">
+
+Deploy this integration to enable automatic instrumentation of your Java application using OpenTelemetry.
+
+### Architecture overview
+
+This integration includes:
+
+* Downloading the OpenTelemetry Java agent to your application host
+* Installing the OpenTelemetry collector with Logz.io exporter
+* Establishing communication between the agent and collector
+
+Upon deployment, the Java agent automatically captures spans from your application and forwards them the collector, which exports the data to your Logz.io account.
+
+</div>
+<!-- tab:end -->
+
+
+<!-- tab:start -->
+<div id="local-host">
+
+
+### Connect your Crowdstrike account to Logz.io
+
+**Before you begin, you'll need**:
+
+* a Java application without instrumentation
+* an active account with Logz.io
+
+
+<div class="tasklist">
+
+
+##### Define the port for the collector
+
+By default, the OpenTelemetry Java agent uses OTLP exporter configured to send data to OpenTelemetry collector at `http://localhost:4317` via gRPC. Make sure that port `4317` is available on your host system.
+
+##### Define a name for your tracing service
+
+Your tracing service name is used to identify your service.
+
+##### Download Java agent
+
+Download the latest version of the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent-all.jar) to the host of your Java application.
+
+##### Download and configure OpenTelemetry collector
+
+Create a dedicated directory on the host of your Java application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
+
+<!-- info-box-start:info -->
+**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
+The expected resolution period for this issue is end of June 2021.
+{:.info-box.important}
+<!-- info-box-end -->
+
+After downloading the collector, create a configuration file `config.yaml` with the following parameters:
+
+```yaml
+
+receivers:  
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:4317"
+
+exporters:
+  logzio:
+    account_token: "<<TRACING-SHIPPING-TOKEN>>"
+    #region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is different than US East. https://docs.logz.io/user-guide/accounts/account-region.html#available-regions
+
+processors:
+  batch:
+
+extensions:
+  pprof:
+    endpoint: :1777
+  zpages:
+    endpoint: :55679
+  health_check:
+
+service:
+  extensions: [health_check, pprof, zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logzio]
+
+```
+
+{% include /tracing-shipping/replace-tracing-token.html %}
+
+
+##### Start the collector
+
+Run the following command:
+
+```shell
+
+<path/to>/otelcontribcol_<version_name> --config ./config.yaml
+
+```
+* Replace `<path/to>` to the path to the directory where you downloaded the collector.
+* Replace `<version_name>` with the version name of the collector applicable to your system, e.g. `otelcontribcol_darwin_amd64`.
+
+##### Attach the agent to the collector and run it
+
+Run the following command from the directory of your Java application:
+
+```shell
+
+java -javaagent:<path/to>/opentelemetry-javaagent-all.jar \
+     -Dotel.traces.exporter=otlp \
+     -Dotel.metrics.exporter=none \
+     -Dotel.resource.attributes=service.name=your-service-name \
+     -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+     -jar target/*.jar
+
+```
+
+* Replace `<path/to>` to the path to the directory where you downloaded the agent.
+* Replace `your-service-name` with the name of your tracing service defined earlier.
+
+
+##### Check Logz.io for your traces
+
+Give your traces some time to get from your system to ours, and then open [Tracing](https://app.logz.io/#/dashboard/jaeger).
+
+</div>
+
+</div>
+<!-- tab:end -->
+
+</div>
+<!-- tabContainer:end -->

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -42,7 +42,7 @@ On deployment, the Java agent automatically captures spans from your application
 <div id="local-host">
 
 
-### Connect your Crowdstrike account to Logz.io
+### Setup auto-instrumentation for your Java application and send traces to Logz.io
 
 **Before you begin, you'll need**:
 

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -42,7 +42,7 @@ On deployment, the Java agent automatically captures spans from your application
 <div id="local-host">
 
 
-### Setup auto-instrumentation for your Java application and send traces to Logz.io
+### Setup auto-instrumentation for your locally hosted Java application and send traces to Logz.io
 
 **Before you begin, you'll need**:
 

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -70,8 +70,8 @@ Download the latest version of the [OpenTelemetry Java agent](https://github.com
 Create a dedicated directory on the host of your Java application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
 
 <!-- info-box-start:info -->
-**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
-The expected resolution period for this issue is end of June 2021.
+**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your OpenTelemetry collector with version 0.23 or lower.
+The expected resolution for this issue is later this year.
 {:.info-box.important}
 <!-- info-box-end -->
 

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -32,7 +32,7 @@ This integration includes:
 * Installing the OpenTelemetry collector with Logz.io exporter
 * Establishing communication between the agent and collector
 
-Upon deployment, the Java agent automatically captures spans from your application and forwards them to the collector, which exports the data to your Logz.io account.
+On deployment, the Java agent automatically captures spans from your application and forwards them to the collector, which exports the data to your Logz.io account.
 
 </div>
 <!-- tab:end -->

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -48,18 +48,12 @@ On deployment, the Java agent automatically captures spans from your application
 
 * a Java application without instrumentation
 * an active account with Logz.io
+* port `4317` available on your host system
+* a name defined for your tracing service
 
 
 <div class="tasklist">
 
-
-##### Define the port for the collector
-
-By default, the OpenTelemetry Java agent uses OTLP exporter configured to send data to OpenTelemetry collector at `http://localhost:4317` via gRPC. Make sure that port `4317` is available on your host system.
-
-##### Define a name for your tracing service
-
-Your tracing service name is used to identify your service.
 
 ##### Download Java agent
 

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -113,11 +113,11 @@ Run the following command:
 
 ```shell
 
-<path/to>/otelcontribcol_<version_name> --config ./config.yaml
+<path/to>/otelcontribcol_<VERSION-NAME> --config ./config.yaml
 
 ```
 * Replace `<path/to>` with the path to the directory where you downloaded the collector.
-* Replace `<version_name>` with the version name of the collector applicable to your system, e.g. `otelcontribcol_darwin_amd64`.
+* Replace `<VERSION-NAME>` with the version name of the collector applicable to your system, e.g. `otelcontribcol_darwin_amd64`.
 
 ##### Attach the agent to the collector and run it
 
@@ -128,14 +128,14 @@ Run the following command from the directory of your Java application:
 java -javaagent:<path/to>/opentelemetry-javaagent-all.jar \
      -Dotel.traces.exporter=otlp \
      -Dotel.metrics.exporter=none \
-     -Dotel.resource.attributes=service.name=your-service-name \
+     -Dotel.resource.attributes=service.name=<YOUR-SERVICE-NAME> \
      -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
      -jar target/*.jar
 
 ```
 
 * Replace `<path/to>` with the path to the directory where you downloaded the agent.
-* Replace `your-service-name` with the name of your tracing service defined earlier.
+* Replace `<YOUR-SERVICE-NAME>` with the name of your tracing service defined earlier.
 
 
 ##### Check Logz.io for your traces

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -32,7 +32,7 @@ This integration includes:
 * Installing the OpenTelemetry collector with Logz.io exporter
 * Establishing communication between the agent and collector
 
-Upon deployment, the Java agent automatically captures spans from your application and forwards them the collector, which exports the data to your Logz.io account.
+Upon deployment, the Java agent automatically captures spans from your application and forwards them to the collector, which exports the data to your Logz.io account.
 
 </div>
 <!-- tab:end -->
@@ -122,7 +122,7 @@ Run the following command:
 <path/to>/otelcontribcol_<version_name> --config ./config.yaml
 
 ```
-* Replace `<path/to>` to the path to the directory where you downloaded the collector.
+* Replace `<path/to>` with the path to the directory where you downloaded the collector.
 * Replace `<version_name>` with the version name of the collector applicable to your system, e.g. `otelcontribcol_darwin_amd64`.
 
 ##### Attach the agent to the collector and run it
@@ -140,7 +140,7 @@ java -javaagent:<path/to>/opentelemetry-javaagent-all.jar \
 
 ```
 
-* Replace `<path/to>` to the path to the directory where you downloaded the agent.
+* Replace `<path/to>` with the path to the directory where you downloaded the agent.
 * Replace `your-service-name` with the name of your tracing service defined earlier.
 
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -13,7 +13,7 @@ contributors:
   - yberlinger
   - doron-bargo
 shipping-tags:
-  - components
+  - existing-instrumentation
 order: 330
 ---
 ## Overview


### PR DESCRIPTION
# What changed

Structure of tracing SYD: https://deploy-preview-1217--logz-docs.netlify.app/shipping/#tracing-sources

Java auto instrumentation: https://deploy-preview-1217--logz-docs.netlify.app/shipping/tracing-sources/java-otel-auto.html

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
