### PR TITLE
Typo fix: valus -> values

### DIFF
--- a/_source/logzio_collections/_log-sources/fluentbit-helm-chart.md
+++ b/_source/logzio_collections/_log-sources/fluentbit-helm-chart.md
@@ -48,7 +48,7 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 
 ###### Enabling multiline logs parser
 
-If you want to enable parsing for multiline logs, add the following code to `valus.yaml` under the `customParsers` parameter:
+If you want to enable parsing for multiline logs, add the following code to `values.yaml` under the `customParsers` parameter:
   
 ```yaml
 customParsers:


### PR DESCRIPTION
# What changed
Fixed a tiny typo: `valus.yaml` should have been `values.yaml`

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
