### PR TITLE
Add otel collector and nodejs layers for aws lambda

### DIFF
--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -18,8 +18,8 @@ order: 1380
 <div class="branching-container">
 
 * [Overview](#overview)
-* [New Lambda](#new)
-* [Existing Lambda](#existing)
+* [Build a layer](#new)
+* [Add to existing layer](#existing)
 {:.branching-tabs}
 
 <!-- tab:start -->

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -25,12 +25,7 @@ order: 1380
 <!-- tab:start -->
 <div id="overview">
 
-The Logzio OpenTelemetry Collector Lambda Extension provides a mechanism to synchronously export traces and metrics from AWS Lambda applications. It does this by embedding a stripped-down version of [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) inside an [AWS Extension Layer](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). This allows the Lambda applications to use the OpenTelemetry Collector Exporter to send traces and metrics to any configured backend, such as Logz.io.
-
-<!-- info-box-start:info -->
-This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda)
-<!-- info-box-end -->
-{:.info-box.note}
+The Logzio OpenTelemetry Collector Lambda Extension provides a mechanism to synchronously export traces from AWS Lambda applications. It does this by embedding a stripped-down version of [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) inside an [AWS Extension Layer](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). This allows the Lambda applications to use the OpenTelemetry Collector Exporter to send traces and metrics to any configured backend, such as Logz.io.
 
 
 </div>

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -23,7 +23,7 @@ The Logzio OpenTelemetry Collector Lambda Extension provides a mechanism to sync
 
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
 * Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
-* [Instrumentation](https://docs.logz.io/shipping/tracing-sources/opentelemetry-nodejs-lambda.html) enabled in your code
+* [Tracing instrumentation](https://app.logz.io/#/dashboard/send-your-data?tag=new-instrumentation&collection=tracing-sources) enabled in your code 
 
 
 <div class="tasklist">

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -13,6 +13,7 @@ shipping-tags:
   - new-instrumentation
 order: 1380
 ---
+
 <!-- tabContainer:start -->
 <div class="branching-container">
 
@@ -30,7 +31,6 @@ The Logzio OpenTelemetry Collector Lambda Extension provides a mechanism to sync
 This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda){:.info-box.note}
 <!-- info-box-end -->
 
-</div>
 
 </div>
 <!-- tab:end -->

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -28,8 +28,9 @@ order: 1380
 The Logzio OpenTelemetry Collector Lambda Extension provides a mechanism to synchronously export traces and metrics from AWS Lambda applications. It does this by embedding a stripped-down version of [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) inside an [AWS Extension Layer](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). This allows the Lambda applications to use the OpenTelemetry Collector Exporter to send traces and metrics to any configured backend, such as Logz.io.
 
 <!-- info-box-start:info -->
-This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda){:.info-box.note}
+This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda)
 <!-- info-box-end -->
+{:.info-box.note}
 
 
 </div>

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -14,24 +14,9 @@ shipping-tags:
 order: 1380
 ---
 
-<!-- tabContainer:start -->
-<div class="branching-container">
-
-* [Overview](#overview)
-* [Instructions](#install)
-{:.branching-tabs}
-
-<!-- tab:start -->
-<div id="overview">
 
 The Logzio OpenTelemetry Collector Lambda Extension provides a mechanism to synchronously export traces from AWS Lambda applications. It does this by embedding a stripped-down version of [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) inside an [AWS Extension Layer](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). This allows the Lambda applications to use the OpenTelemetry Collector Exporter to send traces and metrics to any configured backend, such as Logz.io.
 
-
-</div>
-<!-- tab:end -->
-
-<!-- tab:start -->
-<div id="install">
   
 #### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function
 
@@ -55,6 +40,7 @@ aws lambda update-function-configuration --function-name Function --tracing-conf
 ```
   
 ##### Configuration the function
+  
 By default, OpenTelemetry Collector Lambda Extension exports the telemetry data to the Lambda console. To customize the collector configuration, add a `collector.yaml` to your function and specifiy its location via the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment file. Here is a sample configuration file:
   
 ```yaml
@@ -81,8 +67,3 @@ aws lambda update-function-configuration --function-name Function --environment 
 ```
 </div>
 
-</div>
-<!-- tab:end -->
-
-</div>
-<!-- tabContainer:end -->

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -1,23 +1,96 @@
-# OpenTelemetry Collector AWS Lambda Extension layer
+---
+title: Sending traces from AWS Lambda Extension layer with OpenTelemetry Collector
+logo:
+  logofile: AWS-Lambda.svg
+  orientation: vertical
+data-source: AWS Lambda Extension
+data-for-product-source: Tracing
+templates: ["network-device-filebeat"]
+contributors:
+  - nshishkin
+  - yotamloe
+shipping-tags:
+  - new-instrumentation
+order: 1380
+---
+<!-- tabContainer:start -->
+<div class="branching-container">
 
-**This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda)** 
+* [Overview](#overview)
+* [New Lambda](#new)
+* [Existing Lambda](#existing)
+{:.branching-tabs}
 
-The Logzio openTelemetry Collector Lambda Extension provides a mechanism to export telemetry aynchronously from AWS Lambdas. It does this by embedding a stripped-down version of [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) inside an [AWS Extension Layer](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). This allows lambdas to use the OpenTelemetry Collector Exporter to send traces and metrics to any configured backend.
+<!-- tab:start -->
+<div id="overview">
 
+The Logzio OpenTelemetry Collector Lambda Extension provides a mechanism to synchronously export traces and metrics from AWS Lambda applications. It does this by embedding a stripped-down version of [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) inside an [AWS Extension Layer](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). This allows the Lambda applications to use the OpenTelemetry Collector Exporter to send traces and metrics to any configured backend, such as Logz.io.
 
-## Installing
-To install the OpenTelemetry Collector Lambda layer to an existing Lambda function using the `aws` CLI:
+<!-- info-box-start:info -->
+This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda){:.info-box.note}
+<!-- info-box-end -->
 
+</div>
+
+</div>
+<!-- tab:end -->
+
+<!-- tab:start -->
+<div id="new">
+  
+#### Build your OpenTelemetry Collector Lambda layer from scratch
+
+**Before you begin, you'll need**:
+  
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+* Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+
+<div class="tasklist">
+
+##### Download a local copy of the Logzio OpenTelemetry Collector Lambda Extension repository
+
+Download a local copy of the [logzio/opentelemetry-lambda repository from Github](https://github.com/logzio/opentelemetry-lambda).
+
+##### Publish the Logzio OpenTelemetry Collector Lambda Extension
+
+Run the following command to publish OpenTelemetry Collector Lambda layer to your AWS account and get its ARN:
+  
+```shell
+cd collector && make publish-layer
 ```
+  
+</div>
+
+</div>
+<!-- tab:end -->
+
+<!-- tab:start -->
+<div id="existing">
+ 
+#### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function
+
+**Before you begin, you'll need**:
+  
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+* Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+
+<div class="tasklist">
+
+##### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function using the AWS CLI
+
+```shell
 aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-collector-layer:1	
 ```
-Activate function tracing:
-```
+  
+##### Activate function tracing
+  
+```shelll
 aws lambda update-function-configuration --function-name Function --tracing-config Mode=Active
 ```
-## Configuration
+  
+##### Configuration the function
 
-By default, OpenTelemetry Collector Lambda layer exports telemetry data to Lambda console. To customize the collector configuration, add a `collector.yaml` to your function and specifiy its location via the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment file.
+By default, OpenTelemetry Collector Lambda Extension exports the telemetry data to the Lambda console. To customize the collector configuration, add a `collector.yaml` to your function and specifiy its location via the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment file.
 
 Here is a sample configuration file:
 
@@ -30,8 +103,8 @@ receivers:
 
 exporters:
   logzio:
-    account_token: <<LOGZIO-TOKEN>>
-    region: "us"
+    account_token: <<TRACING-SHIPPING-TOKEN>>
+    region: <<LOGZIO_ACCOUNT_REGION_CODE>>
 
 service:
   pipelines:
@@ -40,19 +113,19 @@ service:
       exporters: [logzio]
 
 ```
+  
+{% include /tracing-shipping/replace-tracing-token.html %}
 
-Once the file has been deployed with a Lambda, configuring the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` will tell the OpenTelemetry extension where to find the collector configuration:
+Once the file has been deployed with a Lambda, configuring the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` will tell the OpenTelemetry Collector Lambda Extension where to find the collector configuration:
 
 ```
 aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/var/task/collector.yaml}
 ```
 
+</div>
 
-### Build your OpenTelemetry Collector Lambda layer from scratch
-- Download a local copy of the [logzio/opentelemetry-lambda repository from Github](https://github.com/logzio/opentelemetry-lambda).
-- Run command: `cd collector && make publish-layer` to publish OpenTelemetry Collector Lambda layer in your AWS account and get its ARN
+</div>
+<!-- tab:end -->
 
-Be sure to:
-
-* Install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-* Config [AWS credential](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+</div>
+<!-- tabContainer:end -->

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -1,0 +1,58 @@
+# OpenTelemetry Collector AWS Lambda Extension layer
+
+**This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda)** 
+
+The Logzio openTelemetry Collector Lambda Extension provides a mechanism to export telemetry aynchronously from AWS Lambdas. It does this by embedding a stripped-down version of [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) inside an [AWS Extension Layer](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). This allows lambdas to use the OpenTelemetry Collector Exporter to send traces and metrics to any configured backend.
+
+
+## Installing
+To install the OpenTelemetry Collector Lambda layer to an existing Lambda function using the `aws` CLI:
+
+```
+aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-collector-layer:1	
+```
+Activate function tracing:
+```
+aws lambda update-function-configuration --function-name Function --tracing-config Mode=Active
+```
+## Configuration
+
+By default, OpenTelemetry Collector Lambda layer exports telemetry data to Lambda console. To customize the collector configuration, add a `collector.yaml` to your function and specifiy its location via the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment file.
+
+Here is a sample configuration file:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  logzio:
+    account_token: <<LOGZIO-TOKEN>>
+    region: "us"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logzio]
+
+```
+
+Once the file has been deployed with a Lambda, configuring the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` will tell the OpenTelemetry extension where to find the collector configuration:
+
+```
+aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/var/task/collector.yaml}
+```
+
+
+### Build your OpenTelemetry Collector Lambda layer from scratch
+- Download a local copy of the [logzio/opentelemetry-lambda repository from Github](https://github.com/logzio/opentelemetry-lambda).
+- Run command: `cd collector && make publish-layer` to publish OpenTelemetry Collector Lambda layer in your AWS account and get its ARN
+
+Be sure to:
+
+* Install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+* Config [AWS credential](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -14,7 +14,6 @@ shipping-tags:
 order: 1380
 ---
 
-
 The Logzio OpenTelemetry Collector Lambda Extension provides a mechanism to synchronously export traces from AWS Lambda applications. It does this by embedding a stripped-down version of [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) inside an [AWS Extension Layer](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). This allows the Lambda applications to use the OpenTelemetry Collector Exporter to send traces and metrics to any configured backend, such as Logz.io.
 
   
@@ -24,6 +23,8 @@ The Logzio OpenTelemetry Collector Lambda Extension provides a mechanism to sync
 
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
 * Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+* [Instrumentation](https://docs.logz.io/shipping/tracing-sources/opentelemetry-nodejs-lambda.html) enabled in your code
+
 
 <div class="tasklist">
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -19,7 +19,6 @@ order: 1380
 
 * [Overview](#overview)
 * [Build a layer](#new)
-* [Add to existing layer](#existing)
 {:.branching-tabs}
 
 <!-- tab:start -->
@@ -55,69 +54,6 @@ Run the following command to publish OpenTelemetry Collector Lambda layer to you
 cd collector && make publish-layer
 ```
   
-</div>
-
-</div>
-<!-- tab:end -->
-
-<!-- tab:start -->
-<div id="existing">
- 
-#### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function
-
-**Before you begin, you'll need**:
-  
-* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-* Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
-
-<div class="tasklist">
-
-##### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function using the AWS CLI
-
-```shell
-aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-collector-layer:1	
-```
-  
-##### Activate function tracing
-  
-```shelll
-aws lambda update-function-configuration --function-name Function --tracing-config Mode=Active
-```
-  
-##### Configuration the function
-
-By default, OpenTelemetry Collector Lambda Extension exports the telemetry data to the Lambda console. To customize the collector configuration, add a `collector.yaml` to your function and specifiy its location via the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment file.
-
-Here is a sample configuration file:
-
-```yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:
-
-exporters:
-  logzio:
-    account_token: <<TRACING-SHIPPING-TOKEN>>
-    region: <<LOGZIO_ACCOUNT_REGION_CODE>>
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [logzio]
-
-```
-  
-{% include /tracing-shipping/replace-tracing-token.html %}
-
-Once the file has been deployed with a Lambda, configuring the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` will tell the OpenTelemetry Collector Lambda Extension where to find the collector configuration:
-
-```
-aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/var/task/collector.yaml}
-```
-
 </div>
 
 </div>

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-collector-lambda-extention.md
@@ -55,8 +55,8 @@ aws lambda update-function-configuration --function-name Function --tracing-conf
 ```
   
 ##### Configuration the function
-By default, OpenTelemetry Collector Lambda Extension exports the telemetry data to the Lambda console. To customize the collector configuration, add a `collector.yaml` to your function and specifiy its location via the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment file.
-Here is a sample configuration file:
+By default, OpenTelemetry Collector Lambda Extension exports the telemetry data to the Lambda console. To customize the collector configuration, add a `collector.yaml` to your function and specifiy its location via the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment file. Here is a sample configuration file:
+  
 ```yaml
 receivers:
   otlp:

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -32,10 +32,7 @@ To use it, you will need add the layer to your function configuration and then s
 
 [AWS SDK v2 instrumentation](https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-aws-sdk) is also
 included and loaded automatically if you use the AWS SDK v2.
-  
-<!-- info-box-start:info -->
-This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda)<!-- info-box-end -->
-{:.info-box.note}
+
 
 </div>
 <!-- tab:end -->

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -18,8 +18,8 @@ order: 1380
 <div class="branching-container">
 
 * [Overview](#overview)
-* [New Lambda](#new)
-* [Existing Lambda](#existing)
+* [Build a layer](#new)
+* [Add to existing layer](#existing)
 {:.branching-tabs}
 
 <!-- tab:start -->

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -18,7 +18,7 @@ order: 1380
 <div class="branching-container">
 
 * [Overview](#overview)
-* [Build a layer](#new)
+* [Install](#install)
 {:.branching-tabs}
 
 <!-- tab:start -->
@@ -37,9 +37,9 @@ included and loaded automatically if you use the AWS SDK v2.
 <!-- tab:end -->
 
 <!-- tab:start -->
-<div id="new">
+<div id="install">
   
-#### Build your OpenTelemetry Collector NodeJS Lambda layer from scratch
+#### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function
 
 **Before you begin, you'll need**:
   
@@ -48,19 +48,32 @@ included and loaded automatically if you use the AWS SDK v2.
 
 <div class="tasklist">
 
-##### Download a local copy of the Logzio OpenTelemetry Collector Lambda NodeJS Extension repository
-
-Download a local copy of the [logzio/opentelemetry-lambda repository from Github](https://github.com/logzio/opentelemetry-lambda).
-  
-##### Download all dependencies and compile the code
-  
-Run:
+##### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function using the AWS CLI
 
 ```shell
-cd nodejs && npm install
+aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-collector-layer:1
+```
+  
+##### Activate function tracing
+  
+```shell
+aws lambda update-function-configuration --function-name Function --tracing-config Mode=Active
 ```
 
-This will download all dependencies and compile the code. The layer zip file will be located at `./packages/layer/build/layer.zip`.
+##### Install the OpenTelemetry Collector NodeJS Lambda Extension to an existing Lambda function using the AWS CLI
+  
+```shell
+aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-nodejs-wrapper:1
+```
+  
+##### Add environment variable
+  
+Add the `AWS_LAMBDA_EXEC_WRAPPER` environment variable to point to the `otel-handler` executable:
+
+```shell
+aws lambda update-function-configuration --function-name Function --environment Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler}
+```
+  
   
 </div>
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -29,7 +29,6 @@ included and loaded automatically if you use the AWS SDK v2.
   
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
 * Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
-* [Instrumentation](https://docs.logz.io/shipping/tracing-sources/opentelemetry-nodejs-lambda.html) enabled in your code before
 
 <div class="tasklist">
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -29,6 +29,7 @@ included and loaded automatically if you use the AWS SDK v2.
   
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
 * Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+* [Instrumentation](https://docs.logz.io/shipping/tracing-sources/opentelemetry-nodejs-lambda.html) enabled in your code before
 
 <div class="tasklist">
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -13,16 +13,6 @@ shipping-tags:
   - new-instrumentation
 order: 1380
 ---
-
-<!-- tabContainer:start -->
-<div class="branching-container">
-
-* [Overview](#overview)
-* [Install](#install)
-{:.branching-tabs}
-
-<!-- tab:start -->
-<div id="overview">
   
 OpenTelemetry Lambda NodeJS is a layer for running NodeJS applications on AWS Lambda with OpenTelemetry. Adding the layer and pointing to it with
 the `AWS_LAMBDA_EXEC_WRAPPER` environment variable will initialize OpenTelemetry, enabling tracing with no code change.
@@ -32,12 +22,6 @@ To use it, you will need add the layer to your function configuration and then s
 [AWS SDK v2 instrumentation](https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-aws-sdk) is also
 included and loaded automatically if you use the AWS SDK v2.
 
-
-</div>
-<!-- tab:end -->
-
-<!-- tab:start -->
-<div id="install">
   
 #### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function
 
@@ -76,9 +60,3 @@ aws lambda update-function-configuration --function-name Function --environment 
   
   
 </div>
-
-</div>
-<!-- tab:end -->
-  
-</div>
-<!-- tabContainer:end -->

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -19,7 +19,6 @@ order: 1380
 
 * [Overview](#overview)
 * [Build a layer](#new)
-* [Add to existing layer](#existing)
 {:.branching-tabs}
 
 <!-- tab:start -->
@@ -65,49 +64,6 @@ This will download all dependencies and compile the code. The layer zip file wil
   
 </div>
 
-</div>
-<!-- tab:end -->
-
-<!-- tab:start -->
-<div id="existing">
- 
-#### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function
-
-**Before you begin, you'll need**:
-  
-* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-* Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
-
-<div class="tasklist">
-
-##### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function using the AWS CLI
-
-```shell
-aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-collector-layer:1
-```
-  
-##### Activate function tracing
-  
-```shell
-aws lambda update-function-configuration --function-name Function --tracing-config Mode=Active
-```
-
-##### Install the OpenTelemetry Collector NodeJS Lambda Extension to an existing Lambda function using the AWS CLI
-
-```shell
-aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-nodejs-wrapper:1
-```
-  
-##### Add environment variable
-  
-Add the `AWS_LAMBDA_EXEC_WRAPPER` environment variable to point to the `otel-handler` executable:
-  
-```shell
-aws lambda update-function-configuration --function-name Function --environment Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler}
-```
-
-
-</div>
 </div>
 <!-- tab:end -->
   

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -1,45 +1,118 @@
-# OpenTelemetry Lambda NodeJS
+---
+title: Sending traces from AWS Lambda NodeJS Extension layer with OpenTelemetry Collector
+logo:
+  logofile: AWS-Lambda.svg
+  orientation: vertical
+data-source: AWS Lambda Extension NodeJS
+data-for-product-source: Tracing
+templates: ["network-device-filebeat"]
+contributors:
+  - nshishkin
+  - yotamloe
+shipping-tags:
+  - new-instrumentation
+order: 1380
+---
 
-**This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda)**
+<!-- tabContainer:start -->
+<div class="branching-container">
 
-Layer for running NodeJS applications on AWS Lambda with OpenTelemetry. Adding the layer and pointing to it with
+* [Overview](#overview)
+* [New Lambda](#new)
+* [Existing Lambda](#existing)
+{:.branching-tabs}
+
+<!-- tab:start -->
+<div id="overview">
+  
+OpenTelemetry Lambda NodeJS is a layer for running NodeJS applications on AWS Lambda with OpenTelemetry. Adding the layer and pointing to it with
 the `AWS_LAMBDA_EXEC_WRAPPER` environment variable will initialize OpenTelemetry, enabling tracing with no code change.
 
-To use, add the layer to your function configuration and then set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-handler`.
+To use it, you will need add the layer to your function configuration and then set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-handler`.
 
 [AWS SDK v2 instrumentation](https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-aws-sdk) is also
 included and loaded automatically if you use the AWS SDK v2.
+  
+<!-- info-box-start:info -->
+This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda)<!-- info-box-end -->
+{:.info-box.note}
 
-## Installing
-To install the OpenTelemetry Collector Lambda layer to an existing Lambda function using the `aws` CLI:
+</div>
+<!-- tab:end -->
 
+<!-- tab:start -->
+<div id="new">
+  
+#### Build your OpenTelemetry Collector NodeJS Lambda layer from scratch
+
+**Before you begin, you'll need**:
+  
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+* Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+
+<div class="tasklist">
+
+##### Download a local copy of the Logzio OpenTelemetry Collector Lambda NodeJS Extension repository
+
+Download a local copy of the [logzio/opentelemetry-lambda repository from Github](https://github.com/logzio/opentelemetry-lambda).
+  
+##### Download all dependencies and compile the code
+  
+Run:
+
+```shell
+cd nodejs && npm install
 ```
+
+This will download all dependencies and compile the code. The layer zip file will be located at `./packages/layer/build/layer.zip`.
+  
+</div>
+
+</div>
+<!-- tab:end -->
+
+<!-- tab:start -->
+<div id="existing">
+ 
+#### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function
+
+**Before you begin, you'll need**:
+  
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+* Configured [AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+
+<div class="tasklist">
+
+##### Install the OpenTelemetry Collector Lambda Extension to an existing Lambda function using the AWS CLI
+
+```shell
 aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-collector-layer:1
 ```
-Activate function tracing:
-```
+  
+##### Activate function tracing
+  
+```shell
 aws lambda update-function-configuration --function-name Function --tracing-config Mode=Active
 ```
