### PR TITLE
Update new logic for breadcrumbs

### DIFF
--- a/_source/_layouts/default.html
+++ b/_source/_layouts/default.html
@@ -16,6 +16,21 @@
     {%- if page.data-source -%}
     <div class="breadcrumbs">
       <span><a href="{{site.baseurl}}/shipping/">Ship your data</a></span>
+			{%- if page.data-for-product-source == "Logs" -%}
+      <span><a href="{{site.baseurl}}/shipping/#log-sources">{{ page.data-for-product-source  }}</a></span>
+			{%- endif -%}
+			{%- if page.data-for-product-source == "Metrics" -%}
+      <span><a href="{{site.baseurl}}/shipping/#prometheus-sources">{{ page.data-for-product-source  }}</a></span>
+			{%- endif -%}
+			{%- if page.data-for-product-source == "Tracing" -%}
+      <span><a href="{{site.baseurl}}/shipping/#tracing-sources">{{ page.data-for-product-source  }}</a></span>
+			{%- endif -%}
+			{%- if page.data-for-product-source == "Cloud SIEM" -%}
+      <span><a href="{{site.baseurl}}/shipping/#security-sources">{{ page.data-for-product-source  }}</a></span>
+			{%- endif -%}
+			{%- if page.data-for-product-source == "Community Shippers" -%}
+      <span><a href="{{site.baseurl}}/shipping/#community-shippers">{{ page.data-for-product-source  }}</a></span>
+			{%- endif -%}
       <span>{{ page.data-source }}</span>
     </div>
     {%- endif -%}

--- a/_source/logzio_collections/_log-sources/dotnet.md
+++ b/_source/logzio_collections/_log-sources/dotnet.md
@@ -5,6 +5,7 @@ logo:
   orientation: vertical
 short-description: Configure a .NET appender in a configuration file or add it directly to the code to send your logs to Logz.io.
 data-source: .NET code
+data-for-product-source: Logs
 templates: ["library"]
 open-source:
   - title: logzio-dotnet


### PR DESCRIPTION
# What changed

Ship your data in breadcrumbs we are missing for what is shipper.
The problem that we have that breadcrumbs right now going from the template. Update with right breadcrumbs, we need to add additional   variable/tag in the header of markdown to make it happen  =>  data-for-product-source:

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
