### PR TITLE
Removed no-search and contributors from sitemap

### DIFF
--- a/_source/logzio_collections/_contributors/_mno.md
+++ b/_source/logzio_collections/_contributors/_mno.md
@@ -5,4 +5,5 @@ github: mnevilleoneill
 
 logzio-role: Senior Customer Success Engineer
 collection: contributors
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/afishler.md
+++ b/_source/logzio_collections/_contributors/afishler.md
@@ -3,4 +3,5 @@ title: Arie Fishler
 github: afishler
 
 logzio-role: Director of Log Management & Distributed Tracing
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/amirkalron.md
+++ b/_source/logzio_collections/_contributors/amirkalron.md
@@ -4,4 +4,5 @@ linkedin: amir-kalron-7687a31
 github: amirkalron
 
 logzio-role: Software engineer
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/amosd92.md
+++ b/_source/logzio_collections/_contributors/amosd92.md
@@ -3,4 +3,5 @@ title: Amos Etzion
 github: amosd92
 
 logzio-role: Customer Support Engineer
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/ayigal.md
+++ b/_source/logzio_collections/_contributors/ayigal.md
@@ -3,4 +3,5 @@ title: Asaf Yigal
 github: ayigal
 
 logzio-role: Co-founder and VP Product
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/barakm.md
+++ b/_source/logzio_collections/_contributors/barakm.md
@@ -4,4 +4,5 @@ linkedin: /barakmerimovich/
 github: barakm
 
 logzio-role: Head of Architecture
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/boofinka.md
+++ b/_source/logzio_collections/_contributors/boofinka.md
@@ -5,4 +5,5 @@ linkedin: yotambernaz
 github: boofinka
 
 logzio-role: Customer Care Engineer
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/daniel-tk.md
+++ b/_source/logzio_collections/_contributors/daniel-tk.md
@@ -3,6 +3,7 @@ title: Daniel Tkatch
 github: daniel-tk
 
 logzio-role: Application Content Developer
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/danielberman.md
+++ b/_source/logzio_collections/_contributors/danielberman.md
@@ -4,4 +4,5 @@ twitter: proudboffin
 github: DanielBerman
 
 logzio-role: Product Marketing Manager
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/davidyer.md
+++ b/_source/logzio_collections/_contributors/davidyer.md
@@ -3,4 +3,5 @@ title: David Yerushalmi
 github: davidyer
 
 logzio-role: DevOps Security Specialist
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/dorisnaaman.md
+++ b/_source/logzio_collections/_contributors/dorisnaaman.md
@@ -4,6 +4,7 @@ linkedin: dor-doris-naaman-90243199
 github: dorisnaaman
 
 logzio-role: Security Product Analyst
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/doron-bargo.md
+++ b/_source/logzio_collections/_contributors/doron-bargo.md
@@ -4,4 +4,5 @@ linkedin:
 github: Doron-Bargo
 
 logzio-role: Director of Integrations
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/fadi-khatib.md
+++ b/_source/logzio_collections/_contributors/fadi-khatib.md
@@ -3,6 +3,7 @@ title: Fadi Khatib
 github: fadi-khatib
 
 logzio-role: Application Content Developer
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/gregoryloucas.md
+++ b/_source/logzio_collections/_contributors/gregoryloucas.md
@@ -4,4 +4,5 @@ linkedin: gregoryloucas
 github: gregoryloucas
 
 logzio-role: Solution Architect
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/hidan.md
+++ b/_source/logzio_collections/_contributors/hidan.md
@@ -5,6 +5,7 @@ github: Simplychee
 
 
 logzio-role: Keeper of the Docs
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/idohalevi.md
+++ b/_source/logzio_collections/_contributors/idohalevi.md
@@ -4,4 +4,5 @@ linkedin: ido-halevi-381603147
 github: idohalevi
 
 logzio-role: Product Manager
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/imnotashrimp.md
+++ b/_source/logzio_collections/_contributors/imnotashrimp.md
@@ -6,4 +6,5 @@ twitter: KeeperOfTheDocs
 github: imnotashrimp
 
 logzio-role: Keeper of the Copy
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/mirii1994.md
+++ b/_source/logzio_collections/_contributors/mirii1994.md
@@ -4,4 +4,5 @@ linkedin:
 github: mirii1994
 
 logzio-role: Software engineer
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/moshekruger.md
+++ b/_source/logzio_collections/_contributors/moshekruger.md
@@ -3,6 +3,7 @@ title: moshe kruger
 github: moshekruger
 
 logzio-role: Content author
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/nshishkin.md
+++ b/_source/logzio_collections/_contributors/nshishkin.md
@@ -5,6 +5,7 @@ github: nico-shishkin
 
 
 logzio-role: Keeper of the Docs
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/quintessence.md
+++ b/_source/logzio_collections/_contributors/quintessence.md
@@ -3,4 +3,5 @@ title: Quintessence Anx
 github: quintessence
 
 logzio-role: Developer Advocate
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/ralongit.md
+++ b/_source/logzio_collections/_contributors/ralongit.md
@@ -1,5 +1,6 @@
 ---
 title: Raul Gurshumov
 github: ralongit
