### PR TITLE
x509 cert - support all regions, bump version, remove LambdaName

### DIFF
--- a/_source/logzio_collections/_synthetic-monitoring-sources/X509.md
+++ b/_source/logzio_collections/_synthetic-monitoring-sources/X509.md
@@ -58,43 +58,42 @@ The integration is based on a Lambda function that will be auto-deployed togethe
 
 👇 To begin, click this button to start the automated deployment. You will need to deploy it in your environment.
 
-[![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/template?templateURL=https://logzio-aws-integrations-us-east-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/autodeployment.yaml&stackName=logzio-x509-certiricate-metrics)
-
-
-##### Specify the template
-
-![Specify stack template](https://dytvr9ot2sszz.cloudfront.net/logz-docs/X509/X509_template.png)
-
-Keep the defaults and click **Next**.
+| Region           | Deployment                                                                                                                                                                                                                                                                                                                                                               |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `us-east-1`      | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-us-east-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)           | 
+| `us-east-2`      | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://logzio-aws-integrations-us-east-2.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)           | 
+| `us-west-1`      | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-us-west-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)           | 
+| `us-west-2`      | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://logzio-aws-integrations-us-west-2.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)           | 
+| `eu-central-1`   | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-eu-central-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)     | 
+| `eu-north-1`     | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-north-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-eu-north-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)         | 
+| `eu-west-1`      | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-eu-west-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)           | 
+| `eu-west-2`      | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://logzio-aws-integrations-eu-west-2.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)           | 
+| `eu-west-3`      | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://logzio-aws-integrations-eu-west-3.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)           | 
+| `sa-east-1`      | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-sa-east-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)           | 
+| `ap-northeast-1` | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-ap-northeast-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>) | 
+| `ap-northeast-2` | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://logzio-aws-integrations-ap-northeast-2.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>) | 
+| `ap-northeast-3` | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-3#/stacks/create/review?templateURL=https://logzio-aws-integrations-ap-northeast-3.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>) | 
+| `ap-south-1`     | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-ap-south-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)         | 
+| `ap-southeast-1` | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-ap-southeast-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>) | 
+| `ap-southeast-2` | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://logzio-aws-integrations-ap-southeast-2.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>) | 
+| `ca-central-1`   | [![Deploy to AWS](https://dytvr9ot2sszz.cloudfront.net/logz-docs/lights/LightS-button.png)](https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://logzio-aws-integrations-ca-central-1.s3.amazonaws.com/x509-certificate-metricts-auto-deployment/0.0.3/sam-template.yaml&stackName=logzio-x509-cert&param_LogzioLogsToken=<<LOG-SHIPPING-TOKEN>>&param_LogzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>&param_LogzioListener=https://<<LISTENER-HOST>>)     |
 
 
 ##### Specify the stack details
 
-![Specify stack details](https://dytvr9ot2sszz.cloudfront.net/logz-docs/X509/X509_details.png)
 
-Specify the stack details as per the table below and select **Next**.
+Specify the stack details as per the table below and select **Create stack**.
 
 
 | Parameter                           | Description                                                                                                                                                                                              | Required/Optional | Default |
 |------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `LogzioMetricsToken`                | Your Logz.io metrics shipping token:`<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>`   | Required | - |
 | `LogzioListener`                    | The Logz.io listener URL: `https://<<LISTENER-HOST>>:8071` {% include log-shipping/listener-var.html %}          |  Required | - |
- | `LambdaName`                        | Name for the current lambda function.                                                                                                                      | Optional | x509-Certificate-Metrics-Lambda |
 | `CertificateURL`                    | The URL to collect x509 certificate metrics from, including port. i.e: https://app.logz.io:443                                                                                                           | Required | - |
 | `LambdaTimeout`                     | The amount of time that Lambda allows a function to run before stopping it. Minimum value is 1 second and Maximum value is 900 seconds. We recommend to start with 300 seconds (5 minutes).  | Optional | `300` |
 | `CloudWatchEventScheduleExpression` | The scheduling expression that determines when and how often the Lambda function runs. We recommend to start with 10 hour rate.                                                  | Optional | 10 hours |
 | `LogzioLogsToken`                              | Your Logz.io log shipping token:`<<LOG-SHIPPING-TOKEN>>` {% include log-shipping/log-shipping-token.html %}           | Required         | - |
 
-
-##### Configure the stack options
-
-![Specify stack options](https://dytvr9ot2sszz.cloudfront.net/logz-docs/X509/X509_options.png)
-
-Keep the defaults and click **Next**.
-
-##### Review the deployment
-
-Confirm that you acknowledge that AWS CloudFormation might create IAM resources and select **Create stack**.
 
 
 ##### Run the tests
@@ -104,7 +103,7 @@ Run the ping statistics tests to generate metrics.
 
 ##### Check Logz.io for your metrics
 
-Give your metrics some time to get from your system to ours, and then open [Kibana](https://app.logz.io/#/dashboard/kibana). All metrics that were sent from the Lambda function will have the prefix `x509` in their name.
+Give your metrics some time to get from your system to ours, and then open [OpenSearch Dashboards](https://app.logz.io/#/dashboard/osd). All metrics that were sent from the Lambda function will have the prefix `x509` in their name.
   
 
 {% include metric-shipping/custom-dashboard.html %} Install the pre-built dashboard to enhance the observability of your metrics.


### PR DESCRIPTION
# What changed

- Change to the link type that's a 1 step instead of 3.
- Bump version.
- Add more regions.
- Remove the LambdaName variable.

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
