### PR TITLE
Shippers - Changing *note* to *important*

### DIFF
--- a/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-framework-otel-auto.md
@@ -156,7 +156,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 

--- a/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/dotnet-otel-auto.md
@@ -157,7 +157,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 #### Standard configuration

--- a/_source/logzio_collections/_tracing-sources/go-otel.md
+++ b/_source/logzio_collections/_tracing-sources/go-otel.md
@@ -435,7 +435,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 #### Standard configuration

--- a/_source/logzio_collections/_tracing-sources/java-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/java-otel-auto.md
@@ -233,7 +233,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 #### Standard configuration

--- a/_source/logzio_collections/_tracing-sources/kafka-java-otel-auto copy.md
+++ b/_source/logzio_collections/_tracing-sources/kafka-java-otel-auto copy.md
@@ -145,7 +145,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 #### Standard configuration

--- a/_source/logzio_collections/_tracing-sources/nestjs-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/nestjs-otel-auto.md
@@ -334,7 +334,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 #### Standard configuration

--- a/_source/logzio_collections/_tracing-sources/nodejs-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/nodejs-otel-auto.md
@@ -170,7 +170,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 #### Standard configuration

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -41,7 +41,7 @@ This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Col
 
 <div class="tasklist">
 
-##### Add the OpenTelemetry collector layer to your Lambda function
+##### Add the OpenTelemetry collector layer to your Lambda function 
 
 This layer contains the OpenTelemetry collector that will capture data from your application.
 

--- a/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry-nodejs-lambda.md
@@ -36,7 +36,7 @@ Adding environmental variables using the AWS CLI commands below, will overwrite 
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 <div class="tasklist">

--- a/_source/logzio_collections/_tracing-sources/opentelemetry.md
+++ b/_source/logzio_collections/_tracing-sources/opentelemetry.md
@@ -249,7 +249,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 #### Standard configuration

--- a/_source/logzio_collections/_tracing-sources/otel-traces-helm.md
+++ b/_source/logzio_collections/_tracing-sources/otel-traces-helm.md
@@ -26,7 +26,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 ###### Sending logs from nodes with taints

--- a/_source/logzio_collections/_tracing-sources/python-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/python-otel-auto.md
@@ -241,7 +241,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 #### Standard configuration

--- a/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
+++ b/_source/logzio_collections/_tracing-sources/ruby-otel-auto.md
@@ -181,7 +181,7 @@ This chart is a fork of the [opentelemtry-collector](https://github.com/open-tel
 
 <!-- info-box-start:info -->
 This integration uses OpenTelemetry Collector Contrib, not the OpenTelemetry Collector Core.
-{:.info-box.note}
+{:.info-box.important}
 <!-- info-box-end -->
 
 


### PR DESCRIPTION
# What changed

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/opentelemetry.html#kubernetes

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/dotnet-otel-auto.html#kubernetes

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/dotnet-framework-otel-auto.html#kubernetes

* https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/opentelemetry-nodejs-lambda.html *

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/java-otel-auto.html#kubernetes

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/python-otel-auto.html#kubernetes 

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/nodejs-otel-auto.html#kubernetes

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/nestjs-otel-auto.html#kubernetes

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/kafka-java-otel-auto-copy.html#kubernetes

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/ruby-otel-auto.html#kubernetes 

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/go-otel.html#kubernetes

https://deploy-preview-2086--logz-docs.netlify.app/shipping/tracing-sources/otel-traces-helm.html 