+sitemap: false
 
 ---

--- a/_source/logzio_collections/_contributors/rhershenhoren.md
+++ b/_source/logzio_collections/_contributors/rhershenhoren.md
@@ -1,5 +1,6 @@
 ---
 title: Razi Hershenhoren
 github: razi284
+sitemap: false
 
 ---

--- a/_source/logzio_collections/_contributors/ronish31.md
+++ b/_source/logzio_collections/_contributors/ronish31.md
@@ -4,6 +4,7 @@ linkedin: roni-shaham-0b8071160
 github: ronish31
 
 logzio-role: Integration Developer
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/savidov.md
+++ b/_source/logzio_collections/_contributors/savidov.md
@@ -3,6 +3,7 @@ title: Shiran Avidov
 github: ShiranAvidov
 
 logzio-role: Application Content Developer
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/schwin007.md
+++ b/_source/logzio_collections/_contributors/schwin007.md
@@ -3,4 +3,5 @@ title: Josh Schnitzer
 github: schwin007
 
 logzio-role: Senior Support Engineer
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/shalper.md
+++ b/_source/logzio_collections/_contributors/shalper.md
@@ -4,6 +4,7 @@ linkedin: /sara-halper-011a116a/
 github: shalper
 
 logzio-role: Keeper of the Docs
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/shishkinnico.md
+++ b/_source/logzio_collections/_contributors/shishkinnico.md
@@ -3,4 +3,5 @@ title: Nico Shishkin
 github: shishkinnico
 
 logzio-role: Technical Writer
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/supereli.md
+++ b/_source/logzio_collections/_contributors/supereli.md
@@ -4,4 +4,5 @@ linkedin: elimathews
 github: supereli
 
 logzio-role: Sales Engineer
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/tdelrios.md
+++ b/_source/logzio_collections/_contributors/tdelrios.md
@@ -3,4 +3,5 @@ title: Thiago Del Rios
 github: tdelrios
 
 logzio-role: Customer Success
+sitemap: false
 ---

--- a/_source/logzio_collections/_contributors/yberlinger.md
+++ b/_source/logzio_collections/_contributors/yberlinger.md
@@ -5,6 +5,7 @@ github: YajB
 
 
 logzio-role: Keeper of the Docs
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/yheger.md
+++ b/_source/logzio_collections/_contributors/yheger.md
@@ -3,6 +3,7 @@ title: Yael Heger
 github: YaelHeger
 
 logzio-role: Application Content Developer
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/yotamloe.md
+++ b/_source/logzio_collections/_contributors/yotamloe.md
@@ -5,6 +5,7 @@ linkedin: yotam-loewenbach
 twitter: YLoewenbach
 
 logzio-role: Application Content Developer
+sitemap: false
 ---
 
 {% comment %} LEAVE CONTENT EMPTY {% endcomment %}

--- a/_source/logzio_collections/_contributors/yyyogev.md
+++ b/_source/logzio_collections/_contributors/yyyogev.md
@@ -4,4 +4,5 @@ linkedin: yogev-metzuyanim-77a0b4b5
 github: yyyogev
 
 logzio-role: Integrations Ninja
