### PR TITLE
Added test events tab to cloudwatch

### DIFF
--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -523,11 +523,15 @@ You can generate test events using the Logz.io Lambda test events generator and 
 
 ##### Generate a test event
 
-In your terminal, run the following command:
+1. In your terminal, run the following command:
 
-```shell
-bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tree/master/python3/cloudwatch/test_events/test_event_generator.sh)
-```
+   ```shell
+   bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tree/master/python3/cloudwatch/test_events/test_event_generator.sh)
+   ```
+               
+   This script generates a test event with a UTC timestamp of the moment you run the script.
+               
+2. Copy the output JSON.
 
 ##### Add the generated test event to your Lambda function
 
@@ -536,13 +540,13 @@ bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tr
 3. Select **New event**.
 4. In the **Template** field, select **CloudWatch Logs**.
 5. In the **Name** field, enter a name for the test event. No specific naming convention is required. 
-6. Populate the body field with the JSON output of the test event generated in the previous step.
+6. Populate the body field with the output JSON of the test event generated in the previous step.
 7. Select **Format** to format the test event.
 8. Select **Save changes**.
 
 ##### Run the test event
 
-To run the test event, select **Test** in the **Test** tab. The Lambda function will run and generate two logs in your account. The timestamp of the test event is in the UTC timezone.
+To run the test event, select **Test** in the **Test** tab. The Lambda function will run and generate two logs in your account.
 
 </div>
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -27,14 +27,13 @@ order: 110
 * [Automated CloudFormation deployment](#automated-cloudformation-deployment)
 * [Deployment using a module](#module-deployment)
 * [Terraform deployment](#terraform-deployment)
+* [Test events](#test-events)
 {:.branching-tabs}
 
 <!-- tab:start -->
 <div id="manual-lambda-configuration">
 
 #### Manual configuration with a Lambda function
-
-{% include log-shipping/note-lambda-test.md %}
 
 <div class="tasklist">
 
@@ -135,8 +134,6 @@ If you still don't see your logs, see [log shipping troubleshooting]({{site.base
 
 #### Automated CloudFormation deployment
 
-{% include log-shipping/note-lambda-test.md %}
-
 **Before you begin, you'll need**:
   
 * AWS CLI
@@ -227,8 +224,6 @@ Deploy this integration to add a module for CloudWatch to your existing stack. T
 Logz.io Public Registry extensions are currently only available on the AWS region `us-east-1`.
 {:.info-box.note}
 <!-- info-box-end -->
-
-{% include log-shipping/note-lambda-test.md %}
 
 **Before you begin, you'll need**:
 
@@ -511,6 +506,45 @@ To destroy the resources, use the following:
 ```bash
 terraform destroy
 ```
+</div>
+
+</div>
+<!-- tab:end -->
+
+<!-- tab:start -->
+<div id="test-events">
+
+#### Working with test events
+
+You can generate test events using the Logz.io Lambda test events generator and add these events to your Lambda function. This functionality is currently only available on Linux & macOS.
+
+
+<div class="tasklist">
+
+##### Generate a test event
+
+In your terminal, run the following command:
+
+```shell
+bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tree/master/python3/cloudwatch/test_events/test_event_generator.sh)
+```
+
+##### Add the generated test event to your Lambda function
+
+1. Select the Lambda function that you need to add the test event to.
+2. Open the **Test** tab.
+3. Select **New event**.
+4. In the **Template** field, select **CloudWatch Logs**.
+5. In the **Name** field, enter the required name for the test event.
+6. Populate the body field with the value of the test event generated in the previous step.
+7. Select **Format** to format the test event.
+8. Select **Save changes**.
+
+##### Run the test event
+
+To run the test event, select **Test** in the **Test** tab. The Lambda function will run and generate two logs in your account. The timestamp of the test event is in the UTC timezone.
+
+</div>
 
 </div>
 <!-- tab:end -->

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -524,13 +524,10 @@ You can generate test events using the Logz.io Lambda test events generator and 
 ##### Generate a test event
 
 1. In your terminal, run the following command:
-
-</div>
   
    ```shell
    bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tree/master/python3/cloudwatch/test_events/test_event_generator.sh)      
    ```
-</div>
                
    This script generates a test event with a UTC timestamp of the moment you run the script.
                

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -525,10 +525,8 @@ You can generate test events using the Logz.io Lambda test events generator and 
 
 1. In your terminal, run the following command:
 
-   ```shell
-  
-   bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tree/master/python3/cloudwatch/test_events/test_event_generator.sh)
-               
+   ```ini
+   bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tree/master/python3/cloudwatch/test_events/test_event_generator.sh)      
    ```
                
    This script generates a test event with a UTC timestamp of the moment you run the script.

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -546,7 +546,8 @@ You can generate test events using the Logz.io Lambda test events generator and 
 
 ##### Run the test event
 
-To run the test event, select **Test** in the **Test** tab. The Lambda function will run and generate two logs in your account.
+To run the test event, select **Test** in the **Test** tab. The Lambda function will run and generate the following two logs in your account:
+`[ERROR] Logz.io cloudwatch test log1` `[ERROR] Logz.io cloudwatch test log2`
 
 </div>
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -525,9 +525,12 @@ You can generate test events using the Logz.io Lambda test events generator and 
 
 1. In your terminal, run the following command:
 
-   ```ini
+</div>
+  
+   ```shell
    bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tree/master/python3/cloudwatch/test_events/test_event_generator.sh)      
    ```
+</div>
                
    This script generates a test event with a UTC timestamp of the moment you run the script.
                

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -535,7 +535,7 @@ bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tr
 2. Open the **Test** tab.
 3. Select **New event**.
 4. In the **Template** field, select **CloudWatch Logs**.
-5. In the **Name** field, enter the required name for the test event.
+5. In the **Name** field, enter a name for the test event. No specific naming convention is required. 
 6. Populate the body field with the JSON output of the test event generated in the previous step.
 7. Select **Format** to format the test event.
 8. Select **Save changes**.

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -536,7 +536,7 @@ bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tr
 3. Select **New event**.
 4. In the **Template** field, select **CloudWatch Logs**.
 5. In the **Name** field, enter the required name for the test event.
-6. Populate the body field with the value of the test event generated in the previous step.
+6. Populate the body field with the JSON output of the test event generated in the previous step.
 7. Select **Format** to format the test event.
 8. Select **Save changes**.
 

--- a/_source/logzio_collections/_log-sources/cloudwatch.md
+++ b/_source/logzio_collections/_log-sources/cloudwatch.md
@@ -526,7 +526,9 @@ You can generate test events using the Logz.io Lambda test events generator and 
 1. In your terminal, run the following command:
 
    ```shell
+  
    bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tree/master/python3/cloudwatch/test_events/test_event_generator.sh)
+               
    ```
                
    This script generates a test event with a UTC timestamp of the moment you run the script.


### PR DESCRIPTION
# What changed

https://deploy-preview-1657--logz-docs.netlify.app/shipping/log-sources/cloudwatch.html#test-events

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
