### PR TITLE
Note for sending logs via TCP

### DIFF
--- a/_source/logzio_collections/_log-sources/json-uploads.md
+++ b/_source/logzio_collections/_log-sources/json-uploads.md
@@ -142,6 +142,7 @@ Keep to these practices when shipping JSON logs over TCP:
 
 * Each log must be a single-line JSON object
 * Each log line must be 500,000 bytes or less
+* Each log line must be followed by a `\n` (even the last log)
 * Include your account token as a top-level property: `{ ... "token": "<<LOG-SHIPPING-TOKEN>>" , ... }`
 
 #### Send TLS/SSL streams over TCP


### PR DESCRIPTION
# What changed

Added a note for sending logs via TCP.
Without a `\n` after the last log, the last log won't appear in our system.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
