### PR TITLE
Added a note for metric accounts no longer supported

### DIFF
--- a/_source/_includes/metric-shipping/elk-accounts-note.md
+++ b/_source/_includes/metric-shipping/elk-accounts-note.md
@@ -1,0 +1,5 @@
+<!-- info-box-start:info -->
+Metrics accounts created after March 2021 use Prometheus instead of ElasticSearch. The feature described in this document is no longer relevant to these accounts. Metrics accounts created before March 2021 can continue using this feature for the time being.
+{:.info-box.note}
+<!-- info-box-end -->
+

--- a/_source/logzio_collections/_metrics-sources/system.md
+++ b/_source/logzio_collections/_metrics-sources/system.md
@@ -29,6 +29,8 @@ order: 190
 
 #### Metricbeat setup - Linux/MacOS
 
+{% include metric-shipping/elk-accounts-note.md %}
+
 **Before you begin, you'll need**:
 [Metricbeat 7.1](https://www.elastic.co/guide/en/beats/metricbeat/7.1/metricbeat-installation.html) or higher
 
@@ -93,6 +95,8 @@ Give your metrics some time to get from your system to ours, and then open [Logz
 <div id="metricbeat-config-win">
 
 #### Metricbeat setup - Windows
+
+{% include metric-shipping/elk-accounts-note.md %}
 
 **Before you begin, you'll need**:
 [Metricbeat 7.1](https://www.elastic.co/guide/en/beats/metricbeat/7.1/metricbeat-installation.html#win) or higher
@@ -166,6 +170,8 @@ Give your metrics some time to get from your system to ours, and then open [Logz
 <div id="docker-config">
 
 ## Docker setup
+
+{% include metric-shipping/elk-accounts-note.md %}
 
 To simplify shipping metrics from one or many sources,
 we created Docker Metrics Collector.


### PR DESCRIPTION
# What changed

https://deploy-preview-1338--logz-docs.netlify.app/shipping/metrics-sources/system.html#metricbeat-config-unix

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
