### PR TITLE
Metrics - redirecting deprecated links

### DIFF
--- a/_source/_data/toc.yml
+++ b/_source/_data/toc.yml
@@ -219,8 +219,8 @@ firstLevel:
     
     
     
-  - title: Elastic-based Metrics information #deprecated topics
-    url: /user-guide/infrastructure-monitoring/elastic-metrics
+  #- title: Elastic-based Metrics information #deprecated topics
+  #  url: /user-guide/infrastructure-monitoring/elastic-metrics
   - title: Troubleshooting
     thirdLevel:
     - title: Kubernetes with Helm

--- a/netlify.toml
+++ b/netlify.toml
@@ -397,3 +397,33 @@
   to = "/shipping/#prometheus-sources"
   status = 301
   force = true
+
+[[redirects]]
+  from = "/user-guide/infrastructure-monitoring/elastic-metrics"
+  to = "/user-guide/infrastructure-monitoring/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/user-guide/metrics/integrations.html"
+  to = "/user-guide/infrastructure-monitoring/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/user-guide/metrics/data-sources.html"
+  to = "/user-guide/infrastructure-monitoring/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/user-guide/infrastructure-monitoring/data-rollups.html"
+  to = "/user-guide/infrastructure-monitoring/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/user-guide/infrastructure-monitoring/metrics-explore/"
+  to = "/user-guide/infrastructure-monitoring/"
+  status = 301
+  force = true


### PR DESCRIPTION
# What changed

https://deploy-preview-2062--logz-docs.netlify.app/user-guide/infrastructure-monitoring/elastic-metrics
https://deploy-preview-2062--logz-docs.netlify.app/user-guide/metrics/integrations.html
https://deploy-preview-2062--logz-docs.netlify.app/user-guide/metrics/data-sources.html
https://deploy-preview-2062--logz-docs.netlify.app/user-guide/infrastructure-monitoring/data-rollups.html
https://deploy-preview-2062--logz-docs.netlify.app/user-guide/infrastructure-monitoring/metrics-explore/