### PR TITLE
Revert CSP headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,6 @@
   for = "/*"
   [headers.values]
     Strict-Transport-Security = "max-age=31536000; includeSubDomains;"
-    Content-Security-Policy = "default-src 'self' logz.io *.logz.io"
     X-Content-Type-Options = "nosniff"
 
 


### PR DESCRIPTION
missing csp

```
Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Either the 'unsafe-inline' keyword, a hash ('sha256-m6LLxclyRtUyKJv7W6YqJfXyFhjoqwYL6hEL85BKkYo='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:20 Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Either the 'unsafe-inline' keyword, a hash ('sha256-Q7UDa1GrlTa15wiAIFvw+Gfj1hlT1GqTf9eUxrSldYs='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:26 Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Either the 'unsafe-inline' keyword, a hash ('sha256-afKegVSrTShzGXueUZ8xjwAJzDqzjw0WTFrL7+P116c='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:1 Refused to load the script 'https://use.fontawesome.com/releases/v5.0.9/js/all.js' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'script-src-elem' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:30 Refused to load the stylesheet 'https://use.fontawesome.com/releases/v5.0.10/css/all.css' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'style-src-elem' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:33 Refused to load the stylesheet 'https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'style-src-elem' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:1 Refused to load the image 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAeCAYAAAAy2w7YAAAAAXNSR0IArs4c6QAAAmdJREFUSA3Flj1rFFEUhh0VAjEfEhNQoiBmgyKIRZLKZqOghVhYpNAy4EIsFG20Eiv9E/4DISZFfkIEo4UgSWGMWKlgihQmhRDX592dMx7v3p3ZWVg88Ow93+fOnZ2dTQ4USL1eHyPlJlyH83AcJN9hA1ZgMUmSbdbywoABeA4/oUiU8wwGSk2i4BxsQFlZp+BsR8NInITtshNc/g/0Su4wEo7ApivqVv2oXn7YQW+gP4ZwN7v4XsJnCEU+xfaCwCT2o8DXNNnBEOxFLqGqDPzD4K9Wux5KY7OROvUaVPwfwXk7krzqk4jfdzn3gthrFzP1luX4o6ua063rTpeq58YkjIW28qqW7AedNKdbjzpd6rCzw1hoKzXr6QeNuiamXuEM+s1gvRHT05zLLmbqMVOyleQ1O9hgXcK+CA9h38WkPwDFlp3fq2+yAaYQbTfIF5bVs0H+6GymX79hiCL5SkJuXtGgEzRYgLWcSYrdBeW2lcNtI38Dd1AvgV4Tc2C/HJ/Q9auwAsvQmRTcoyftulD3NOfGZfcoqyf5bU6BQoswYQXoFXgFeZIdeeIKdRRZI/NHVr1ZJfambVrxzy3evI2jbgxiS33k7cKheH7X3n0q+xn2y751Uz0Yot1p4zNSbNA1GT2Sq+qbcGw6vk3o5P6opqzo5VjRFc1Cr4ZoU2c0Q4NqsnosNR3dDkP0nvkNH0DHeBqmoRt5R9EX0P+GC6CL2dF/gXmYgxEcDUHXBl5AWVFN45FRI/QRUO/5ZufIJ8FBeA8mqyg1GE+RLp+Jclv/jER6t7go7IMqnGoJpg7F0hw99P9f/gBf4Jq0CsaoiAAAAABJRU5ErkJggg==' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:1 Refused to load the image 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+DQo8c3ZnIHdpZHRoPSIxOHB4IiBoZWlnaHQ9IjE4cHgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4NCiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDQwICgzMzc2MikgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+DQogICAgPHRpdGxlPmJyZWFraW5ncGFnZTwvdGl0bGU+DQogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+DQogICAgPGRlZ...40MTA0NDQxIEwxNS4zMzEyNjc3LDEzLjQxMDQ0NDEgTDE0LjQ3Mzk0MDcsMTIuNTk4NjYzOSBMMTcuMjA3MzUwNiwxMC40NjY4MzM5IEwxMy4wNjA3ODIxLDEwLjQ2NjgzMzkgTDEzLjQ5NjI5NzcsNy4zNDg2OTUgTDExLjA5OTg1MzIsOC44Nzg5NDUwNSBMMTAuMTIxMjAyNiwyLjg5Mjc3MTMgTDcuODc3NzIyNTgsOC40MjU0OTI4NSBMNC41NzA1NDQ0Nyw2LjIwMzk4MDEgTDUuNjY1NDgwNDEsMTAuNzUwMzkyNyBMMi45NTEwMTQ3MiwxMS41OTgyNDc2IEw1LjEzNjQ1MjgzLDEzLjQxMDQ0NDEgTDYuNzE1Njc1NzIsMTMuNDEwNDQ0MSBaIiBpZD0iYnJlYWtpbmdwYWdlIj48L3BhdGg+DQogICAgICAgICAgICA8L2c+DQogICAgICAgIDwvZz4NCiAgICA8L2c+DQo8L3N2Zz4=' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:1 Refused to load the image 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+DQo8c3ZnIHdpZHRoPSIxN3B4IiBoZWlnaHQ9IjE3cHgiIHZpZXdCb3g9IjAgMCAxNyAxNyIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4NCiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDQwICgzMzc2MikgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+DQogICAgPHRpdGxlPnNsb3d0cmFja2VyczwvdGl0bGU+DQogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+DQogICAgPGRlZ...MyNSAzOTguMDQ2NzUzLDQ1OS4wMDk1MTIgTDM5OC4yMjAyNzgsNDYxLjk5OTk5NyBMMzk4LjIyMDI3OCw0NjIuMDA1MTggQzM5OC4yMjAyNzgsNDY0LjA5NzYxNyAzOTkuNDE3MzczLDQ2NS44MDI4OTIgNDAxLjUxMDcxMiw0NjUuODAxMDg5IEM0MDMuNjIyNTMxLDQ2NS43OTgzODUgNDA5LjYwODY4Myw0NjUuODAxMDg5IDQwOS42MDg2ODMsNDY1LjgwMTA4OSBDNDA5Ljc4MTA4MSw0NjUuODAxMDg5IDQwOS45MjAzNTEsNDY1LjY2MTE0MyA0MDkuOTIwMzUxLDQ2NS40ODk0MjEgQzQwOS45MjAzNTEsNDY1LjMxNzAyMyA0MDkuNzczMTkzLDQ2NS4yMzA3MTEgNDA5LjYwOTU4NCw0NjUuMTc4NjU0IFoiPjwvcGF0aD4NCiAgICAgICAgPC9nPg0KICAgIDwvZz4NCjwvc3ZnPg==' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:1 Refused to load the image 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+DQo8c3ZnIHdpZHRoPSIxOHB4IiBoZWlnaHQ9IjE4cHgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4NCiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDQwICgzMzc2MikgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+DQogICAgPHRpdGxlPndhcm5pbmc8L3RpdGxlPg0KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPg0KICAgIDxkZWZzPjwvZ...IyNDc1LDExLjc4OTM2OCAxMi4wNTgyNjk5LDExLjc4OTM2OCBDMTIuMzUzNjcwOCwxMS43ODkzNjggMTIuNjI0NzE4OCwxMS42OTkzODQgMTIuODM5NzU1LDExLjU1OTU5ODIgQzExLjAwOTUxMTUsOC43MTgwOTk3NSAxMi4xNDUzMzE2LDQuMTM3NjgxMTYgMTIuMTQ1MzMxNiw0LjEzNzY4MTE2IEM2Ljk0NjQ3MDYzLDUuMjMxNjE0MjQgNC42NjU4MTk4NSwxMC4xMDAzNzE0IDQuMDU3OTcxMDEsMTEuNjY2MTQyMiBDNC4yMzI5NDY3MywxMS43NDMyMTkyIDQuNDMxNzg4MzEsMTEuNzg5ODU1MSA0LjY0MjkyODExLDExLjc4OTg1NTEgWiIgaWQ9Indhcm5pbmd0cmFja2VycyI+PC9wYXRoPg0KICAgICAgICAgICAgPC9nPg0KICAgICAgICA8L2c+DQogICAgPC9nPg0KPC9zdmc+' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:1 Refused to load the image 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+DQo8c3ZnIHdpZHRoPSIxNXB4IiBoZWlnaHQ9IjE1cHgiIHZpZXdCb3g9IjAgMCAxNSAxNSIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4NCiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDMuNy4yICgyODI3NikgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+DQogICAgPHRpdGxlPmNvbGxhcHNlIGNvcHkgMjwvdGl0bGU+DQogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+DQogI...k9IjcuNSIgcj0iNy41Ij48L2NpcmNsZT4NCiAgICAgICAgICAgIDxwYXRoIGQ9Ik00LjM2LDQuMzYgTDEwLjU3NDU2MzQsMTAuNTc0NTYzNCIgaWQ9IkxpbmUiIHN0cm9rZT0iI0ZGRkZGRiIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSI+PC9wYXRoPg0KICAgICAgICAgICAgPHBhdGggZD0iTTQuMzYsNC4zNiBMMTAuNTc0NTYzNCwxMC41NzQ1NjM0IiBpZD0iTGluZS1Db3B5IiBzdHJva2U9IiNGRkZGRkYiIHN0cm9rZS1saW5lY2FwPSJzcXVhcmUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDcuNjAwMDAwLCA3LjYwMDAwMCkgc2NhbGUoLTEsIDEpIHRyYW5zbGF0ZSgtNy42MDAwMDAsIC03LjYwMDAwMCkgIj48L3BhdGg+DQogICAgICAgIDwvZz4NCiAgICA8L2c+DQo8L3N2Zz4=' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.

jquery.ba-hashchange.min.js:9 Uncaught TypeError: Cannot read property 'msie' of undefined
    at jquery.ba-hashchange.min.js:9
    at jquery.ba-hashchange.min.js:9
    at jquery.ba-hashchange.min.js:9
(anonymous) @ jquery.ba-hashchange.min.js:9
(anonymous) @ jquery.ba-hashchange.min.js:9
(anonymous) @ jquery.ba-hashchange.min.js:9
docs.logz.io/:50 Refused to load the stylesheet 'https://fonts.googleapis.com/css?family=Lato:400,400i,500,500i,600,600i,700,700i,800,800i&display=swap' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'style-src-elem' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:50 Refused to load the stylesheet 'https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'style-src-elem' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:54 Refused to load the stylesheet 'https://fonts.googleapis.com/css?family=Lato:400,400i,500,500i,600,600i,700,700i,800,800i&display=swap' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'style-src-elem' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:54 Refused to load the stylesheet 'https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'style-src-elem' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:1 Refused to load the stylesheet 'https://fonts.googleapis.com/css?family=Lato:200,400' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'style-src-elem' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:1 Refused to load the stylesheet 'https://fonts.googleapis.com/css?family=Lato:200,400' because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Note that 'style-src-elem' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:119 Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Either the 'unsafe-inline' keyword, a hash ('sha256-SFczXEfmyW4bbzWtLtbez+aKOdBzUfA5p6qMHghBWJY='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.

docs.logz.io/:1294 Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self' logz.io *.logz.io". Either the 'unsafe-inline' keyword, a hash ('sha256-C87waPXIclOrrpubcglnzBlguKNEv34PbGOF4nJ8K5o='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.
```