### PR TITLE
added link to additional filebeat modules

### DIFF
--- a/_source/logzio_collections/_log-sources/filebeat.md
+++ b/_source/logzio_collections/_log-sources/filebeat.md
@@ -27,6 +27,7 @@ order: 10
 
 * [Filebeat for Linux](#linux)
 * [Filebeat for Windows](#windows)
+* [Modules](#modules)
 {:.branching-tabs}
 
 <!-- tab:start -->
@@ -74,11 +75,6 @@ Give your logs some time to get from your system to ours, and then open [Kibana]
 If you still don't see your logs, see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
 
 </div>
-
-#### Additional resources:
-
-For additional Filebeat modules and configuration details, check out [Filebeat Modules](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-modules.html).
-
 
 </div>
 <!-- tab:end -->
@@ -143,12 +139,29 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 
 </div>
 
-#### Additional resources:
+</div>
+<!-- tab:end -->
 
-For additional Filebeat modules and configuration details, check out [Filebeat Modules](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-modules.html).
+<!-- tab:start -->
+<div id="modules">
+
+Beat shippers make use of modules to ship data from various sources. Refer to the list below to see what modules each of the shippers support.
+
+* [Apache ActiveMQ](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-activemq.html#filebeat-module-activemq)
+
+* [AWS](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-aws.html)
+
+* [Azure](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-azure.html)
+
+* [Google Cloud](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gcp.html)
+
+* [MySQL](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-mysql.html)
+
+* [Find more modules](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-modules.html)
 
 
 
 </div>
 <!-- tab:end -->
+
 

--- a/_source/logzio_collections/_log-sources/filebeat.md
+++ b/_source/logzio_collections/_log-sources/filebeat.md
@@ -75,6 +75,11 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 
 </div>
 
+#### Additional resources:
+
+For additional Filebeat modules and configuration details, check out [Filebeat Modules](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-modules.html).
+
+
 </div>
 <!-- tab:end -->
 
@@ -137,6 +142,10 @@ Give your logs some time to get from your system to ours, and then open [Kibana]
 If you still don't see your logs, see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
 
 </div>
+
+#### Additional resources:
+
+For additional Filebeat modules and configuration details, check out [Filebeat Modules](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-modules.html).
 
 
 

--- a/_source/logzio_collections/_log-sources/filebeat.md
+++ b/_source/logzio_collections/_log-sources/filebeat.md
@@ -145,7 +145,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <!-- tab:start -->
 <div id="modules">
 
-Beat shippers make use of modules to ship data from various sources. Refer to the list below to see what modules each of the shippers support.
+Beat shippers make use of modules to ship data from various sources. Refer to the list below to see which modules each shipper supports.
 
 * [Apache ActiveMQ](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-activemq.html#filebeat-module-activemq)
 


### PR DESCRIPTION
# What changed

Based on this ticket - https://logzio.atlassian.net/jira/software/c/projects/DOC/boards/177?modal=detail&selectedIssue=DOC-253&assignee=612f83adae44ae0070bbc24a

I've updated this page - added modules tab with relevant links:

https://deploy-preview-1556--logz-docs.netlify.app/shipping/log-sources/filebeat.html

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
