### PR TITLE
mark `region` parameter required in traces docs 

### DIFF
--- a/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
@@ -172,7 +172,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
@@ -172,7 +172,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
@@ -172,7 +172,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
@@ -172,7 +172,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
@@ -176,7 +176,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` -Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service name
 

--- a/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
@@ -176,7 +176,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` -Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service name
 

--- a/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
@@ -176,7 +176,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service name
 

--- a/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
@@ -176,7 +176,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service name
 

--- a/_source/logzio_collections/_tracing-sources/go-otel.md
+++ b/_source/logzio_collections/_tracing-sources/go-otel.md
@@ -452,7 +452,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/go-otel.md
+++ b/_source/logzio_collections/_tracing-sources/go-otel.md
@@ -452,7 +452,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/go-otel.md
+++ b/_source/logzio_collections/_tracing-sources/go-otel.md
@@ -452,7 +452,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -83,7 +83,7 @@ receivers:
 exporters:
   logzio:
     account_token: <<TRACING-SHIPPING-TOKEN>>
-    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your Logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: <<LOGZIO_ACCOUNT_REGION_CODE>>
     
 processors:
   batch:

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -83,7 +83,7 @@ receivers:
 exporters:
   logzio:
     account_token: <<TRACING-SHIPPING-TOKEN>>
-    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your Logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
     
 processors:
   batch:

--- a/_source/logzio_collections/_tracing-sources/jaeger_collector.md
+++ b/_source/logzio_collections/_tracing-sources/jaeger_collector.md
@@ -83,7 +83,7 @@ receivers:
 exporters:
   logzio:
     account_token: <<TRACING-SHIPPING-TOKEN>>
-    #region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
     
 processors:
   batch:

--- a/_source/logzio_collections/_tracing-sources/nestjs-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/nestjs-otel-auto.md
@@ -350,7 +350,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is different than [US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/nestjs-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/nestjs-otel-auto.md
@@ -350,7 +350,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/nodejs-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/nodejs-otel-auto.md
@@ -187,7 +187,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your logz.io account region code.[available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces dns name
 

--- a/_source/logzio_collections/_tracing-sources/nodejs-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/nodejs-otel-auto.md
@@ -187,7 +187,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your logz.io account region code.[available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces dns name
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -65,7 +65,7 @@ Add the following parameters to the configuration file of your OpenTelemetry col
 ```yaml
   logzio:
     account_token: <<TRACING-SHIPPING-TOKEN>>
-    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" #Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: <<LOGZIO_ACCOUNT_REGION_CODE>>
 ```
 
 * Under the `service` list:
@@ -93,7 +93,7 @@ receivers:
 exporters:
   logzio:
     account_token: "<<TRACING-SHIPPING-TOKEN>>"
-    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>"
 
 processors:
   batch:
@@ -212,7 +212,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Check Logz.io for your traces
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -65,7 +65,7 @@ Add the following parameters to the configuration file of your OpenTelemetry col
 ```yaml
   logzio:
     account_token: <<TRACING-SHIPPING-TOKEN>>
-    #region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" #Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 ```
 
 * Under the `service` list:
@@ -93,7 +93,7 @@ receivers:
 exporters:
   logzio:
     account_token: "<<TRACING-SHIPPING-TOKEN>>"
-    #region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 processors:
   batch:
@@ -212,7 +212,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Check Logz.io for your traces
 

--- a/_source/logzio_collections/_tracing-sources/python-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/python-otel-auto.md
@@ -78,7 +78,7 @@ receivers:
 exporters:
   logzio:
     account_token: "<<TRACING-SHIPPING-TOKEN>>"
-    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>"
 
 processors:
   batch:
@@ -212,7 +212,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/python-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/python-otel-auto.md
@@ -78,7 +78,7 @@ receivers:
 exporters:
   logzio:
     account_token: "<<TRACING-SHIPPING-TOKEN>>"
-    #region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 processors:
   batch:
@@ -212,7 +212,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 ##### Define the logzio-otel-traces service dns
 

--- a/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
@@ -197,7 +197,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` - Your Logz.io account region code. [Available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 
 ##### Define the logzio-otel-traces service dns

--- a/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
@@ -197,7 +197,7 @@ logzio-otel-traces logzio-helm/logzio-otel-traces
 ```
 
 {% include /tracing-shipping/replace-tracing-token.html %}
-`<<LOGZIO_ACCOUNT_REGION_CODE>>` - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+`<<LOGZIO_ACCOUNT_REGION_CODE>>` Your logz.io account region code. [available regions](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 
 ##### Define the logzio-otel-traces service dns

--- a/_source/logzio_collections/_tracing-sources/zipkin-installation.md
+++ b/_source/logzio_collections/_tracing-sources/zipkin-installation.md
@@ -71,8 +71,8 @@ receivers:
 
 exporters:
   logzio:
-    account_token: <<TRACING-SHIPPING-TOKEN>>
-    #region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    account_token: "<<TRACING-SHIPPING-TOKEN>>"
+    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
 
 processors:
   batch:

--- a/_source/logzio_collections/_tracing-sources/zipkin-installation.md
+++ b/_source/logzio_collections/_tracing-sources/zipkin-installation.md
@@ -72,7 +72,7 @@ receivers:
 exporters:
   logzio:
     account_token: "<<TRACING-SHIPPING-TOKEN>>"
-    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" # Your logz.io account region code. Defaults to "us". Required only if your logz.io region is [different than US East](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions).
+    region: "<<LOGZIO_ACCOUNT_REGION_CODE>>"
 
 processors:
   batch:


### PR DESCRIPTION
Since the launch of opentelemetry collector contrib version 0.55.0
The `region` parameter in our exporter has no default value since we added the option to set `endpoint` to a custom HTTP destination.
Our exporter is requiring `region` or `endpoint` parameters set
I went over our tracing docs and removed the optional mark from `region`