### PR TITLE
fix failing workflow

### DIFF
--- a/.github/workflows/git-secrets.yml
+++ b/.github/workflows/git-secrets.yml
@@ -9,7 +9,7 @@ jobs:
   # This workflow contains a single job called "main"
   git-secrets:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -22,12 +22,14 @@ jobs:
           python-version: 3.8
       - name: Installing dependencies
         run:
-          sudo apt-get install git less openssh-server
+          sudo apt-get install less openssh-server
       - name: Installing scanning tool
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           brew install git-secrets
           git secrets --install
           git secrets --register-aws 
       - name: Running scanning tool
         run:
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           git secrets --scan


### PR DESCRIPTION
# What changed

This one is to fix the git-secrets workflow that always fails

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
