### PR TITLE
Added manual cloudformation deployment

### DIFF
--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -166,7 +166,6 @@ Save the template as a yaml file and add the values of your stack to the as per 
 
 | Parameter | Description |
 |---|---|
-| Stack name | logzio-cur-auto-deployment |
 | CloudWatchEventScheduleExpression | `Default: rate(10 hours)` The scheduling expression that determines when and how often the Lambda function runs. Logz.io recommends to start with 10 hours rate. |
 | LambdaMemorySize | `Default: 1024 (MB)` The amount of memory available to the function at runtime. Logz.io recommends to start with 1024 MB. |
 | LambdaTimeout | `Default: 300 (seconds)` The amount of time that Lambda allows a function to run before stopping it. Logz.io recommends to start with 300 seconds (5 minutes). |

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -159,7 +159,7 @@ On the **Logzio::awsCostAndUsage::cur::MODULE** page, navigate to **Example temp
                 "ReportTimeUnit": "ReportTimeUnit",
                 "ReportAdditionalSchemaElements": "ReportAdditionalSchemaElements",
                 "LogzioURL": "LogzioURL",
-                "LogzioToken": "LogzioToken",
+                "LogzioToken": "<<LOG-SHIPPING-TOKEN>>",
                 "LambdaMemorySize": "LambdaMemorySize",
                 "LambdaTimeout": "LambdaTimeout",
                 "CloudWatchEventScheduleExpression": "CloudWatchEventScheduleExpression"
@@ -208,7 +208,7 @@ If you are editing an existing stack:
                 "ReportTimeUnit": "ReportTimeUnit",
                 "ReportAdditionalSchemaElements": "ReportAdditionalSchemaElements",
                 "LogzioURL": "LogzioURL",
-                "LogzioToken": "LogzioToken",
+                "LogzioToken": "<<LOG-SHIPPING-TOKEN>>",
                 "LambdaMemorySize": "LambdaMemorySize",
                 "LambdaTimeout": "LambdaTimeout",
                 "CloudWatchEventScheduleExpression": "CloudWatchEventScheduleExpression"

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -18,6 +18,17 @@ shipping-tags:
   - aws
 order: 830
 ---
