### PR TITLE
Fix misleading comment `seconds -> milliseconds`

### DIFF
--- a/_source/logzio_collections/_prometheus-sources/nodejs-custom-metrics.md
+++ b/_source/logzio_collections/_prometheus-sources/nodejs-custom-metrics.md
@@ -60,7 +60,7 @@ const metricExporter = new sdk.RemoteWriteExporter(collectorOptions);
 // Initialize the meter provider
 const meter = new MeterProvider.MeterProvider({
     exporter: metricExporter,
-    interval: 15000, // Push interval in seconds
+    interval: 15000, // Push interval in milliseconds
 }).getMeter('example-exporter');
 
 


### PR DESCRIPTION
Fix misleading comment `seconds -> milliseconds`