### PR TITLE
DOC-222: correct the link to Deployments API

### DIFF
--- a/_source/_data/toc.yml
+++ b/_source/_data/toc.yml
@@ -22,7 +22,7 @@ firstLevel:
     - title: Exceptions
       url: /user-guide/insights/exceptions/
     - title: Deployment markers
-      url: /user-guide/insights/exceptions/deployments/
+      url: /user-guide/kibana/exceptions-deployments
     - title: Patterns
       url: /user-guide/kibana/log-patterns.html
     - title: Wildcard searches

--- a/_source/user-guide/kibana/exceptions-deployments.md
+++ b/_source/user-guide/kibana/exceptions-deployments.md
@@ -1,7 +1,7 @@
 ---
 layout: article
 title: Deployment markers
-permalink: /user-guide/insights/exceptions/deployments.html
+permalink: /user-guide/kibana/exceptions-deployments.html   
 flags:
   logzio-plan: community
   beta: true
@@ -25,7 +25,7 @@ You can send deployment logs by API to automatically correlate exceptions with s
 
 ##### Send deployment logs by API
 
-Use the [API endpoint](/api/#operation/createMarkers) to create **Deployment markers**.
+Use the [API endpoint](https://docs.logz.io/api/#tag/Deployments) to create **Deployment markers**.
 
 Here's an example payload:
 


### PR DESCRIPTION
# What changed
https://deploy-preview-1351--logz-docs.netlify.app/user-guide/kibana/exceptions-deployments. correctly links to https://docs.logz.io/api/#tag/Deployments

Updated the deployments topic and toc.yaml
Deployments topic was pointing to [Deployment markers](https://docs.logz.io/user-guide/insights/exceptions/deployments/), which linked to the Beta-api. 


<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
