### PR TITLE
Update sentinelone.md

### DIFF
--- a/_source/logzio_collections/_security-sources/sentinelone.md
+++ b/_source/logzio_collections/_security-sources/sentinelone.md
@@ -26,10 +26,10 @@ SentinelOne platform delivers the defenses to prevent, detect, and undo—known 
 
 <div class="tasklist">
 
-##### Install the SentinelOne certificate on your Filebeat server
+##### Create the SentinelOne certificate via OpenSSL on your Filebeat server
 
 SentinelOne sends encrypted data,
-so you'll need to create a dedicated SentinelOne certificate to decrypt the logs by the Filebeat server.
+so you'll need to create a dedicated SentinelOne certificate to decrypt the logs by the Filebeat server. This certificate (.crt file) will need to be uploaded to your SentinelOne management console interface later in this setup.
 
 ```shell
 sudo mkdir /etc/filebeat/certificates
@@ -113,8 +113,9 @@ Open the SentinelOne Admin Console. Configure SentinelOne to send logs to your S
     1. Under **Types**, select **SYSLOG**.
     2. Toggle the button to **enable SYSLOG**.
     3. **Host** - Enter your public SYSLOG server IP address and port.
-    4. **Formatting** - Select **CEF2**.
-    5. Save your changes.
+    4. Enable **TLS** and upload the .crt file created earlier as a server certificate. The other certificate options can be left blank.
+    5. **Formatting** - Select **CEF2**.
+    6. Save your changes.
 
 ![SentinelOne Admin Console configuration](https://dytvr9ot2sszz.cloudfront.net/logz-docs/log-shipping/sentinelone-admin5.png)
 


### PR DESCRIPTION
SentinelOne doc has been misleading for a while now: https://logzio.slack.com/archives/C016HS56VF0/p1627546083327800

The server certificate created in step 1 needs to be uploaded to the SentinelOne console when configuring syslog. This step is left out and leads to new support threads opened periodically when data is inevitably sent to the syslog server without being decrypted

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
