### PR TITLE
Create otel-traces-helm.md

### DIFF
--- a/_source/logzio_collections/_tracing-sources/otel-traces-helm.md
+++ b/_source/logzio_collections/_tracing-sources/otel-traces-helm.md
@@ -53,12 +53,6 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 
 Give your traces some time to get from your system to ours, then open [Logz.io](https://app.logz.io/).
 
-## Example usage:
-* Go to `hotrod.yml` file inside this directory
-* Change the `<<otel-cluster-ip>>` parameter to the cluster-ip address of your opentelemetry collector service.
-* Deploy the `hotrod.yml` to your kubernetes cluster (example: `kubectl apply -f hotrod.yml`)
-* Access the hotrod pod on port 8080 and start sending traces.
-
 </div>
 
 ####  Customizing Helm chart parameters


### PR DESCRIPTION
New helm chart integration to collect traces from Kubernetes clusters with opentelemetry collector