### PR TITLE
lambda extension - add type to instructions

### DIFF
--- a/_source/logzio_collections/_log-sources/lambda-extensions.md
+++ b/_source/logzio_collections/_log-sources/lambda-extensions.md
@@ -168,6 +168,8 @@ aws lambda update-function-configuration \
     --environment "Variables={}"
 ```
 
+Your lambda logs will appear under the type `lambda-extension-logs`.
+
 
 <!-- info-box-start:info -->
 This command overwrites the existing function configuration. If you already have your own layers and environment variables for your function, include them in the list.
@@ -223,6 +225,7 @@ Add the environment variables to the function, according to the [**Environment v
 ##### Run the function
 
 Run the function. It may take more than one run of the function for the logs to start shipping to your Logz.io account.
+Your lambda logs will appear under the type `lambda-extension-logs`.
 
 </div>
 


### PR DESCRIPTION
# What changed

Add a line in the doc that explains under which type the logs should appear in the kibana, so that users will be able to look for it if they need to.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
