### PR TITLE
Add K8S Deploy events integration

### DIFF
--- a/_source/logzio_collections/_log-sources/k8s-deploy-events.md
+++ b/_source/logzio_collections/_log-sources/k8s-deploy-events.md
@@ -1,0 +1,120 @@
+---
+title: Ship K8S deploy events logs with Helm
+logo:
+  logofile: kubernetes.svg
+  orientation: vertical
+short-description: Ship kubernetes deploy events logs with Helm
+data-source: Kubernetes Deploy Events
+data-for-product-source: Logs
+open-source:
+  - title: logzio-helm
+    github-repo: logzio-helm
+contributors:
+  - ralongit
+shipping-tags:
+  - log-shipper
+  - container
+order: 430
+---
+
+
+The Kubernetes deploy events logs Helm sends data about deployment events in the cluster, and how they affect the cluster's resources. Currently supported resource kinds are Deployment, Daemonset, Statefulset, ConfigMap, Secret, Service Account, Cluster Role and Cluster Role Binding.
+
+Helm is a tool for managing packages of pre-configured Kubernetes resources using Charts. You can use this Helm chart to ship kubernetes deploy events logs with Helm. 
+
+
+###### Sending logs from nodes with taints
+
+If you want to ship logs from any of the nodes that have a taint, make sure that the taint key values are listed in your in your daemonset/deployment configuration as follows:
+  
+```yaml
+tolerations:
+- key: 
+  operator: 
+  value: 
+  effect: 
+```
+  
+To determine if a node uses taints as well as to display the taint keys, run:
+  
+```
+kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.taints}"
+```
+
+You need to use `Helm` client with version `v3.9.0` or above.
+
+
+#### Standard configuration
+
+<div class="tasklist">
+
+##### Add `logzio-helm` repo
+  
+```shell
+helm repo add logzio-helm https://logzio.github.io/logzio-helm
+helm repo update
+```
+
+
+###### Run the Helm deployment code
+
+```shell
+helm install --namespace=monitoring \
+--set secrets.logzioShippingToken='<<LOG-SHIPPING-TOKEN>>' \
+--set secrets.logzioListener='<<LISTENER-HOST>>' \
+--set secrets.env_id='<<ENV-ID>>' \
+--set secrets.customListener='<<CUSTOM-HOST>>' \
+logzio-k8s-events logzio-helm/logzio-k8s-events
+```
+  
+{% include log-shipping/listener-var.html %} {% include log-shipping/log-shipping-token.html %} 
+Replace `<<SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/general) of the account you want to ship to.
+
+Replace `<<LISTENER-HOST>>` with your region’s host address (for example, `listener-eu.logz.io`). For more information on finding your account’s region, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html).
+
+Replace `<<ENV-ID>>` with your Kubernetes cluster name.
+
+##### Check Logz.io for your logs
+
+Give your logs some time to get from your system to ours, then open [Logz.io](https://app.logz.io/).
+
+</div>
+
+
+####  Customizing Helm chart parameters
+
+
+##### Optional Custom Listener
+If you have an HTTP/s endpoint that receives JSON input than you can override the Logz.io listener by setting the `customListener` secret. 
+
+Replace `<<CUSTOM-HOST>>` with your endpoint URL. 
+
+```shell
+helm install --namespace=monitoring \
+--set secrets.logzioShippingToken='<<SHIPPING-TOKEN>>' \
+--set secrets.customListener='<<CUSTOM-HOST>>' \
+--set secrets.env_id='<<ENV-ID>>' \
+logzio-k8s-events logzio-helm/logzio-k8s-events
+```
+
+#### Deployment Events Versioning
+
+In order to add an indication for the versioning in our K8S 360 and Service Overview UI, the following annotation should be added to the metadata of each resource you'd like to track its versioning. 
+Commit URL structure: `https://github.com/<account>/<repository>/commit/<commit-hash>`
+
+Example: `https://github.com/logzio/logzio-k8s-events/commit/069c75c95caeca58dd0776405bb8dfb4eed3acb2`
+
+```yaml
+metadata:
+  annotations:
+    logzio/commit_url: ""  
+```
+
+#### Uninstalling the Chart
+
+The command removes all the k8s components associated with the chart and deletes the release.
+To uninstall the `logzio-k8s-events` deployment:
+
+```shell
+helm uninstall --namespace=monitoring logzio-k8s-events
+```


### PR DESCRIPTION
Added an integration that allows sending logs regarding Kubernetes deploy events.

# What changed

<!-- Let us know what you changed.
Don't worry about the bottom part of this template—the docs team will take care of it. -->

----

<!-- ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎ Just let us know what you changed at the top of the template. ⬆︎⬆︎⬆︎⬆︎⬆︎⬆︎
The docs team can take care of everything below this line. -->

## Pages to review

<!-- Don't remove this section. If you don't fill it out, the docs team can still use it -->
<!-- After the build, paste URLs with the pages affected by this revision -->
- LinkToPage1
- LinkToPage2

## Remaining work

<!-- List any outstanding work here -->
- [ ] Technical review
- [ ] Copy Review
- [ ] Redirects: <!-- Give a list of redirects. Provide old URL and new URL. -->

## Post launch

To be completed by the docs team upon merge:

- [ ] Teams to update with the new information:
- [ ] Replace original content on the support portal with 'this page has been moved to ...' - paste the URL
- [ ] Update these log shipping pages in the app: - paste the URL