+
+<!-- tabContainer:start -->
+<div class="branching-container">
+
+* [Manual configuration](#manual-configuration)
+* [Automated CloudFormation deployment](#automated-cloudformation-deployment)
+{:.branching-tabs}
+
+<!-- tab:start -->
+<div id="manual-configuration">
+
 AWS Cost and Usage Reports function tracks your AWS usage and provides estimated charges associated with your account. This integration allows you to ship logs from your AWS Cost and Usage Reports to your Logz.io account.
 
 #### Configuration
@@ -91,3 +102,122 @@ To get more out of this functionality, you can enable a dedicated AWS cost and u
 If you still don't see your logs, see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
 
 </div>
+
+</div>
+<!-- tab:end -->
+
+<!-- tab:start -->
+<div id="manual-cloudformation-deployment">
+
+#### Manual CloudFormation deployment
+
+{% include log-shipping/note-lambda-test.md %}
+
+**Before you begin, you'll need**:
+
+* A CloudFormation stack
+* An S3 bucket to store the CloudFormation package
+
+<div class="tasklist">
+
+##### Select the Logz.io AWS Cost and Usage extension
+
+1. Navigate to **CloudFormation > Registry > Public extensions**.
+2. Set **Extension type > Modules** and **Publisher > Third party**.
+3. Select **Logzio::awsCostAndUsage::cur::MODULE**.
+
+
+##### Activate the Logz.io AWS Cost and Usage extension
+
+1. On the **Logzio::awsCostAndUsage::cur::MODULE** select **Activate**.
+2. In the **Extension details** section, select **Use default**.
+3. In the **Automatic updates** section, select **On**.
+4. Select **Activate extension**.
+
+##### Copy the configuration template
+
+On the **Logzio::awsCostAndUsage::cur::MODULE** page, navigate to **Example template** and select **Copy template**.
+
+##### Add your stack values to the configuration template
+
+```yaml
+{
+    "Resources": {
+        "MyModule": {
+            "Type": "Logzio::awsCostAndUsage::cur::MODULE",
+            "Properties": {
+                "S3BucketName": "S3BucketName",
+                "ReportName": "ReportName",
+                "ReportPrefix": "ReportPrefix",
+                "ReportTimeUnit": "ReportTimeUnit",
+                "ReportAdditionalSchemaElements": "ReportAdditionalSchemaElements",
+                "LogzioURL": "LogzioURL",
+                "LogzioToken": "LogzioToken",
+                "LambdaMemorySize": "LambdaMemorySize",
+                "LambdaTimeout": "LambdaTimeout",
+                "CloudWatchEventScheduleExpression": "CloudWatchEventScheduleExpression"
+            }
+        }
+    }
+}
+```
+
+Save the template as a yaml file and add the values of your stack to the as per the table below.
+
+| Parameter | Description |
+|---|---|
+| Stack name | logzio-cur-auto-deployment |
+| CloudWatchEventScheduleExpression | `Default: rate(10 hours)` The scheduling expression that determines when and how often the Lambda function runs. Logz.io recommends to start with 10 hours rate. |
+| LambdaMemorySize | `Default: 1024 (MB)` The amount of memory available to the function at runtime. Logz.io recommends to start with 1024 MB. |
+| LambdaTimeout | `Default: 300 (seconds)` The amount of time that Lambda allows a function to run before stopping it. Logz.io recommends to start with 300 seconds (5 minutes). |
+| LogzioToken | Your Logz.io log shipping token:`<<LOG-SHIPPING-TOKEN>>` {% include log-shipping/log-shipping-token.html %} |
+| LogzioURL | The Logz.io listener URL: `https://<<LISTENER-HOST>>:8071` {% include log-shipping/listener-var.html %} |
+| ReportAdditionalSchemaElements | Choose INCLUDE if you want AWS to include additional details about individual resources IDs in the report (This might significantly increase the report size and might affect performance. AWS Lambda can run for up to 15 minutes with up to 10240 MB, and the process time for the whole file must end within this timeframe.) This is an optional parameter. |
+| ReportName | The name of report that you want to create. |
+| ReportPrefix | The prefix that AWS adds to the report name when AWS delivers the report. |
+| ReportTimeUnit | The granularity of the line items in the report. Can be Hourly, Daily or Monthly. (Enabling hourly reports does not mean that a new report is generated every hour. It means that data in the report is aggregated with a granularity of one hour.) |
+| S3BucketName | The name for the bucket which will contain the report files. |
+
+##### Add your stack values to the configuration template
+
+If you are creating a new stack:
+
+1. In step 1 of the **Create stack** process, select **Template is ready**.
+2. Select **Upload a template file**.
+
+If you are editing an existing stack:
+
+1. Select the stack.
+2. Select **Update**.
+3. Select **Edit template in designer**.
+4. Paste the contents of the yaml file into the **Resources** section of the template as follows:
+
+   ```yaml
+   "MyModule": {
+            "Type": "Logzio::awsCostAndUsage::cur::MODULE",
+            "Properties": {
+                "S3BucketName": "S3BucketName",
+                "ReportName": "ReportName",
+                "ReportPrefix": "ReportPrefix",
+                "ReportTimeUnit": "ReportTimeUnit",
+                "ReportAdditionalSchemaElements": "ReportAdditionalSchemaElements",
+                "LogzioURL": "LogzioURL",
+                "LogzioToken": "LogzioToken",
+                "LambdaMemorySize": "LambdaMemorySize",
+                "LambdaTimeout": "LambdaTimeout",
+                "CloudWatchEventScheduleExpression": "CloudWatchEventScheduleExpression"
+            }
+        }
+   ```
+5. If required, change the module name by editing the `"MyModule"` value.
+
+
+
+</div>
+
+</div>
+<!-- tab:end -->
+
+
+</div>
+<!-- tabContainer:end -->

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -23,7 +23,7 @@ order: 830
 <div class="branching-container">
 
 * [Manual configuration](#manual-configuration)
-* [Manual CloudFormation deployment](#manual-cloudformation-deployment)
+* [Deployment using a module](#module-deployment)
 {:.branching-tabs}
 
 <!-- tab:start -->
@@ -107,7 +107,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <!-- tab:end -->
 
 <!-- tab:start -->
-<div id="manual-cloudformation-deployment">
+<div id="module-deployment">
 
 #### Manual CloudFormation deployment
 

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -158,7 +158,7 @@ On the **Logzio::awsCostAndUsage::cur::MODULE** page, navigate to **Example temp
                 "ReportPrefix": "ReportPrefix",
                 "ReportTimeUnit": "ReportTimeUnit",
                 "ReportAdditionalSchemaElements": "ReportAdditionalSchemaElements",
-                "LogzioURL": "LogzioURL",
+                "LogzioURL": "https://<<LISTENER-HOST>>:8071",
                 "LogzioToken": "<<LOG-SHIPPING-TOKEN>>",
                 "LambdaMemorySize": "LambdaMemorySize",
                 "LambdaTimeout": "LambdaTimeout",

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -109,7 +109,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <!-- tab:start -->
 <div id="module-deployment">
 
-#### Manual CloudFormation deployment
+#### Deployment using a module
 
 {% include log-shipping/note-lambda-test.md %}
 

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -111,7 +111,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 
 #### Deployment using a module
   
-Deploy this integration to add a module for AWS cost and usage report to your existing stack. This integration uses Cloudwatch Public Registry.
+Deploy this integration to add a module for AWS cost and usage report to your existing stack. This integration uses CloudWatch Public Registry.
 
 <!-- info-box-start:info -->
 Logz.io Public Registry extensions are currently only available on the AWS region `us-east-1`.

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -23,7 +23,7 @@ order: 830
 <div class="branching-container">
 
 * [Manual configuration](#manual-configuration)
-* [Automated CloudFormation deployment](#automated-cloudformation-deployment)
+* [Manual CloudFormation deployment](#manual-cloudformation-deployment)
 {:.branching-tabs}
 
 <!-- tab:start -->

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -113,6 +113,11 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
   
 Deploy this integration to add a module for AWS cost and usage report to your existing stack. This integration uses Cloudwatch Public Registry.
 
+<!-- info-box-start:info -->
+Logz.io Public Registry extensions are currently only available on the AWS region `us-east-1`.
+{:.info-box.note}
+<!-- info-box-end -->
+
 {% include log-shipping/note-lambda-test.md %}
 
 **Before you begin, you'll need**:

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -110,6 +110,8 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <div id="module-deployment">
 
 #### Deployment using a module
+  
+Deploy this integration to add a module for AWS cost and usage report to your existing stack. This integration uses Cloudwatch Public Registry.
 
 {% include log-shipping/note-lambda-test.md %}
 

--- a/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
+++ b/_source/logzio_collections/_log-sources/aws-cost-and-usage-report.md
@@ -22,21 +22,29 @@ order: 830
 <!-- tabContainer:start -->
 <div class="branching-container">
 
-* [Manual configuration](#manual-configuration)
+* [Overview](#overview)
+* [Automated CloudFormation deployment](#auto-configuration)
 * [Deployment using a module](#module-deployment)
 {:.branching-tabs}
-
+  
 <!-- tab:start -->
-<div id="manual-configuration">
+<div id="overview">
+  
 
 AWS Cost and Usage Reports function tracks your AWS usage and provides estimated charges associated with your account. This integration allows you to ship logs from your AWS Cost and Usage Reports to your Logz.io account.
-
-#### Configuration
 
 <!-- info-box-start:info -->
 Your Lambda function needs to run within the AWS Lambda limits, such as memory allocation and timeout. Make sure you understand these limits. If you can't adjust your settings to stay within the Lambda limits, you can use the AWS [Support Center console](https://console.aws.amazon.com/support/v1#/case/create?issueType=service-limit-increase) to request an increase. [Learn more about AWS Lambda Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html).
 {:.info-box.important}
 <!-- info-box-end -->
+  
+</div>
+<!-- tab:end -->
+
+<!-- tab:start -->
+<div id="auto-configuration">
+
+#### Automated CloudFormation deployment
 
 This deployment will automatically create the following resources:
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -25,7 +25,7 @@ order: 110
 
 * [Manual Lambda configuration](#manual-lambda-configuration)
 * [Automated CloudFormation deployment](#automated-cloudformation-deployment)
-* [Manual CloudFormation deployment](#manual-cloudformation-deployment)
+* [Deployment using a module](#module-deployment)
 * [Terraform deployment](#terraform-deployment)
 {:.branching-tabs}
 
@@ -216,7 +216,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <!-- tab:end -->
 
 <!-- tab:start -->
-<div id="manual-cloudformation-deployment">
+<div id="module-deployment">
 
 #### Manual CloudFormation deployment
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -220,6 +220,9 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 
 #### Deployment using a module
 
+Deploy this integration to add a module for Cloudwatch to your existing stack. This integration uses Cloudwatch Public Registry.
+
+
 {% include log-shipping/note-lambda-test.md %}
 
 **Before you begin, you'll need**:

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -25,6 +25,7 @@ order: 110
 
 * [Manual Lambda configuration](#manual-lambda-configuration)
 * [Automated CloudFormation deployment](#automated-cloudformation-deployment)
+* [Manual CloudFormation deployment](#manual-cloudformation-deployment)
 * [Terraform deployment](#terraform-deployment)
 {:.branching-tabs}
 
@@ -211,6 +212,110 @@ Give your logs some time to get from your system to ours, and then open [Kibana]
 If you still don't see your logs, see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
 
 </div>
+</div>
+<!-- tab:end -->
+
+<!-- tab:start -->
+<div id="manual-cloudformation-deployment">
+
+#### Manual CloudFormation deployment
+
+{% include log-shipping/note-lambda-test.md %}
+
+**Before you begin, you'll need**:
+
+* A CloudFormation stack
+* An S3 bucket to store the CloudFormation package
+
+<div class="tasklist">
+
+##### Select the Logz.io AWS Cloudwatch extension
+
+1. Navigate to **CloudFormation > Registry > Public extensions**.
+2. Set **Extension type > Modules** and **Publisher > Third party**.
+3. Select **logzio::autoDeploymentLogzio::CloudWatch::MODULE**.
+
+
+##### Activate the Logz.io AWS Cloudwatch extension
+
+1. On the **logzio::autoDeploymentLogzio::CloudWatch** select **Activate**.
+2. In the **Extension details** section, select **Use default**.
+3. In the **Automatic updates** section, select **On**.
+4. Select **Activate extension**.
+
+##### Copy the configuration template
+
+On the **logzio::autoDeploymentLogzio::CloudWatch** page, navigate to **Example template** and select **Copy template**.
+
+##### Add your stack values to the configuration template
+
+```yaml
+{
+    "Resources": {
+        "MyModule": {
+            "Type": "logzio::autoDeploymentLogzio::CloudWatch::MODULE",
+            "Properties": {
+                "LogzioListenerUrl": "LogzioListenerUrl",
+                "LogzioToken": "LogzioToken",
+                "LogzioType": "LogzioType",
+                "LogzioFormat": "LogzioFormat",
+                "LogzioCompress": "LogzioCompress",
+                "LogzioSendAll": "LogzioSendAll",
+                "LogzioEnrich": "LogzioEnrich",
+                "LogGroup": "LogGroup"
+            }
+        }
+    }
+}
+```
+
+Save the template as a yaml file and add the values of your stack to the as per the table below.
+
+
+| Parameter | Description | Required/Default |
+|---|---|---|
+| LogzioToken | Your Logz.io account token. {% include log-shipping/log-shipping-token.html %}  | Required  |
+| LogzioListenerUrl |  {% include log-shipping/listener-var.md %}
+| LogzioType | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type.    You should create a new Lambda for each log type you use. | `logzio_cloudwatch_lambda` |
+| LogzioFormat | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. | `text` |
+| LogzioCompress | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. | `false` |
+| LogzioEnrich | Enrich CloudWatch events with custom properties, formatted as `key1=value1;key2=value2`. | -- |
+
+##### Add your stack values to the configuration template
+
+If you are creating a new stack:
+
+1. In step 1 of the **Create stack** process, select **Template is ready**.
+2. Select **Upload a template file**.
+
+If you are editing an existing stack:
+
+1. Select the stack.
+2. Select **Update**.
+3. Select **Edit template in designer**.
+4. Paste the contents of the yaml file into the **Resources** section of the template as follows:
+
+   ```yaml
+   "MyModule": {
+            "Type": "logzio::autoDeploymentLogzio::CloudWatch::MODULE",
+            "Properties": {
+                "LogzioListenerUrl": "LogzioListenerUrl",
+                "LogzioToken": "LogzioToken",
+                "LogzioType": "LogzioType",
+                "LogzioFormat": "LogzioFormat",
+                "LogzioCompress": "LogzioCompress",
+                "LogzioSendAll": "LogzioSendAll",
+                "LogzioEnrich": "LogzioEnrich",
+                "LogGroup": "LogGroup"
+            }
+        }
+   ```
+5. If required, change the module name by editing the `"MyModule"` value.
+
+
+
+</div>
+
 </div>
 <!-- tab:end -->
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -138,8 +138,9 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 {% include log-shipping/note-lambda-test.md %}
 
 **Before you begin, you'll need**:
-AWS CLI,
-an S3 bucket to store the CloudFormation package
+  
+* AWS CLI
+* An S3 bucket to store the CloudFormation package
 
 <div class="tasklist">
 
@@ -232,7 +233,6 @@ Logz.io Public Registry extensions are currently only available on the AWS regio
 **Before you begin, you'll need**:
 
 * A CloudFormation stack
-* An S3 bucket to store the CloudFormation package
 
 <div class="tasklist">
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -221,7 +221,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 
 #### Deployment using a module
 
-Deploy this integration to add a module for Cloudwatch to your existing stack. This integration uses Cloudwatch Public Registry.
+Deploy this integration to add a module for CloudWatch to your existing stack. This integration uses CloudWatch Public Registry.
   
 <!-- info-box-start:info -->
 Logz.io Public Registry extensions are currently only available on the AWS region `us-east-1`.

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -308,7 +308,7 @@ If you are editing an existing stack:
    "MyModule": {
             "Type": "logzio::autoDeploymentLogzio::CloudWatch::MODULE",
             "Properties": {
-                "LogzioListenerUrl": "LogzioListenerUrl",
+                "LogzioListenerUrl": "https://<<LISTENER-HOST>>:8071",
                 "LogzioToken": "<<LOG-SHIPPING-TOKEN>>",
                 "LogzioType": "LogzioType",
                 "LogzioFormat": "LogzioFormat",

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -263,7 +263,7 @@ On the **logzio::autoDeploymentLogzio::CloudWatch** page, navigate to **Example 
             "Type": "logzio::autoDeploymentLogzio::CloudWatch::MODULE",
             "Properties": {
                 "LogzioListenerUrl": "LogzioListenerUrl",
-                "LogzioToken": "LogzioToken",
+                "LogzioToken": "<<LOG-SHIPPING-TOKEN>>",
                 "LogzioType": "LogzioType",
                 "LogzioFormat": "LogzioFormat",
                 "LogzioCompress": "LogzioCompress",
@@ -309,7 +309,7 @@ If you are editing an existing stack:
             "Type": "logzio::autoDeploymentLogzio::CloudWatch::MODULE",
             "Properties": {
                 "LogzioListenerUrl": "LogzioListenerUrl",
-                "LogzioToken": "LogzioToken",
+                "LogzioToken": "<<LOG-SHIPPING-TOKEN>>",
                 "LogzioType": "LogzioType",
                 "LogzioFormat": "LogzioFormat",
                 "LogzioCompress": "LogzioCompress",

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -262,7 +262,7 @@ On the **logzio::autoDeploymentLogzio::CloudWatch** page, navigate to **Example 
         "MyModule": {
             "Type": "logzio::autoDeploymentLogzio::CloudWatch::MODULE",
             "Properties": {
-                "LogzioListenerUrl": "LogzioListenerUrl",
+                "LogzioListenerUrl": "https://<<LISTENER-HOST>>:8071",
                 "LogzioToken": "<<LOG-SHIPPING-TOKEN>>",
                 "LogzioType": "LogzioType",
                 "LogzioFormat": "LogzioFormat",

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -233,6 +233,7 @@ Logz.io Public Registry extensions are currently only available on the AWS regio
 **Before you begin, you'll need**:
 
 * A CloudFormation stack
+* An S3 bucket to store the CloudFormation package
 
 <div class="tasklist">
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -221,7 +221,11 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 #### Deployment using a module
 
 Deploy this integration to add a module for Cloudwatch to your existing stack. This integration uses Cloudwatch Public Registry.
-
+  
+<!-- info-box-start:info -->
+Logz.io Public Registry extensions are currently only available on the AWS region `us-east-1`.
+{:.info-box.note}
+<!-- info-box-end -->
 
 {% include log-shipping/note-lambda-test.md %}
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -218,7 +218,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <!-- tab:start -->
 <div id="module-deployment">
 
-#### Manual CloudFormation deployment
+#### Deployment using a module
 
 {% include log-shipping/note-lambda-test.md %}
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -274,13 +274,15 @@ Save the template as a yaml file and add the values of your stack to the as per 
 
 | Parameter | Description | Required/Default |
 |---|---|---|
+| LogzioListenerUrl |  {% include log-shipping/listener-var.md %} | |
 | LogzioToken | Your Logz.io account token. {% include log-shipping/log-shipping-token.html %}  | Required  |
-| LogzioListenerUrl |  {% include log-shipping/listener-var.md %}
 | LogzioType | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type.    You should create a new Lambda for each log type you use. | `logzio_cloudwatch_lambda` |
 | LogzioFormat | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. | `text` |
 | LogzioCompress | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. | `false` |
+| LogzioSendAll | Set to `true` to send all logs |  |
 | LogzioEnrich | Enrich CloudWatch events with custom properties, formatted as `key1=value1;key2=value2`. | -- |
-
+| LogGroup | CloudWatch log group. | -- |
+  
 ##### Add your stack values to the configuration template
 
 If you are creating a new stack:

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -26,7 +26,7 @@ order: 750
 
 * [Manual Lambda configuration](#manual-lambda-configuration)
 * [Automated CloudFormation deployment](#automated-cloudformation-deployment)
-* [Manual CloudFormation deployment](#manual-cloudformation-deployment)
+* [Deployment using a module](#module-deployment)
 {:.branching-tabs}
 
 <!-- tab:start -->
@@ -185,7 +185,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <!-- tab:end -->
 
 <!-- tab:start -->
-<div id="manual-cloudformation-deployment">
+<div id="module-deployment">
 
 #### Manual CloudFormation deployment
 

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -236,7 +236,7 @@ On the **Logzio::KinesisShipper::KinesisShipper::MODULE** page, navigate to **Ex
                 "LogzioCOMPRESS": "LogzioCOMPRESS",
                 "LogzioMessagesArray": "LogzioMessagesArray",
                 "KinesisStreamBatchSize": "KinesisStreamBatchSize",
-                "LogzioURL": "LogzioURL",
+                "LogzioURL": "https://<<LISTENER-HOST>>:8071",
                 "KinesisStreamStartingPosition": "KinesisStreamStartingPosition",
                 "LogzioTYPE": "LogzioTYPE",
                 "KinesisStream": "KinesisStream"

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -286,7 +286,7 @@ If you are editing an existing stack:
                    "LogzioCOMPRESS": "LogzioCOMPRESS",
                    "LogzioMessagesArray": "LogzioMessagesArray",
                    "KinesisStreamBatchSize": "KinesisStreamBatchSize",
-                   "LogzioURL": "LogzioURL",
+                   "LogzioURL": "https://<<LISTENER-HOST>>:8071",
                    "KinesisStreamStartingPosition": "KinesisStreamStartingPosition",
                    "LogzioTYPE": "LogzioTYPE",
                    "KinesisStream": "KinesisStream"

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -15,6 +15,7 @@ contributors:
   - imnotashrimp
   - ronish31
   - yyyogev
+  - nshishkin
 shipping-tags:
   - aws
 order: 750
@@ -25,6 +26,7 @@ order: 750
 
 * [Manual Lambda configuration](#manual-lambda-configuration)
 * [Automated CloudFormation deployment](#automated-cloudformation-deployment)
+* [Manual CloudFormation deployment](#manual-cloudformation-deployment)
 {:.branching-tabs}
 
 <!-- tab:start -->
@@ -181,6 +183,117 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 
 </div>
 <!-- tab:end -->
+
+<!-- tab:start -->
+<div id="manual-cloudformation-deployment">
+
+#### Manual CloudFormation deployment
+
+{% include log-shipping/note-lambda-test.md %}
+
+**Before you begin, you'll need**:
+
+* A CloudFormation stack
+* An S3 bucket to store the CloudFormation package
+
+<div class="tasklist">
+
+##### Select the Logz.io Kinesis extension
+
+1. Navigate to **CloudFormation > Registry > Public extensions**.
+2. Set **Extension type > Modules** and **Publisher > Third party**.
+3. Select **Logzio::KinesisShipper::KinesisShipper::MODULE**.
+
+
+##### Activate the Logz.io Kinesis extension
+
+1. On the **Logzio::KinesisShipper::KinesisShipper::MODULE** select **Activate**.
+2. In the **Extension details** section, select **Use default**.
+3. In the **Automatic updates** section, select **On**.
+4. Select **Activate extension**.
+
+##### Copy the configuration template
+
+On the **Logzio::KinesisShipper::KinesisShipper::MODULE** page, navigate to **Example template** and select **Copy template**.
+
+##### Add your stack values to the configuration template
+
+```yaml
+{
+    "Resources": {
+        "MyModule": {
+            "Type": "Logzio::KinesisShipper::KinesisShipper::MODULE",
+            "Properties": {
+                "LogzioTOKEN": "LogzioTOKEN",
+                "LogzioFORMAT": "LogzioFORMAT",
+                "LogzioREGION": "LogzioREGION",
+                "LogzioCOMPRESS": "LogzioCOMPRESS",
+                "LogzioMessagesArray": "LogzioMessagesArray",
+                "KinesisStreamBatchSize": "KinesisStreamBatchSize",
+                "LogzioURL": "LogzioURL",
+                "KinesisStreamStartingPosition": "KinesisStreamStartingPosition",
+                "LogzioTYPE": "LogzioTYPE",
+                "KinesisStream": "KinesisStream"
+            }
+        }
+    }
+}
+```
+
+Save the template as a yaml file and add the values of your stack to the as per the table below.
+
+| Parameter | Description |  Required/Default |
+|---|---|---|
+| LogzioTOKEN | Your Logz.io account token. {% include log-shipping/log-shipping-token.html %} | Required  |
+| KinesisStream | The name of the Kinesis stream where this function will listen for updates. | Required  |
+| LogzioREGION | Two-letter region code, or blank for US East (Northern Virginia). Logz.io 2-letter region code. {% include log-shipping/listener-var.html %} | Required | 
+| LogzioURL (Deprecated) | Use LogzioREGION instead. | -- |
+| LogzioTYPE | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type.    You should create a new Lambda for each log type you use. | `kinesis_lambda` |
+| LogzioFORMAT  | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. | `text` |
+| LogzioCOMPRESS | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. | `false` |
+| KinesisStreamBatchSize | The largest number of records to read from your stream at one time. | `100` |
+| KinesisStreamStartingPosition | The position in the stream to start reading from. For more information, see [ShardIteratorType](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html) in the Amazon Kinesis API Reference. | `LATEST` |
+
+##### Add your stack values to the configuration template
+
+If you are creating a new stack:
+
+1. In step 1 of the **Create stack** process, select **Template is ready**.
+2. Select **Upload a template file**.
+
+If you are editing an existing stack:
+
+1. Select the stack.
+2. Select **Update**.
+3. Select **Edit template in designer**.
+4. Paste the contents of the yaml file into the **Resources** section of the template as follows:
+
+   ```yaml
+   "MyModule": {
+               "Type": "Logzio::KinesisShipper::KinesisShipper::MODULE",
+               "Properties": {
+                   "LogzioTOKEN": "LogzioTOKEN",
+                   "LogzioFORMAT": "LogzioFORMAT",
+                   "LogzioREGION": "LogzioREGION",
+                   "LogzioCOMPRESS": "LogzioCOMPRESS",
+                   "LogzioMessagesArray": "LogzioMessagesArray",
+                   "KinesisStreamBatchSize": "KinesisStreamBatchSize",
+                   "LogzioURL": "LogzioURL",
+                   "KinesisStreamStartingPosition": "KinesisStreamStartingPosition",
+                   "LogzioTYPE": "LogzioTYPE",
+                   "KinesisStream": "KinesisStream"
+               }
+           }
+   ```
+5. If required, change the module name by editing the `"MyModule"` value.
+
+
+
+</div>
+
+</div>
+<!-- tab:end -->
+
 
 </div>
 <!-- tabContainer:end -->

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -191,6 +191,10 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
   
 Deploy this integration to add a module for Kinesis to your existing stack. This integration uses Cloudwatch Public Registry.
 
+<!-- info-box-start:info -->
+Logz.io Public Registry extensions are currently only available on the AWS region `us-east-1`.
+{:.info-box.note}
+<!-- info-box-end -->
 
 {% include log-shipping/note-lambda-test.md %}
 

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -187,7 +187,7 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <!-- tab:start -->
 <div id="module-deployment">
 
-#### Manual CloudFormation deployment
+#### Deployment using a module
 
 {% include log-shipping/note-lambda-test.md %}
 

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -188,6 +188,9 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 <div id="module-deployment">
 
 #### Deployment using a module
+  
+Deploy this integration to add a module for Kinesis to your existing stack. This integration uses Cloudwatch Public Registry.
+
 
 {% include log-shipping/note-lambda-test.md %}
 

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -201,7 +201,6 @@ Logz.io Public Registry extensions are currently only available on the AWS regio
 **Before you begin, you'll need**:
 
 * A CloudFormation stack
-* An S3 bucket to store the CloudFormation package
 
 <div class="tasklist">
 

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -201,6 +201,7 @@ Logz.io Public Registry extensions are currently only available on the AWS regio
 **Before you begin, you'll need**:
 
 * A CloudFormation stack
+* An S3 bucket to store the CloudFormation package
 
 <div class="tasklist">
 

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -230,7 +230,7 @@ On the **Logzio::KinesisShipper::KinesisShipper::MODULE** page, navigate to **Ex
         "MyModule": {
             "Type": "Logzio::KinesisShipper::KinesisShipper::MODULE",
             "Properties": {
-                "LogzioTOKEN": "LogzioTOKEN",
+                "LogzioTOKEN": "<<LOG-SHIPPING-TOKEN>>",
                 "LogzioFORMAT": "LogzioFORMAT",
                 "LogzioREGION": "LogzioREGION",
                 "LogzioCOMPRESS": "LogzioCOMPRESS",
@@ -279,7 +279,7 @@ If you are editing an existing stack:
    "MyModule": {
                "Type": "Logzio::KinesisShipper::KinesisShipper::MODULE",
                "Properties": {
-                   "LogzioTOKEN": "LogzioTOKEN",
+                   "LogzioTOKEN": "<<LOG-SHIPPING-TOKEN>>",
                    "LogzioFORMAT": "LogzioFORMAT",
                    "LogzioREGION": "LogzioREGION",
                    "LogzioCOMPRESS": "LogzioCOMPRESS",

--- a/_source/logzio_collections/_log-sources/kinesis.md
+++ b/_source/logzio_collections/_log-sources/kinesis.md
@@ -246,13 +246,14 @@ Save the template as a yaml file and add the values of your stack to the as per 
 |---|---|---|
 | LogzioTOKEN | Your Logz.io account token. {% include log-shipping/log-shipping-token.html %} | Required  |
 | KinesisStream | The name of the Kinesis stream where this function will listen for updates. | Required  |
-| LogzioREGION | Two-letter region code, or blank for US East (Northern Virginia). Logz.io 2-letter region code. {% include log-shipping/listener-var.html %} | Required | 
-| LogzioURL (Deprecated) | Use LogzioREGION instead. | -- |
-| LogzioTYPE | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type.    You should create a new Lambda for each log type you use. | `kinesis_lambda` |
+| LogzioREGION | Two-letter region code, or blank for US East (Northern Virginia). Logz.io 2-letter region code. | Required | 
+| LogzioURL | {% include log-shipping/listener-var.html %} | -- |
+| LogzioTYPE | The log type you'll use with this Lambda. This can be a [built-in log type]({{site.baseurl}}/user-guide/log-shipping/built-in-log-types.html), or a custom log type.    You should create a new Lambda for each log type you use. | `logzio_kinesis_stream` |
 | LogzioFORMAT  | `json` or `text`. If `json`, the Lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. | `text` |
 | LogzioCOMPRESS | Set to `true` to compress logs before sending them. Set to `false` to send uncompressed logs. | `false` |
 | KinesisStreamBatchSize | The largest number of records to read from your stream at one time. | `100` |
 | KinesisStreamStartingPosition | The position in the stream to start reading from. For more information, see [ShardIteratorType](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html) in the Amazon Kinesis API Reference. | `LATEST` |
+| LogzioMessagesArray | Set this variable to split the a record into multiple logs based on a field containing an array |  |
 
 ##### Add your stack values to the configuration template
 

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -109,6 +109,9 @@ If you still don't see your events, see [log shipping troubleshooting]({{site.ba
 
 </div>
 </div>
+  
+
+<!-- tab:end -->
 
 <!-- tab:start -->
 <div id="manual-cloudformation-deployment">

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -174,7 +174,7 @@ Save the template as a yaml file and add the values of your stack to the as per 
 | Parameter | Description |
 | --- | --- |
 | `<<LISTENER-HOST>>` | Your Logz.io [listener url](https://docs.logz.io/user-guide/accounts/account-region.html), followed by port `8070` or `8071`. For example, `https://listener.logz.io:8071` |
-| `logzioLogLevel` | Log level for the Lambda function. Defaults to `info`. Valid options are: `debug`, `info`, `warn`, `error`, `fatal`, `panic`. |
+| `<<LOGZIO-LOG-LEVEL>>` | Log level for the Lambda function. Defaults to `info`. Valid options are: `debug`, `info`, `warn`, `error`, `fatal`, `panic`. |
 | `<<LOG-SHIPPING-TOKEN>>` | Your Logz.io [operations token](https://app.logz.io/#/dashboard/settings/general). |
 
 ##### Add your stack values to the configuration template

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -197,7 +197,7 @@ If you are editing an existing stack:
             "Type": "logzio::awsSecurityHub::collector::MODULE",
             "Properties": {
                 "logzioOperationsToken": "<<LOG-SHIPPING-TOKEN>>",
-                "logzioListener": "logzioListener",
+                "logzioListener": "https://<<LISTENER-HOST>>:8071",
                 "logzioLogLevel": "logzioLogLevel"
             }
         }

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -161,7 +161,7 @@ On the **logzio::awsSecurityHub::collector::MODULE** page, navigate to **Example
             "Type": "logzio::awsSecurityHub::collector::MODULE",
             "Properties": {
                 "logzioOperationsToken": "<<LOG-SHIPPING-TOKEN>>",
-                "logzioListener": "logzioListener",
+                "logzioListener": "https://<<LISTENER-HOST>>:8071",
                 "logzioLogLevel": "logzioLogLevel"
             }
         }

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -21,7 +21,7 @@ order: 830
 
 * [Overview](#overview)
 * [Automated CloudFormation deployment](#automated-cloudformation-deployment)
-* [Manual CloudFormation deployment](#manual-cloudformation-deployment)
+* [Deployment using a module](#module-deployment)
 {:.branching-tabs}
 
 <!-- tab:start -->
@@ -115,9 +115,9 @@ If you still don't see your events, see [log shipping troubleshooting]({{site.ba
 <!-- tab:end -->
 
 <!-- tab:start -->
-<div id="manual-cloudformation-deployment">
+<div id="module-deployment">
 
-#### Manual CloudFormation deployment
+#### Deployment using a module
 
 {% include log-shipping/note-lambda-test.md %}
 

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -121,6 +121,10 @@ If you still don't see your events, see [log shipping troubleshooting]({{site.ba
   
 Deploy this integration to add a module for AWS security hub to your existing stack. This integration uses Cloudwatch Public Registry.
 
+<!-- info-box-start:info -->
+Logz.io Public Registry extensions are currently only available on the AWS region `us-east-1`.
+{:.info-box.note}
+<!-- info-box-end -->
 
 {% include log-shipping/note-lambda-test.md %}
 

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -19,7 +19,7 @@ order: 830
 <!-- tabContainer:start -->
 <div class="branching-container">
 
-* [Overview](#manual-lambda-configuration)
+* [Overview](#overview)
 * [Automated CloudFormation deployment](#automated-cloudformation-deployment)
 * [Manual CloudFormation deployment](#manual-cloudformation-deployment)
 {:.branching-tabs}

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -108,6 +108,8 @@ Give the stack some time to deploy and the resources to get created. Once this i
 If you still don't see your events, see [log shipping troubleshooting]({{site.baseurl}}/user-guide/log-shipping/log-shipping-troubleshooting.html).
 
 </div>
+
+</div>
 </div>
   
 <!-- tab:end -->

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -16,6 +16,17 @@ shipping-tags:
 order: 830
 ---
 
+<!-- tabContainer:start -->
+<div class="branching-container">
+
+* [Overview](#manual-lambda-configuration)
+* [Automated CloudFormation deployment](#automated-cloudformation-deployment)
+* [Manual CloudFormation deployment](#manual-cloudformation-deployment)
+{:.branching-tabs}
+
+<!-- tab:start -->
+<div id="overview">
+
 #### Overview
 
 This integration ships events from AWS Security Hub to Logz.io. It will automatically deploy [resources](#resources) to your AWS Account.
@@ -27,6 +38,14 @@ Your Lambda function needs to run within the AWS Lambda limits, such as memory a
 {:.info-box.important}
 <!-- info-box-end -->
 
+</div>
+
+<!-- tab:end -->
+
+<!-- tab:start -->
+<div id="automated-cloudformation-deployment">
+
+#### Automated CloudFormation deployment
 
 <div class="tasklist">
 
@@ -74,6 +93,7 @@ Specify the **Key** and **Value** parameters for the **Tags** and select **Next*
 Confirm that you acknowledge that AWS CloudFormation might create IAM resources and select **Create stack**.
 
 <div id="resources">
+
 ##### Deployed resources
 
 This deployment will automatically create the following resources:
@@ -89,3 +109,94 @@ If you still don't see your events, see [log shipping troubleshooting]({{site.ba
 
 </div>
 </div>
+
+<!-- tab:start -->
+<div id="manual-cloudformation-deployment">
+
+#### Manual CloudFormation deployment
+
+{% include log-shipping/note-lambda-test.md %}
+
+**Before you begin, you'll need**:
+
+* A CloudFormation stack
+* An S3 bucket to store the CloudFormation package
+
+<div class="tasklist">
+
+##### Select the Logz.io AWS Security Hub extension
+
+1. Navigate to **CloudFormation > Registry > Public extensions**.
+2. Set **Extension type > Modules** and **Publisher > Third party**.
+3. Select **logzio::awsSecurityHub::collector::MODULE**.
+
+
+##### Activate the Logz.io Kinesis extension
+
+1. On the **logzio::awsSecurityHub::collector::MODULE** select **Activate**.
+2. In the **Extension details** section, select **Use default**.
+3. In the **Automatic updates** section, select **On**.
+4. Select **Activate extension**.
+
+##### Copy the configuration template
+
+On the **logzio::awsSecurityHub::collector::MODULE** page, navigate to **Example template** and select **Copy template**.
+
+##### Add your stack values to the configuration template
+
+```yaml
+{
+    "Resources": {
+        "MyModule": {
+            "Type": "logzio::awsSecurityHub::collector::MODULE",
+            "Properties": {
+                "logzioOperationsToken": "logzioOperationsToken",
+                "logzioListener": "logzioListener",
+                "logzioLogLevel": "logzioLogLevel"
+            }
+        }
+    }
+}
+```
+
+Save the template as a yaml file and add the values of your stack to the as per the table below.
+
+| Parameter | Description |  
+|---|---|---|
+| logzioOperationsToken | Your Logz.io account token. {% include log-shipping/log-shipping-token.html %} |
+| logzioListener | {% include log-shipping/listener-var.html %} | 
+| logzioLogLevel | Required log level.  | 
+
+##### Add your stack values to the configuration template
+
+If you are creating a new stack:
+
+1. In step 1 of the **Create stack** process, select **Template is ready**.
+2. Select **Upload a template file**.
+
+If you are editing an existing stack:
+
+1. Select the stack.
+2. Select **Update**.
+3. Select **Edit template in designer**.
+4. Paste the contents of the yaml file into the **Resources** section of the template as follows:
+
+   ```yaml
+   "Resources": {
+        "MyModule": {
+            "Type": "logzio::awsSecurityHub::collector::MODULE",
+            "Properties": {
+                "logzioOperationsToken": "logzioOperationsToken",
+                "logzioListener": "logzioListener",
+                "logzioLogLevel": "logzioLogLevel"
+            }
+        }
+    }
+   ```
+5. If required, change the module name by editing the `"MyModule"` value.
+
+</div>
+<!-- tab:end -->
+
+</div>
+<!-- tabContainer:end -->

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -160,7 +160,7 @@ On the **logzio::awsSecurityHub::collector::MODULE** page, navigate to **Example
         "MyModule": {
             "Type": "logzio::awsSecurityHub::collector::MODULE",
             "Properties": {
-                "logzioOperationsToken": "logzioOperationsToken",
+                "logzioOperationsToken": "<<LOG-SHIPPING-TOKEN>>",
                 "logzioListener": "logzioListener",
                 "logzioLogLevel": "logzioLogLevel"
             }
@@ -196,7 +196,7 @@ If you are editing an existing stack:
         "MyModule": {
             "Type": "logzio::awsSecurityHub::collector::MODULE",
             "Properties": {
-                "logzioOperationsToken": "logzioOperationsToken",
+                "logzioOperationsToken": "<<LOG-SHIPPING-TOKEN>>",
                 "logzioListener": "logzioListener",
                 "logzioLogLevel": "logzioLogLevel"
             }

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -175,7 +175,7 @@ Save the template as a yaml file and add the values of your stack to the as per 
 | --- | --- |
 | `logzioListener` | Your Logz.io [listener url](https://docs.logz.io/user-guide/accounts/account-region.html), followed by port `8070` or `8071`. For example, `https://listener.logz.io:8071` |
 | `logzioLogLevel` | Log level for the Lambda function. Defaults to `info`. Valid options are: `debug`, `info`, `warn`, `error`, `fatal`, `panic`. |
-| `logzioOperationsToken` | Your Logz.io [operations token](https://app.logz.io/#/dashboard/settings/general). |
+| `<<LOG-SHIPPING-TOKEN>>` | Your Logz.io [operations token](https://app.logz.io/#/dashboard/settings/general). |
 
 ##### Add your stack values to the configuration template
 

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -162,7 +162,7 @@ On the **logzio::awsSecurityHub::collector::MODULE** page, navigate to **Example
             "Properties": {
                 "logzioOperationsToken": "<<LOG-SHIPPING-TOKEN>>",
                 "logzioListener": "https://<<LISTENER-HOST>>:8071",
-                "logzioLogLevel": "logzioLogLevel"
+                "logzioLogLevel": "<<LOGZIO-LOG-LEVEL>>"
             }
         }
     }

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -173,7 +173,7 @@ Save the template as a yaml file and add the values of your stack to the as per 
 
 | Parameter | Description |
 | --- | --- |
-| `logzioListener` | Your Logz.io [listener url](https://docs.logz.io/user-guide/accounts/account-region.html), followed by port `8070` or `8071`. For example, `https://listener.logz.io:8071` |
+| `<<LISTENER-HOST>>` | Your Logz.io [listener url](https://docs.logz.io/user-guide/accounts/account-region.html), followed by port `8070` or `8071`. For example, `https://listener.logz.io:8071` |
 | `logzioLogLevel` | Log level for the Lambda function. Defaults to `info`. Valid options are: `debug`, `info`, `warn`, `error`, `fatal`, `panic`. |
 | `<<LOG-SHIPPING-TOKEN>>` | Your Logz.io [operations token](https://app.logz.io/#/dashboard/settings/general). |
 

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -135,7 +135,7 @@ If you still don't see your events, see [log shipping troubleshooting]({{site.ba
 3. Select **logzio::awsSecurityHub::collector::MODULE**.
 
 
-##### Activate the Logz.io Kinesis extension
+##### Activate the Logz.io AWS Security Hub extension
 
 1. On the **logzio::awsSecurityHub::collector::MODULE** select **Activate**.
 2. In the **Extension details** section, select **Use default**.

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -131,7 +131,6 @@ Logz.io Public Registry extensions are currently only available on the AWS regio
 **Before you begin, you'll need**:
 
 * A CloudFormation stack
-* An S3 bucket to store the CloudFormation package
 
 <div class="tasklist">
 

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -198,7 +198,7 @@ If you are editing an existing stack:
             "Properties": {
                 "logzioOperationsToken": "<<LOG-SHIPPING-TOKEN>>",
                 "logzioListener": "https://<<LISTENER-HOST>>:8071",
-                "logzioLogLevel": "logzioLogLevel"
+                "logzioLogLevel": "<<LOGZIO-LOG-LEVEL>>"
             }
         }
     }

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -165,11 +165,11 @@ On the **logzio::awsSecurityHub::collector::MODULE** page, navigate to **Example
 
 Save the template as a yaml file and add the values of your stack to the as per the table below.
 
-| Parameter | Description |  
-|---|---|---|
-| logzioOperationsToken | Your Logz.io account token. {% include log-shipping/log-shipping-token.html %} |
-| logzioListener | {% include log-shipping/listener-var.html %} | 
-| logzioLogLevel | Required log level.  | 
+| Parameter | Description |
+| --- | --- |
+| `logzioListener` | Your Logz.io [listener url](https://docs.logz.io/user-guide/accounts/account-region.html), followed by port `8070` or `8071`. For example, `https://listener.logz.io:8071` |
+| `logzioLogLevel` | Log level for the Lambda function. Defaults to `info`. Valid options are: `debug`, `info`, `warn`, `error`, `fatal`, `panic`. |
+| `logzioOperationsToken` | Your Logz.io [operations token](https://app.logz.io/#/dashboard/settings/general). |
 
 ##### Add your stack values to the configuration template
 

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -110,7 +110,6 @@ If you still don't see your events, see [log shipping troubleshooting]({{site.ba
 </div>
 </div>
   
-
 <!-- tab:end -->
 
 <!-- tab:start -->
@@ -197,6 +196,8 @@ If you are editing an existing stack:
     }
    ```
 5. If required, change the module name by editing the `"MyModule"` value.
+
+</div>
 
 </div>
 <!-- tab:end -->

--- a/_source/logzio_collections/_security-sources/aws-security-hub.md
+++ b/_source/logzio_collections/_security-sources/aws-security-hub.md
@@ -118,6 +118,9 @@ If you still don't see your events, see [log shipping troubleshooting]({{site.ba
 <div id="module-deployment">
 
 #### Deployment using a module
+  
+Deploy this integration to add a module for AWS security hub to your existing stack. This integration uses Cloudwatch Public Registry.
+
 
 {% include log-shipping/note-lambda-test.md %}
 


### PR DESCRIPTION
# What changed



https://deploy-preview-1635--logz-docs.netlify.app/shipping/security-sources/aws-security-hub.html#manual-cloudformation-deployment

https://deploy-preview-1635--logz-docs.netlify.app/shipping/log-sources/aws-cost-and-usage-report.html#manual-cloudformation-deployment

https://deploy-preview-1635--logz-docs.netlify.app/shipping/log-sources/kinesis.html#manual-cloudformation-deployment

https://deploy-preview-1635--logz-docs.netlify.app/shipping/log-sources/cloudwatch.html#manual-cloudformation-deployment


----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
