### PR TITLE
Update node-steps.md

### DIFF
--- a/_source/_includes/tracing-shipping/node-steps.md
+++ b/_source/_includes/tracing-shipping/node-steps.md
@@ -58,12 +58,7 @@ const sdk = new opentelemetry.NodeSDK({
     instrumentations: [getNodeAutoInstrumentations()],
 });
 
-sdk
-    .start()
-    .then(() => {
-        console.log("Tracing initialized");
-    })
-    .catch((error) => console.log("Error initializing tracing", error));
+sdk.start()
 
 process.on("SIGTERM", () => {
     sdk


### PR DESCRIPTION
Using the [node-sdk](https://www.npmjs.com/package/@opentelemetry/sdk-node/v/0.37.0) asynchronically breaks the code sample since version [v1.10.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.10.0)