+sitemap: false
 ---

--- a/_source/logzio_collections/_docs-admin/canary.md
+++ b/_source/logzio_collections/_docs-admin/canary.md
@@ -6,6 +6,7 @@ flags:
   admin: true
   beta: true
   logzio-plan: enterprise
+sitemap: false
 open-source:
   - title: Logz.io docs
     github-repo: logz-docs

--- a/_source/logzio_collections/_docs-admin/contributing-to-docs.md
+++ b/_source/logzio_collections/_docs-admin/contributing-to-docs.md
@@ -6,6 +6,7 @@ flags:
   admin: true
   beta: true
   logzio-plan: pro
+sitemap: false
 ---
 
 ## Page flags

--- a/_source/no-search/archive4safekeeping-tracing/alice-slack-chatbot.md
+++ b/_source/no-search/archive4safekeeping-tracing/alice-slack-chatbot.md
@@ -5,6 +5,7 @@ description: Use Alice to work with your Logz.io accounts. Search your logs, see
 permalink: /integrations/alice-slack-chatbot.html
 flags:
   logzio-plan: pro
+sitemap: false
 open-source:
   - title: Alice
     github-repo: slack-integration

--- a/_source/no-search/archive4safekeeping-tracing/jaeger.md
+++ b/_source/no-search/archive4safekeeping-tracing/jaeger.md
@@ -5,6 +5,7 @@ logo:
   orientation: vertical
 data-source: Jaeger
 description: Here's how you can use Logz.io as data storage for Jaeger traces.
+sitemap: false
 open-source:
   - title: Jaeger-Logz.io Trace Storage
     github-repo: jaeger-logzio

--- a/_source/no-search/archive4safekeeping-tracing/jaeger_collector.md
+++ b/_source/no-search/archive4safekeeping-tracing/jaeger_collector.md
@@ -5,6 +5,7 @@ logo:
   orientation: vertical
 data-source: Jaeger Collector
 description: How to deploy a Logz.io Jaeger Collector
+sitemap: false
 open-source:
   - title: jaeger-logzio
     github-repo: jaeger-logzio

--- a/_source/no-search/archive4safekeeping-tracing/k8s-deployment-with_jaegercollector.md
+++ b/_source/no-search/archive4safekeeping-tracing/k8s-deployment-with_jaegercollector.md
@@ -4,6 +4,7 @@ title: Kubernetes deployment reference
 permalink: /user-guide/distributed-tracing/k8s-deployment
 flags:
   logzio-plan: pro enterprise
+sitemap: false
 tags:
   - distributed tracing
 contributors:

--- a/_source/no-search/archive4safekeeping-tracing/k8s-deployment_pre-June2021.md
+++ b/_source/no-search/archive4safekeeping-tracing/k8s-deployment_pre-June2021.md
@@ -2,6 +2,7 @@
 layout: article
 title: Kubernetes deployment reference
 permalink: #/user-guide/distributed-tracing/k8s-deployment
+sitemap: false
 flags:
   logzio-plan: pro enterprise
 tags:

--- a/_source/no-search/archive4safekeeping-tracing/tracing-highlights.md
+++ b/_source/no-search/archive4safekeeping-tracing/tracing-highlights.md
@@ -4,6 +4,7 @@ title: Distributed Tracing table of contents
 permalink: /user-guide/distributed-tracing/tracing-highlights
 flags:
   logzio-plan: community
+sitemap: false
 tags:
   - distributed tracing
 contributors:

--- a/_source/no-search/archive4safekeeping-tracing/tracing-navigation.md
+++ b/_source/no-search/archive4safekeeping-tracing/tracing-navigation.md
@@ -4,7 +4,8 @@ title: Parent
 permalink: /user-guide/distributed-tracing/navigation
 flags:
   logzio-plan: community
-  beta: true 
+  beta: true
+sitemap: false
 tags:
   - distributed tracing
 contributors:

