### PR TITLE
Removed "metrics sources" folder from google

### DIFF
--- a/_source/robots.txt
+++ b/_source/robots.txt
@@ -9,7 +9,7 @@ Allow: /
 Disallow: /docs-admin/
 Disallow: /technical-notes/
 Disallow: /googlec6c327a13fb89cb5.html
-Disallow: /shipping/metrics-sources
+Disallow: /shipping/metrics-sources/
 Sitemap: {{ site.url | append: site.baseurl}}/sitemap.xml
 
 {%- else %}


### PR DESCRIPTION
# What changed

Added sub-folder /shipping/metrics-sources to sitemap's "Disallow" rule.

https://deploy-preview-1467--logz-docs.netlify.app/robots.txt


----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
