### PR TITLE
swapped http language with rsyslog

### DIFF
--- a/_source/_includes/general-shipping/replace-placeholders-rsyslog.html
+++ b/_source/_includes/general-shipping/replace-placeholders-rsyslog.html
@@ -1,0 +1,5 @@
+Replace the placeholders to match your specifics. (They are indicated by the double angle brackets `<< >>`):
+
+* {% include /log-shipping/log-shipping-token.html %}
+
+* {% include log-shipping/listener-var-rsyslog.html %}

--- a/_source/_includes/log-shipping/listener-var-rsyslog.html
+++ b/_source/_includes/log-shipping/listener-var-rsyslog.html
@@ -1,0 +1,1 @@
+Replace `<<LISTENER-HOST>>` with the host [for your region](https://docs.logz.io/user-guide/accounts/account-region.html#available-regions). For example, `listener.logz.io` if your account is hosted on AWS US East, or `listener-nl.logz.io` if hosted on Azure West Europe. The required ports are **rsyslog over TLS** = `5001` or **rsyslog** = `5000`

--- a/_source/logzio_collections/_log-sources/rsyslog.md
+++ b/_source/logzio_collections/_log-sources/rsyslog.md
@@ -104,7 +104,7 @@ if $programname == 'TYPE' then @@<<LISTENER-HOST>>:5001;logzFormatFileTagName
 if $programname == 'TYPE' then ~
 ```
 
-{% include /general-shipping/replace-placeholders.html %}
+{% include /general-shipping/replace-placeholders-rsyslog.html %}
 * `<<PATH_TO_FILE>>`: Path to your file or directory.
 * `<<TYPE>>`: {% include log-shipping/type.md %}
 
@@ -129,7 +129,6 @@ If you still don't see your logs, see our [Rsyslog troubleshooting guide](https:
 <!-- tab:start -->
 <div id="rsyslog-selinux">
 
-###### Shipping with Rsyslog and SELinux
 
 Security-Enhanced Linux (SELinux) is a security architecture for Linux based systems that allows administrators to have more control over who can access the system.
 


### PR DESCRIPTION
What changed? The Rsyslog over TLS doc (https://docs.logz.io/shipping/log-sources/rsyslog.html) referenced the following ports:

"The required port depends whether HTTP or HTTPS is used: HTTP = 8070, HTTPS = 8071."

The problem with this is that rsyslog uses ports 5001 or 5000 and is not HTTP/s so this is incorrect info.
----

the rsyslog.md file referenced the template: {% include /general-shipping/replace-placeholders.html %}
which calls the template: * {% include log-shipping/listener-var-rsyslog.html %}
and includes "The required port depends whether HTTP or HTTPS is used: HTTP = 8070, HTTPS = 8071."

What I added was a new replace-holders-rsyslog.html and listener-var-syslog.html to use the correct ports