--- a/_source/no-search/archive4safekeeping-tracing/zipkin.md
+++ b/_source/no-search/archive4safekeeping-tracing/zipkin.md
@@ -6,6 +6,7 @@ logo:
 data-source: Zipkin
 templates: ["no-template"]
 description: Here's how you can use Logz.io as data storage for Zipkin traces.
+sitemap: false
 open-source:
   - title: Zipkin-Logz.io Trace Storage
     github-repo: zipkin-logzio

--- a/_source/no-search/credits.md
+++ b/_source/no-search/credits.md
@@ -2,6 +2,7 @@
 layout: article
 title: Our writers
 permalink: /credits.html
+sitemap: false
 show-date: false
 community-info: false
 ---

--- a/_source/no-search/drafts/permissions-detailed.md
+++ b/_source/no-search/drafts/permissions-detailed.md
@@ -5,6 +5,7 @@ permalink: /user-guide/user-permissions/
 flags:
   admin: true
   logzio-plan: community
+sitemap: false
 tags:
   - users
 contributors:

--- a/_source/no-search/exceptions-deployments.md
+++ b/_source/no-search/exceptions-deployments.md
@@ -5,6 +5,7 @@ permalink: /user-guide/insights/exceptions/deployments.html
 flags:
   logzio-plan: community
   beta: true
+sitemap: false
 tags:
   - insights
   - exceptions

--- a/_source/no-search/finding-your-account-id.md
+++ b/_source/no-search/finding-your-account-id.md
@@ -5,6 +5,7 @@ permalink: /user-guide/accounts/finding-your-account-id.html
 flags:
   admin: true
   logzio-plan: community
+sitemap: false
 tags:
   - accounts
 contributors:

--- a/_source/no-search/flexible-storage-api-changes.md
+++ b/_source/no-search/flexible-storage-api-changes.md
@@ -3,6 +3,7 @@ layout: article
 title: API changes following the release of flexible volume
 permalink: /user-guide/accounts/flexible-volume-announcement/
 flags:
+sitemap: false
 tags:
   - accounts
   - main-account

--- a/_source/no-search/p8s-remote-write_obsolete.md
+++ b/_source/no-search/p8s-remote-write_obsolete.md
@@ -4,10 +4,12 @@ title: Remote write for Prometheus
 permalink: /user-guide/metrics/p8s-remote-write.html
 flags:
   logzio-plan: community
+sitemap: false
 tags:
   - metrics integrations
 contributors:
   - yberlinger
+ 
 ---
 This topic is for Prometheus users migrating their solution to Logz.io Infrastructure Monitoring.
 

--- a/_source/no-search/prometheus-importing-bulk-dashbds.md
+++ b/_source/no-search/prometheus-importing-bulk-dashbds.md
@@ -5,6 +5,7 @@ permalink: /user-guide/infrastructure-monitoring/prometheus-importing-dashbds.ht
 flags:
   logzio-plan:  
   beta: true
+sitemap: false
 tags:
   - metrics integrations
 contributors:

--- a/_source/no-search/prometheus-importing-dashbds-manual only.md
+++ b/_source/no-search/prometheus-importing-dashbds-manual only.md
@@ -4,6 +4,7 @@ title: Importing metrics dashboards
 permalink: /user-guide/infrastructure-monitoring/prometheus-importing-dashbds-manual-only.html
 flags:
   logzio-plan: pro 
+sitemap: false
 tags:
   - metrics integrations
 contributors:

--- a/_source/no-search/test.md
+++ b/_source/no-search/test.md
@@ -2,6 +2,7 @@
 layout: article
 title: TEST PAGE
 permalink: /test/
+sitemap: false
 # community-info: false
 ---
 

--- a/_source/no-search/training.md
+++ b/_source/no-search/training.md
@@ -4,6 +4,7 @@ title: Logz.io Training 101
 permalink: /training/
 flags:
   logzio-plan: community
+sitemap: false
 tags:
   - training
 ---


### PR DESCRIPTION
# What changed

Added a `sitemap: false` tag to all pages under /no-search/ and /contributors/ based on [documentation from the Jekyll sitemap](https://github.com/jekyll/jekyll-sitemap) addon that we're using.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
