### PR TITLE
removed prebuilt dashboards from nav

### DIFF
--- a/_source/_data/toc.yml
+++ b/_source/_data/toc.yml
@@ -119,7 +119,7 @@ firstLevel:
     - title: Explore in Kibana
       url: /user-guide/infrastructure-monitoring/explore-in-kibana-drilldown-links.html
   - title: Elastic-based Metrics information #deprecated topics
-      url: /user-guide/infrastructure-monitoring/elastic-metrics
+    url: /user-guide/infrastructure-monitoring/elastic-metrics
 
 
     # ===== DISTRIBUTED TRACING =====

--- a/_source/_data/toc.yml
+++ b/_source/_data/toc.yml
@@ -118,6 +118,8 @@ firstLevel:
       url: /user-guide/infrastructure-monitoring/annotations/
     - title: Explore in Kibana
       url: /user-guide/infrastructure-monitoring/explore-in-kibana-drilldown-links.html
+  #- title: Pre-built metrics dashboards
+  #  url: /user-guide/infrastructure-monitoring/metrics-dashboards
   - title: Elastic-based Metrics information #deprecated topics
     url: /user-guide/infrastructure-monitoring/elastic-metrics
 

--- a/_source/_data/toc.yml
+++ b/_source/_data/toc.yml
@@ -118,6 +118,8 @@ firstLevel:
       url: /user-guide/infrastructure-monitoring/annotations/
     - title: Explore in Kibana
       url: /user-guide/infrastructure-monitoring/explore-in-kibana-drilldown-links.html
+  - title: Elastic-based Metrics information #deprecated topics
+      url: /user-guide/infrastructure-monitoring/elastic-metrics
 
 
     # ===== DISTRIBUTED TRACING =====

--- a/_source/_data/toc.yml
+++ b/_source/_data/toc.yml
@@ -118,10 +118,6 @@ firstLevel:
       url: /user-guide/infrastructure-monitoring/annotations/
     - title: Explore in Kibana
       url: /user-guide/infrastructure-monitoring/explore-in-kibana-drilldown-links.html
-  - title: Pre-built metrics dashboards
-    url: /user-guide/infrastructure-monitoring/metrics-dashboards
-  - title: Elastic-based Metrics information #deprecated topics
-    url: /user-guide/infrastructure-monitoring/elastic-metrics
 
 
     # ===== DISTRIBUTED TRACING =====


### PR DESCRIPTION
# What changed

Removed pre-built dashboards and Elastic related pages from the side navigation (from under "Infrastructure Monitoring")

https://deploy-preview-1476--logz-docs.netlify.app

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
