### PR TITLE
fix rollout text messages - related to PR1385

### DIFF
--- a/_source/_data/shipper-tabs.yml
+++ b/_source/_data/shipper-tabs.yml
@@ -20,7 +20,7 @@ tabs:
     templated: true
     top-content: >-
       <p class="info-box important no-title">
-        <span class="bold">Prometheus Metrics are currently in roll-out. Supported regions include US East, EU Central, and EU West.
+        <span class="bold">Prometheus Metrics are currently in roll-out:</SPAN><br> Supported regions include US East, Canada, EU Central, West Europe, Europe, and West US 2.
          <br> </br>
         Contact your Logz.io Customer Success Manager to request early-access.
       </p>

--- a/_source/_includes/p8s-shipping/prometheus-rollout.md
+++ b/_source/_includes/p8s-shipping/prometheus-rollout.md
@@ -1,5 +1,5 @@
 <p class="info-box important no-title">
-  <span class="bold">Prometheus Metrics are currently in roll-out. Supported regions include US East, EU Central, and EU West. <br> <br>
+  <span class="bold">Prometheus Metrics are currently in roll-out:</SPAN> <br>Supported regions include US East, Canada, EU Central, West Europe, Europe, and West US 2.  <br> <br>
   Contact your Logz.io Customer Success Manager to request early-access.
 </p>
    

--- a/_source/user-guide/regions/account-region.md
+++ b/_source/user-guide/regions/account-region.md
@@ -50,7 +50,9 @@ Your listener host and API host will always be in the same region as your accoun
 
 ## Supported regions for Prometheus metrics
 
-Prometheus Metrics are currently in roll-out. Supported regions include US East, EU Central, and EU West. Your listener host and API host will always be in the same region as your Prometheus metrics account.
+
+{% include /p8s-shipping/prometheus-rollout.md %}
+Your listener host and API host will always be in the same region as your Prometheus metrics account.
 
 | Region | Cloud | Logz.io account host | Listener host | API host | Region code | Region slug |
 |---|---|---|


### PR DESCRIPTION
# What changed

Related to https://github.com/logzio/logz-docs/pull/1385

https://deploy-preview-1397--logz-docs.netlify.app/user-guide/accounts/account-region.html#supported-regions-for-prometheus-metrics


Edited include announcement of Prometheus rollout regions and announcement text in 

- _source/_data/shipper-tabs.yml
- logz-docs/_source/_data/shipper-tabs.yml

https://deploy-preview-1397--logz-docs.netlify.app/shipping/#prometheus-sources



<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
