### PR TITLE
Small hint about timezones and container log format

### DIFF
--- a/_source/logzio_collections/_log-sources/kubernetes.md
+++ b/_source/logzio_collections/_log-sources/kubernetes.md
@@ -185,6 +185,7 @@ If you wish to make advanced changes in your Fluentd configuration, you can down
 * Note that `FLUENT_FILTER_KUBERNETES_URL` does not appear in the default environment variable list in the DaemonSet.
 If you wish to use this variable, you'll have to add it manually to the DaemonSet's environment variables.
 
+* Verify that your node / k8s instance timezone is running in UTC timezone for your container logs to be parsed and shipped correctly. Otherwise replace `time_format` line in the config with `%Y-%m-%dT%H:%M:%S.%N%:z`
 
 ##### Deploy the DaemonSet
 


### PR DESCRIPTION
Found out the hard way why the container logs did not want to be shipped, the standard format  with a Z at the end implies UTC. %:z changes this to the utc offset your machine currently is using

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
