### PR TITLE
Use static http client

### DIFF
--- a/_source/logzio_collections/_log-sources/dotnet.md
+++ b/_source/logzio_collections/_log-sources/dotnet.md
@@ -162,6 +162,7 @@ logzioAppender.AddListenerUrl("<<LISTENER-HOST>>");
 // logzioAppender.ActivateOptions();
 // logzioAppender.JsonKeysCamelCase(false);
 // logzioAppender.AddTraceContext(false);
+// logzioAppender.UseStaticHttpClient(false);
 logzioAppender.ActivateOptions();
 hierarchy.Root.AddAppender(logzioAppender);
 hierarchy.Root.Level = Level.All;
@@ -198,6 +199,7 @@ namespace dotnet_log4net
             // logzioAppender.ActivateOptions();
             // logzioAppender.JsonKeysCamelCase(false)
             // logzioAppender.AddTraceContext(false);
+            // logzioAppender.UseStaticHttpClient(false);
             logzioAppender.ActivateOptions();
             
             hierarchy.Root.AddAppender(logzioAppender);
@@ -231,6 +233,7 @@ namespace dotnet_log4net
 | proxyAddress | Proxy address to route your logs through. | `None` |
 | jsonKeysCamelCase | If you have custom fields keys that start with a capital letter and want to see the fields with a capital letter in Logz.io, set this field to true. | `false` |
 | addTraceContext | If want to add trace context to each log, set this field to true. | `false` |
+| useStaticHttpClient | If want to use the same static HTTP/s client for sending logs, set this field to true. | `false` |
 
 
 </div>

--- a/_source/logzio_collections/_log-sources/dotnet.md
+++ b/_source/logzio_collections/_log-sources/dotnet.md
@@ -15,6 +15,7 @@ contributors:
   - imnotashrimp
   - savidov
   - yberlinger
+  - ralongit
 shipping-tags:
   - from-your-code
 order: 230
@@ -100,6 +101,9 @@ For a complete list of options, see the configuration parameters below the code 
 	<jsonKeysCamelCase>false</jsonKeysCamelCase>
 	<!-- Add trace context (traceId and spanId) to each log. The default is false -->
 	<addTraceContext>false</addTraceContext>
+    <!-- Use the same static HTTP/s client for sending logs. The default is false -->
+	<UseStaticHttpClient>false</addTraceContext>
+    
     </appender>
     
     <root>
@@ -302,6 +306,8 @@ namespace dotnet_log4net
             // logzioAppender.AddGzip(true);
             // logzioAppender.ActivateOptions();
             // logzioAppender.JsonKeysCamelCase(false)
+            // logzioAppender.UseStaticHttpClient(false);
+
             logzioAppender.AddTraceContext(true);
             logzioAppender.ActivateOptions();
             
@@ -320,8 +326,7 @@ namespace dotnet_log4net
 ```
 
 ### Serverless platforms
-If you’re using a serverless function, you’ll need to call the appender's flush methods at the end of the function run to make sure the logs are sent before the function finishes its execution. You’ll also need to create a static appender in the Startup.cs file so each invocation will use the same appender. 
-Make sure 'debug' is set to false if the function is deployed as it might cause permission issues with debug files. 
+If you’re using a serverless function, you’ll need to call the appender's flush method at the end of the function run to make sure the logs are sent before the function finishes its execution. You’ll also need to create a static appender in the Startup.cs file so each invocation will use the same appender. The appender should have the `UseStaticHttpClient` flag set to `true`.
 
 ###### Azure serverless function code sample
 *Startup.cs*
@@ -344,6 +349,7 @@ namespace LogzioLog4NetSampleApplication
             logzioAppender.AddToken("<<LOG-SHIPPING-TOKEN>>");
             logzioAppender.AddListenerUrl("https://<<LISTENER-HOST>>:8071");
             logzioAppender.ActivateOptions();
+            logzioAppender.UseStaticHttpClient(true);
             hierarchy.Root.AddAppender(logzioAppender);
             hierarchy.Configured = true;
         }
@@ -446,8 +452,9 @@ For a complete list of options, see the configuration parameters below the code 
 		jsonKeysCamelCase="false"
 		addTraceContext="false"
 		<!-- parseJsonMessage="true"-->
-	>
-		<contextproperty name="host" layout="${machinename}" />
+        <!-- useStaticHttpClient="false"-->        
+        >
+        <contextproperty name="host" layout="${machinename}" />
 		<contextproperty name="threadid" layout="${threadid}" />
 	</target>
     </targets>
@@ -476,7 +483,8 @@ var logzioTarget = new LogzioTarget {
     JsonKeysCamelCase = false,
     AddTraceContext = false,
     // ParseJsonMessage = true, 
-    // ProxyAddress = "http://your.proxy.com:port"
+    // ProxyAddress = "http://your.proxy.com:port",
+    // UseStaticHttpClient = false, 
 };
 
 config.AddRule(LogLevel.Debug, LogLevel.Fatal, logzioTarget);
@@ -499,6 +507,7 @@ LogManager.Configuration = config;
 | proxyAddress | Proxy address to route your logs through. | `None` |
 | jsonKeysCamelCase | If you have custom fields keys that start with a capital letter and want to see the fields with a capital letter in Logz.io, set this field to true. | `false` |
 | addTraceContext | If want to add trace context to each log, set this field to true. | `false` |
+| useStaticHttpClient | If want to use the same static HTTP/s client for sending logs, set this field to true. | `false` |
 
 ###### Code sample
 
@@ -601,6 +610,7 @@ var logzioTarget = new LogzioTarget {
     AddTraceContext = true,
     // ParseJsonMessage = true, 
     // ProxyAddress = "http://your.proxy.com:port"
+    
 };
 
 config.AddRule(LogLevel.Debug, LogLevel.Fatal, logzioTarget);
@@ -608,8 +618,7 @@ LogManager.Configuration = config;
 ```
 
 ##### Serverless platforms
