### PR TITLE
removed the word "metricsbest"

### DIFF
--- a/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
+++ b/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
@@ -44,7 +44,7 @@ That way you can benchmark your goals against past achievements.
 
 Logz.io’s Metrics platform is pre-loaded with dozens of dashboards to help you hit the ground running and get started immediately. Your Metrics account is ready to accept data from many environments, dockers, container systems, queue management systems, and more.
 
- After configuring Metricsbeat to stream your data to Logz.io, you can select any appropriate dashboard from the list and select the data source. Each dashboard is preconfigured to match the particular data type it is named after and is production-ready without any further customization, and does not require previous expertise. The dashboards are designed by Logz.io specialists and let you get up-and-running in a matter of minutes. [Learn how to select your first dashboard]({{site.baseurl}}/user-guide/infrastructure-monitoring/getting-started).
+ After configuring how to stream your data to Logz.io, you can select any appropriate dashboard from the list and select the data source. Each dashboard is preconfigured to match the particular data type it is named after. It is production-ready without any further customization, and does not require previous expertise. The dashboards are designed by Logz.io specialists and let you get up-and-running in a matter of minutes. [Learn how to select your first dashboard]({{site.baseurl}}/user-guide/infrastructure-monitoring/getting-started).
 
 Once you’re ready to move to the next level, you can duplicate any of the preconfigured dashboards to add your own panels and changes, or create entirely new dashboards of your own. [Learn how to add a new dashboard]({{site.baseurl}}/user-guide/infrastructure-monitoring/configure-grafana-drilldown-links.html).
 

--- a/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
+++ b/_source/user-guide/infrastructure-monitoring/highlights-metrics.md
@@ -44,7 +44,9 @@ That way you can benchmark your goals against past achievements.
 
 Logz.io’s Metrics platform is pre-loaded with dozens of dashboards to help you hit the ground running and get started immediately. Your Metrics account is ready to accept data from many environments, dockers, container systems, queue management systems, and more.
 
- After configuring how to stream your data to Logz.io, you can select any appropriate dashboard from the list and select the data source. Each dashboard is preconfigured to match the particular data type it is named after. It is production-ready without any further customization, and does not require previous expertise. The dashboards are designed by Logz.io specialists and let you get up-and-running in a matter of minutes. [Learn how to select your first dashboard]({{site.baseurl}}/user-guide/infrastructure-monitoring/getting-started).
+After configuring how to stream your data to Logz.io, you can select any relevant dashboard from the list and select the data source. Each dashboard is preconfigured to match the particular data type it's named after. These dashboards are production-ready: You don't have to do any customizations, and you don't need to have previous experience to set them up. 
+
+The metrics dashboards are designed by Logz.io specialists so that you can get up-and-running in a matter of minutes. [Learn how to select your first dashboard]({{site.baseurl}}/user-guide/infrastructure-monitoring/getting-started).
 
 Once you’re ready to move to the next level, you can duplicate any of the preconfigured dashboards to add your own panels and changes, or create entirely new dashboards of your own. [Learn how to add a new dashboard]({{site.baseurl}}/user-guide/infrastructure-monitoring/configure-grafana-drilldown-links.html).
 


### PR DESCRIPTION
# What changed

Removed the word "Metricsbeat" from a page. Replaced it with the word "how".
Under header titled "Launch with pre-built dashboards" -> inside the "After configuring how to stream" section

https://deploy-preview-1478--logz-docs.netlify.app/user-guide/infrastructure-monitoring/metrics-logzio

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
