### PR TITLE
video hosted on vidyard

### DIFF
--- a/_source/user-guide/accounts/flexible-storage.md
+++ b/_source/user-guide/accounts/flexible-storage.md
@@ -18,8 +18,6 @@ Flexible volume gives you more control over how you allocate space between your 
 
 With flexible volume, accounts can share indexing capacity and use it as needed. Instead of reserving capacity in advance, you can rely on shared volume to cover your indexing needs across accounts. When properly configured, shared volume can help to optimize distribution and minimize the risk of running out of space.
 
-<!--   <script src="https://fast.wistia.com/embed/medias/jaahqzi56t.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><span class="wistia_embed wistia_async_jaahqzi56t popover=true popoverAnimateThumbnail=true" style="display:inline-block;height:270px;position:relative;width:600px">&nbsp;</span>  -->
-
 
 <iframe class="vidyard_iframe" src="//play.vidyard.com/Na9xMCntQUJFTVy3SXq4kd.html?" width="600" height="270" scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen></iframe>
 

--- a/_source/user-guide/accounts/flexible-storage.md
+++ b/_source/user-guide/accounts/flexible-storage.md
@@ -18,7 +18,11 @@ Flexible volume gives you more control over how you allocate space between your 
 
 With flexible volume, accounts can share indexing capacity and use it as needed. Instead of reserving capacity in advance, you can rely on shared volume to cover your indexing needs across accounts. When properly configured, shared volume can help to optimize distribution and minimize the risk of running out of space.
 
-<script src="https://fast.wistia.com/embed/medias/jaahqzi56t.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><span class="wistia_embed wistia_async_jaahqzi56t popover=true popoverAnimateThumbnail=true" style="display:inline-block;height:270px;position:relative;width:600px">&nbsp;</span>
+<!--   <script src="https://fast.wistia.com/embed/medias/jaahqzi56t.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><span class="wistia_embed wistia_async_jaahqzi56t popover=true popoverAnimateThumbnail=true" style="display:inline-block;height:270px;position:relative;width:600px">&nbsp;</span>  -->
+
+
+<iframe class="vidyard_iframe" src="//play.vidyard.com/Na9xMCntQUJFTVy3SXq4kd.html?" width="600" height="270" scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen></iframe>
+
 
 
 Flexible volume is a global setting that applies to your time-based logging accounts. To reach it, go to [**<i class="li li-gear"></i> > Settings > Manage accounts**](https://app.logz.io/#/dashboard/settings/manage-accounts). This page is only available when logged in to the main account as an admin user.


### PR DESCRIPTION
# What changed

Tracked down UX Slack convos that indicate that Sara embedded a video hosted on Wistia in January 2021: https://github.com/logzio/logz-docs/pull/866 
From February, the content was migrated to Vidya. The Wistia account was closed in June 2021.


> Jan 12th Sara Halper [4:23 PM]
> Remember “flexible volume”? I’ve embedded our 30 sec tutorial in the doc using Wistia. https://docs.logz.io/user-guide/accounts/flexible-volume.html

@MashaPav - please confirm that the embedded video is the correct video for this topic. 

The video was previously hosted on Wistia and is now hosted on Vidyard. 
https://deploy-preview-1531--logz-docs.netlify.app/user-guide/accounts/flexible-volume.html

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