-To install the Logzio opentelemetry nodejs Lambda layer to an existing Lambda function using the `aws` CLI:
 
-```
+##### Install the OpenTelemetry Collector NodeJS Lambda Extension to an existing Lambda function using the AWS CLI
+
+```shell
 aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-nodejs-wrapper:1
 ```
-Add the `AWS_LAMBDA_EXEC_WRAPPER` environment variable to point to the `otel-handler` executable
-```
+  
+##### Add environment variable
+  
+Add the `AWS_LAMBDA_EXEC_WRAPPER` environment variable to point to the `otel-handler` executable:
+  
+```shell
 aws lambda update-function-configuration --function-name Function --environment Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler}
 ```
 
 
-## Building from scratch
-
-To build the layer and sample applications:
-- Download a local copy of the [logzio/opentelemetry-lambda repository from Github](https://github.com/logzio/opentelemetry-lambda).
-- run:
-
-```
-cd nodejs && npm install
-```
-
-This will download all dependencies and compile all code. The layer zip file will be present at `./packages/layer/build/layer.zip`.
-
+</div>
+</div>
+<!-- tab:end -->
+  
+</div>
+<!-- tabContainer:end -->

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -1,0 +1,45 @@
+# OpenTelemetry Lambda NodeJS
+
+**This project is a fork of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda)**
+
+Layer for running NodeJS applications on AWS Lambda with OpenTelemetry. Adding the layer and pointing to it with
+the `AWS_LAMBDA_EXEC_WRAPPER` environment variable will initialize OpenTelemetry, enabling tracing with no code change.
+
+To use, add the layer to your function configuration and then set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-handler`.
+
+[AWS SDK v2 instrumentation](https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-aws-sdk) is also
+included and loaded automatically if you use the AWS SDK v2.
+
+## Installing
+To install the OpenTelemetry Collector Lambda layer to an existing Lambda function using the `aws` CLI:
+
+```
+aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-collector-layer:1
+```
+Activate function tracing:
+```
+aws lambda update-function-configuration --function-name Function --tracing-config Mode=Active
+```
+To install the Logzio opentelemetry nodejs Lambda layer to an existing Lambda function using the `aws` CLI:
+
+```
+aws lambda update-function-configuration --function-name Function --layers arn:aws:lambda:<<your-aws-region>>:486140753397:layer:logzio-opentelemetry-nodejs-wrapper:1
+```
+Add the `AWS_LAMBDA_EXEC_WRAPPER` environment variable to point to the `otel-handler` executable
+```
+aws lambda update-function-configuration --function-name Function --environment Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler}
+```
+
+
+## Building from scratch
+
+To build the layer and sample applications:
+- Download a local copy of the [logzio/opentelemetry-lambda repository from Github](https://github.com/logzio/opentelemetry-lambda).
+- run:
+
+```
+cd nodejs && npm install
+```
+
+This will download all dependencies and compile all code. The layer zip file will be present at `./packages/layer/build/layer.zip`.
+


### PR DESCRIPTION
I added instructions on how to add opentelemetry collector and opentelemetry nodejs SDK for AWS lambda.
After these docs will be published customers will be able to use these layers to send traces from AWS lambda functions

https://deploy-preview-1508--logz-docs.netlify.app/shipping/tracing-sources/opentelemetry-nodejs-lambda.html
https://deploy-preview-1508--logz-docs.netlify.app/shipping/tracing-sources/opentelemetry-collector-lambda-extention.html