-If you’re using a serverless function, you’ll need to call the appender's flush methods at the end of the function run to make sure the logs are sent before the function finishes its execution. You’ll also need to create a static appender in the Startup.cs file so each invocation will use the same appender. 
-Make sure 'debug' is set to false if the function is deployed as it might cause permission issues with debug files. 
+If you’re using a serverless function, you’ll need to call the appender's flush method at the end of the function run to make sure the logs are sent before the function finishes its execution. You’ll also need to create a static appender in the Startup.cs file so each invocation will use the same appender. The appender should have the `UseStaticHttpClient` flag set to `true`.
 
 ###### Azure serverless function code sample
 
@@ -646,6 +655,7 @@ namespace LogzioNLogSampleApplication
                 Debug = false,
                 JsonKeysCamelCase = false,
                 AddTraceContext = false,
+                UseStaticHttpClient = true, 
                 // ParseJsonMessage = true,
                 // ProxyAddress = "http://your.proxy.com:port"
             };
@@ -765,6 +775,9 @@ For a complete list of options, see the configuration parameters below the code 
         <jsonKeysCamelCase>false</jsonKeysCamelCase>
         <!-- Add trace context (traceId and spanId) to each log. The default is false -->
         <addTraceContext>false</addTraceContext>
+        <!-- Use the same static HTTP/s client for sending logs. The default is false -->
+	    <useStaticHttpClient>false</useStaticHttpClient>
+
     </appender>
     
     <root>
@@ -788,6 +801,7 @@ logzioAppender.AddListenerUrl("<<LISTENER-HOST>>");
 // logzioAppender.ActivateOptions();
 // logzioAppender.JsonKeysCamelCase(false);
 // logzioAppender.AddTraceContext(false);
+// logzioAppender.UseStaticHttpClient(false);
 logzioAppender.ActivateOptions();
 hierarchy.Root.AddAppender(logzioAppender);
 hierarchy.Root.Level = Level.All;
@@ -811,6 +825,7 @@ hierarchy.Configured = true;
 | proxyAddress | Proxy address to route your logs through. | `None` |
 | jsonKeysCamelCase | If you have custom fields keys that start with capital letter and want to see the fields with capital letter in Logz.io, set this field to true. | `false` |
 | addTraceContext | If want to add trace context to each log, set this field to true. | `false` |
+| useStaticHttpClient | If want to use the same static HTTP/s client for sending logs, set this field to true. | `false` |
 
 ###### Code sample
 

--- a/_source/logzio_collections/_log-sources/dotnet.md
+++ b/_source/logzio_collections/_log-sources/dotnet.md
@@ -323,7 +323,7 @@ namespace dotnet_log4net
 If you’re using a serverless function, you’ll need to call the appender's flush methods at the end of the function run to make sure the logs are sent before the function finishes its execution. You’ll also need to create a static appender in the Startup.cs file so each invocation will use the same appender. 
 Make sure 'debug' is set to false if the function is deployed as it might cause permission issues with debug files. 
 
-###### Code sample
+###### Azure serverless function code sample
 *Startup.cs*
 ```csharp
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
@@ -611,7 +611,7 @@ LogManager.Configuration = config;
 If you’re using a serverless function, you’ll need to call the appender's flush methods at the end of the function run to make sure the logs are sent before the function finishes its execution. You’ll also need to create a static appender in the Startup.cs file so each invocation will use the same appender. 
 Make sure 'debug' is set to false if the function is deployed as it might cause permission issues with debug files. 
 
-###### Code sample
+###### Azure serverless function code sample
 
 *Startup.cs*
 
@@ -965,7 +965,7 @@ hierarchy.Configured = true;
 If you’re using a serverless function, you’ll need to call the appender's flush methods at the end of the function run to make sure the logs are sent before the function finishes its execution. You’ll also need to create a static appender in the Startup.cs file so each invocation will use the same appender. 
 Make sure 'debug' is set to false if the function is deployed as it might cause permission issues with debug files. 
 
-###### Code sample
+###### Azure serverless function code sample
 *Startup.cs*
 
 ```csharp
@@ -1167,7 +1167,7 @@ namespace Example
 If you’re using a serverless function, you’ll need to create a static appender in the Startup.cs file so each invocation will use the same appender.
 In the Serilog integration, you should use the 'WriteTo.LogzIo()' instad of 'WriteTo.LogzIoDurableHttp()' method as it uses in-memory buffering which is best practice for serverless functions. 
 
-###### Code sample
+###### Azure serverless function code sample
 
 *Startup.cs*
 ```csharp


### PR DESCRIPTION
# What changed
- Created a configuration parameter, 'UseStaticHttpClient' to create static HTTP/s client for sending logs. Best practice for serverless environments.
- Modified explanation on serverless envs. 

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
