### PR TITLE
raw data view and message field

### DIFF
--- a/_source/user-guide/live-tail/index.md
+++ b/_source/user-guide/live-tail/index.md
@@ -29,10 +29,9 @@ Live Tail gives you a live view of your logs as they come into Logz.io, eliminat
 * To clear the Live Tail view,
   click <i class="li li-clear"></i> (clear).
  
- <!-- info-box-start:info --> 
- The **Raw data** view shows the value of the log **message** fields as they enter the log management queue. To view a live tail of logs without the **message** field, use the [**Parsed data view**](#work-in-parsed-data-view).
-
-  {:.info-box.note}
+<!-- info-box-start:info --> 
+The **Raw data** view shows the value of the log **message** fields as they enter the log management queue. To view a live tail of logs without the **message** field, use the [**Parsed data view**](#work-in-parsed-data-view).
+{:.info-box.note}
 <!-- info-box-end -->
 
 #### Find and highlight terms

--- a/_source/user-guide/live-tail/index.md
+++ b/_source/user-guide/live-tail/index.md
@@ -30,7 +30,7 @@ Live Tail gives you a live view of your logs as they come into Logz.io, eliminat
   click <i class="li li-clear"></i> (clear).
  
 <!-- info-box-start:info --> 
-The **Raw data** view shows the value of the log **message** fields as they enter the log management queue. To view a live tail of logs without the **message** field, use the [**Parsed data view**](#work-in-parsed-data-view).
+The **Raw data** view shows the value of the log **message** fields as they enter the log management queue. <br> To view a live tail of logs without the **message** field, use the [**Parsed data view**](#work-in-parsed-data-view).
 {:.info-box.note}
 <!-- info-box-end -->
 

--- a/_source/user-guide/live-tail/index.md
+++ b/_source/user-guide/live-tail/index.md
@@ -28,6 +28,9 @@ Live Tail gives you a live view of your logs as they come into Logz.io, eliminat
   press <i class="li li-scroll"></i> (scroll).
 * To clear the Live Tail view,
   click <i class="li li-clear"></i> (clear).
+  
+  the "Raw data" view shows the value of logs' "message" field as they are entered into the log management queue; to view a live tail of logs without a "message" field, use the [parsed data view](#work-in-parsed-data-view).
+  {:.info-box.note}
 
 #### Find and highlight terms
 

--- a/_source/user-guide/live-tail/index.md
+++ b/_source/user-guide/live-tail/index.md
@@ -28,9 +28,12 @@ Live Tail gives you a live view of your logs as they come into Logz.io, eliminat
   press <i class="li li-scroll"></i> (scroll).
 * To clear the Live Tail view,
   click <i class="li li-clear"></i> (clear).
-  
-  the "Raw data" view shows the value of logs' "message" field as they are entered into the log management queue; to view a live tail of logs without a "message" field, use the [parsed data view](#work-in-parsed-data-view).
+ 
+ <!-- info-box-start:info --> 
+ The **Raw data** view shows the value of the log **message** fields as they enter the log management queue. To view a live tail of logs without the **message** field, use the [**Parsed data view**](#work-in-parsed-data-view).
+
   {:.info-box.note}
+<!-- info-box-end -->
 
 #### Find and highlight terms
 


### PR DESCRIPTION
Added an info box explaining that logs without a message field will not show up in the raw data view.

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
