### PR TITLE
Added note - otel collector

### DIFF
--- a/_source/_includes/tracing-shipping/otel_bug_june2021.md
+++ b/_source/_includes/tracing-shipping/otel_bug_june2021.md
@@ -1,0 +1,5 @@
+<!-- info-box-start:info -->
+**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
+The resolution for this issue is in development and is expected later this year.
+{:.info-box.important}
+<!-- info-box-end -->

--- a/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
@@ -98,6 +98,12 @@ public void ConfigureServices(IServiceCollection services)
 
 ##### Download and configure OpenTelemetry collector
 
+<!-- info-box-start:info -->
+**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
+The resolution for this issue is in development.
+{:.info-box.important}
+<!-- info-box-end -->
+
 Create a dedicated directory on the host of your ASP.NET Core application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
 
 

--- a/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
@@ -98,11 +98,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ##### Download and configure OpenTelemetry collector
 
-<!-- info-box-start:info -->
-**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
-The resolution for this issue is in development.
-{:.info-box.important}
-<!-- info-box-end -->
+{% include tracing-shipping/otel_bug_june2021.md %}
 
 Create a dedicated directory on the host of your ASP.NET Core application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
 

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -61,11 +61,7 @@ Download the latest version of the [OpenTelemetry Java agent](https://github.com
 
 ##### Download and configure OpenTelemetry collector
 
-<!-- info-box-start:info -->
-**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
-The resolution for this issue is in development.
-{:.info-box.important}
-<!-- info-box-end -->
+{% include tracing-shipping/otel_bug_june2021.md %}
 
 Create a dedicated directory on the host of your Java application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
 

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -61,6 +61,12 @@ Download the latest version of the [OpenTelemetry Java agent](https://github.com
 
 ##### Download and configure OpenTelemetry collector
 
+<!-- info-box-start:info -->
+**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
+The resolution for this issue is in development.
+{:.info-box.important}
+<!-- info-box-end -->
+
 Create a dedicated directory on the host of your Java application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
 
 After downloading the collector, create a configuration file `config.yaml` with the following parameters:

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -38,11 +38,7 @@ OpenTelemetry also includes extensions for additional functionality, such as dia
 
 #### Deploy OpenTelemetry Collector with Logz.io Exporter
 
-<!-- info-box-start:info -->
-**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
-The resolution for this issue is in development.
-{:.info-box.important}
-<!-- info-box-end -->
+{% include tracing-shipping/otel_bug_june2021.md %}
 
 <div class="tasklist">
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -38,6 +38,12 @@ OpenTelemetry also includes extensions for additional functionality, such as dia
 
 #### Deploy OpenTelemetry Collector with Logz.io Exporter
 
+<!-- info-box-start:info -->
+**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
+The resolution for this issue is in development.
+{:.info-box.important}
+<!-- info-box-end -->
+
 <div class="tasklist">
 
 ##### Create a Docker network

--- a/_source/logzio_collections/_tracing-sources/python-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/python-otel-auto.md
@@ -79,6 +79,12 @@ Replace `<YOUR-SERVICE-NAME>` with the name of your tracing service defined earl
 
 ##### Download and configure OpenTelemetry collector
 
+<!-- info-box-start:info -->
+**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
+The resolution for this issue is in development.
+{:.info-box.important}
+<!-- info-box-end -->
+
 Create a dedicated directory on the host of your Python application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
 
 After downloading the collector, create a configuration file `config.yaml` with the parameters below.

--- a/_source/logzio_collections/_tracing-sources/python-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/python-otel-auto.md
@@ -79,11 +79,7 @@ Replace `<YOUR-SERVICE-NAME>` with the name of your tracing service defined earl
 
 ##### Download and configure OpenTelemetry collector
 
-<!-- info-box-start:info -->
-**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
-The resolution for this issue is in development.
-{:.info-box.important}
-<!-- info-box-end -->
+{% include tracing-shipping/otel_bug_june2021.md %}
 
 Create a dedicated directory on the host of your Python application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
 

--- a/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
@@ -112,11 +112,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:55681
 
 ##### Download and configure OpenTelemetry collector
 
-<!-- info-box-start:info -->
-**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
-The resolution for this issue is in development.
-{:.info-box.important}
-<!-- info-box-end -->
+{% include tracing-shipping/otel_bug_june2021.md %}
 
 Create a dedicated directory on the host of your Ruby application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
 

--- a/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
@@ -112,6 +112,12 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:55681
 
 ##### Download and configure OpenTelemetry collector
 
+<!-- info-box-start:info -->
+**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
+The resolution for this issue is in development.
+{:.info-box.important}
+<!-- info-box-end -->
+
 Create a dedicated directory on the host of your Ruby application and download the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.23.0) that is relevant to the operating system of your host.
 
 

--- a/_source/user-guide/distributed-tracing/deploying-components.md
+++ b/_source/user-guide/distributed-tracing/deploying-components.md
@@ -39,11 +39,7 @@ We recommend that you use the OpenTelemetry collector to gather trace transactio
 See _<a href ="/shipping/tracing-sources/opentelemetry" target="_blank">Installing the OpenTelemetry Collector for Distributed Tracing</a>_ for the procedure to configure and deploy the OpenTelemetry collector.
 
 
-<!-- info-box-start:info -->
-**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
-The expected resolution period for this issue is end of June 2021.
-{:.info-box.important}
-<!-- info-box-end -->
+{% include tracing-shipping/otel_bug_june2021.md %}
 
 ### Logz.io Jaeger Collector
 If you already have a local Jaeger in your environment, to get a head start on sending tracing data to Logz.io, you may want to consider using the Logz.io Jaeger Collector. 


### PR DESCRIPTION
# What changed

Created a single source note about Known Issues for Logz.io exporter with OpenTelemetry collector versions 0.24 and above reported in June 2021: 

**Known Issue, June 2021**: OpenTelemetry collector version 0.24 and above does not function as expected when deployed with the Logz.io exporter. To remediate this issue, if you’re currently using version 0.24 or above, replace your  OpenTelemetry collector with version 0.23 or lower.
The resolution for this issue is in development and is expected later this year.

Impacts all the relevant Tracing integrations and 1 user guide topic
- https://deploy-preview-1255--logz-docs.netlify.app/shipping/#tracing-sources
- https://deploy-preview-1255--logz-docs.netlify.app/user-guide/distributed-tracing/deploying-components

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
